### PR TITLE
pkconfig formatted values going away

### DIFF
--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -200,9 +200,11 @@ cfg = pkconfig.init(
     nginx_proxy_port=(8080, _cfg_int(5001, 32767), 'port on which nginx_proxy listens'),
     port=(8000, _cfg_int(5001, 32767), 'port on which uwsgi or http listens'),
     processes=(1, _cfg_int(1, 16), 'how many uwsgi processes to start'),
-    run_dir=('{SIREPO_PKCLI_SERVICE_DB_DIR}', str, 'where to run the program'),
+    run_dir=(None, str, 'where to run the program (defaults db_dir)'),
     # uwsgi got hung up with 1024 threads on a 4 core VM with 4GB
     # so limit to 128, which is probably more than enough with
     # this application.
     threads=(10, _cfg_int(1, 128), 'how many uwsgi threads in each process'),
 )
+if not cfg.run_dir:
+    cfg.run_dir = cfg.db_dir

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -985,7 +985,7 @@ def _validate_serial(data):
 
 cfg = pkconfig.init(
     beaker_session=dict(
-        key=('sirepo_{PYKERN_PKCONFIG_CHANNEL}', str, 'Beaker: Name of the cookie key used to save the session under'),
+        key=('sirepo_' + pkconfig.cfg.channel, str, 'Beaker: Name of the cookie key used to save the session under'),
         secret=(None, _cfg_session_secret, 'Beaker: Used with the HMAC to ensure session integrity'),
         secure=(False, bool, 'Beaker: Whether or not the session cookie should be marked as secure'),
     ),


### PR DESCRIPTION
I think this fix is fine, but it could break cookies so I want to make sure I get it right. I want to get rid of [formatted values](https://github.com/radiasoft/pykern/commit/3b9be7133ea7b2ae884b41507e481e7dcacc1707#diff-6a7e51d1079ccbc0ababe499d109774a) in pkconfig. I wanted to be able to parse a value as JSON, and that conflicts with the formatting syntax. I don't think it is that valuable of a feature. And is easy enough to work around.