### PR TITLE
Fix for https://github.com/radiasoft/sirepo/issues/84.

### DIFF
--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -226,7 +226,7 @@ app.directive('plot2d', function(plotting) {
             var ASPECT_RATIO = 4.0 / 7;
             $scope.margin = {top: 50, right: 20, bottom: 50, left: 70};
             $scope.width = $scope.height = 0;
-            var formatter, graphLine, points, xAxis, xAxisGrid, xAxisScale, xPeakValues, xUnits, yAxis, yAxisGrid, yAxisScale;
+            var formatter, ordinate_formatter, graphLine, points, xAxis, xAxisGrid, xAxisScale, xPeakValues, xUnits, yAxis, yAxisGrid, yAxisScale, yUnits;
 
             function mouseMove() {
                 if (! points)
@@ -245,7 +245,7 @@ app.directive('plot2d', function(plotting) {
                         return;
                     var focus = select('.focus');
                     focus.attr('transform', 'translate(' + xPixel + ',' + yAxisScale(localMax[1]) + ')');
-                    focus.select('text').text(formatter(localMax[0]) + ' ' + xUnits);
+                    focus.select('text').text(formatter(localMax[0]) + ' ' + xUnits + ' / ' + ordinate_formatter(localMax[1]) + ' ' + yUnits);
                 }
             };
 
@@ -307,6 +307,7 @@ app.directive('plot2d', function(plotting) {
 
             $scope.init = function() {
                 formatter = d3.format(',.0f');
+                ordinate_formatter = d3.format('.1e');
                 select('svg').attr('height', plotting.INITIAL_HEIGHT);
                 $scope.slider = $(select('.srw-plot2d-slider').node()).slider();
                 $scope.slider.on('slide', sliderChanged);
@@ -333,6 +334,7 @@ app.directive('plot2d', function(plotting) {
                 points = d3.zip(xPoints, json.points);
                 $scope.xRange = json.x_range;
                 xUnits = json.x_units;
+                yUnits = json.y_units;
                 xAxisScale.domain([json.x_range[0], json.x_range[1]]);
                 yAxisScale.domain([d3.min(json.points), d3.max(json.points)]);
                 select('.y-axis-label').text(json.y_label);

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -103,6 +103,7 @@ def extract_report_data(filename, model_data):
         'y_label': _superscript(file_info[filename][0][1] + ' [' + file_info[filename][1][1] + ']'),
         'x_label': file_info[filename][0][0] + ' [' + file_info[filename][1][0] + ']',
         'x_units': file_info[filename][1][0],
+        'y_units': file_info[filename][1][1],
         'points': data,
     }
     if filename in files_3d:


### PR DESCRIPTION
Hi Paul,

I implemented the fix for https://github.com/radiasoft/sirepo/issues/84, please review it and merge in case everything is fine.

Due to the units can be quite long, it's desirable if the added ordinate values are displayed on a new line, but I haven't found how to do it easily (tried `.html()` with `<br>` tag inside instead of `.text()`, but it didn't help). Maybe you can suggest better way to do it?

Thanks,
Maksim