### PR TITLE
Added per-report color map for 3d plots, pursuant to Issue #706

### DIFF
--- a/sirepo/package_data/static/css/sirepo.css
+++ b/sirepo/package_data/static/css/sirepo.css
@@ -256,6 +256,49 @@
         box-shadow: 0 5px 15px rgba(0, 0, 0, .5);
     }
 
+    ul.sr-button-menu {
+        list-style: none;
+    }
+    li.sr-button-menu {
+        padding: 3px;
+    }
+
+    li.sr-button-menu > button.sr-button-menu-selected {
+        border-width: 1px;
+        border-style: solid;
+        border-color: #888888;
+        text-align: left;
+        color: white;
+        background-color: #337ab7;
+    }
+    li.sr-button-menu > button.sr-button-menu-selected:hover {
+        color: white;
+        background-color: #286090;
+    }
+
+    li.sr-button-menu > button.sr-button-menu-unselected {
+        border-width: 1px;
+        border-style: solid;
+        border-color: #888888;
+        text-align: left;
+        color: black;
+        background-color: #f5f5f5;
+    }
+    li.sr-button-menu > button.sr-button-menu-unselected:hover {
+        color: white;
+        background-color: #4897da;
+    }
+
+    .sr-color-map-indicator {
+        width: 64px;
+        height: 24px;
+        border-radius: 4px;
+        border-style: solid;
+        border-width: 1px;
+        vertical-align: middle;
+        display: inline-block;
+    }
+
     .sr-panel-heading {
       font-weight: 300;
       line-height: 1.4;

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -335,7 +335,7 @@ SIREPO.app.directive('labelWithTooltip', function() {
     };
 });
 
-SIREPO.app.directive('fieldEditor', function(appState, panelState, requestSender) {
+SIREPO.app.directive('fieldEditor', function(appState, panelState, requestSender, plotting) {
     return {
         restrict: 'A',
         scope: {
@@ -373,6 +373,9 @@ SIREPO.app.directive('fieldEditor', function(appState, panelState, requestSender
               // '<div data-ng-switch-when="Boolean" class="col-sm-7">',
               //   '<input data-bootstrap-toggle="" data-ng-checked="{{model[field]}}" type="checkbox" id="bs-toggle-id-{{$id}}" data-toggle="toggle" data-on="{{onValue}}" data-off="{{offValue}}">',
               // '</div>',
+              '<div data-ng-switch-when="ColorMap" class="col-sm-7">',
+                '<div data-color-map="" class="dropdown"></div>',
+              '</div>',
               SIREPO.appFieldEditors || '',
               // assume it is an enum
               '<div data-ng-switch-default data-ng-class="fieldClass">',
@@ -1132,6 +1135,68 @@ SIREPO.app.directive('safePath', function() {
     };
 });
 
+SIREPO.app.directive('colorMap', function(appState, plotting) {
+
+    return {
+        restrict: 'A',
+        template: [
+            '<button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown"><span class="sr-color-map-indicator" data-ng-style="colorMapStyle(model[field])"></span> {{ plotting.colorMapNameOrDefault(model[field], reportDefaultMap) }} <span class="caret"></span></button>',
+            '<ul class="dropdown-menu sr-button-menu">',
+                '<li data-ng-repeat="item in enum[info[1]]" class="sr-button-menu">',
+                    '<button class="btn btn-block"  data-ng-class="{\'sr-button-menu-selected\': isSelectedMap(item[0]), \'sr-button-menu-unselected\': ! isSelectedMap(item[0])}" data-ng-click="setColorMap(item[0])">',
+                        '<span class="sr-color-map-indicator" data-ng-style="colorMapStyle(item[0])"></span> {{item[1]}} <span data-ng-if="isDefaultMap(item[0])" class="glyphicon glyphicon-star-empty"></span><span data-ng-if="isSelectedMap(item[0])" class="glyphicon glyphicon-ok"></span>',
+                    '</button>',
+                '</li>',
+            '</ul>',
+        ].join(''),
+        controller: function($scope) {
+
+            $scope.enum = SIREPO.APP_SCHEMA.enum;
+            $scope.info = appState.modelInfo($scope.modelName)[$scope.field];
+            $scope.reportDefaultMap = $scope.info[SIREPO.INFO_INDEX_DEFAULT_VALUE];
+            //srdbg('report default is', $scope.reportDefaultMap);
+            if (!$scope.info) {
+                throw 'invalid model field: ' + $scope.modelName + '.' + $scope.field;
+            }
+            $scope.isSelectedValue = function(value) {
+                return $scope.model[$scope.field] == value;
+            };
+            $scope.isSelectedMap = function(mapName) {
+                if($scope.model && $scope.model[$scope.field]) {
+                    return $scope.isSelectedValue(mapName);
+                }
+                return $scope.isDefaultMap(mapName);
+            };
+            $scope.isDefaultMap = function(mapName) {
+                return plotting.colorMapNameOrDefault(mapName, $scope.reportDefaultMap) === plotting.colorMapNameOrDefault(null, $scope.reportDefaultMap);
+            };
+            $scope.setColorMap = function(mapName) {
+                $scope.model[$scope.field] = mapName;
+            };
+
+            $scope.plotting = plotting;
+            $scope.colorMapStyle = function(mapName) {
+
+                var map = plotting.colorMapOrDefault(mapName, $scope.reportDefaultMap);
+                if (! map) {
+                    return {};
+                }
+
+                var css = 'linear-gradient(to right, ' + map[0];
+                for(var i = 1; i < map.length; ++i) {
+                    css += ', ';
+                    css += map[i];
+                }
+                css += ')';
+                return {
+                    'background': css,
+                };
+
+            };
+        },
+    };
+});
+
 SIREPO.app.directive('numberToString', function() {
     return {
         restrict: 'A',
@@ -1430,6 +1495,9 @@ SIREPO.app.directive('appHeaderRight', function(panelState, appState, appDataSer
                 $window.open(appState.models.simulation.documentationUrl, '_blank');
             };
 
+            function updateGlobals() {
+                srdbg('updating globals');
+            }
         },
     };
 });

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -335,7 +335,7 @@ SIREPO.app.directive('labelWithTooltip', function() {
     };
 });
 
-SIREPO.app.directive('fieldEditor', function(appState, panelState, requestSender, plotting) {
+SIREPO.app.directive('fieldEditor', function(appState, panelState, requestSender) {
     return {
         restrict: 'A',
         scope: {
@@ -374,7 +374,7 @@ SIREPO.app.directive('fieldEditor', function(appState, panelState, requestSender
               //   '<input data-bootstrap-toggle="" data-ng-checked="{{model[field]}}" type="checkbox" id="bs-toggle-id-{{$id}}" data-toggle="toggle" data-on="{{onValue}}" data-off="{{offValue}}">',
               // '</div>',
               '<div data-ng-switch-when="ColorMap" class="col-sm-7">',
-                '<div data-color-map="" class="dropdown"></div>',
+                '<div data-color-map-menu="" class="dropdown"></div>',
               '</div>',
               SIREPO.appFieldEditors || '',
               // assume it is an enum
@@ -1135,7 +1135,7 @@ SIREPO.app.directive('safePath', function() {
     };
 });
 
-SIREPO.app.directive('colorMap', function(appState, plotting) {
+SIREPO.app.directive('colorMapMenu', function(appState, plotting) {
 
     return {
         restrict: 'A',

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -1494,10 +1494,6 @@ SIREPO.app.directive('appHeaderRight', function(panelState, appState, appDataSer
             $scope.openDocumentation = function() {
                 $window.open(appState.models.simulation.documentationUrl, '_blank');
             };
-
-            function updateGlobals() {
-                srdbg('updating globals');
-            }
         },
     };
 });

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -331,28 +331,31 @@ SIREPO.app.factory('plotting', function(appState, d3Service, frameCache, panelSt
             return scope.isAnimation ? 1 : INITIAL_HEIGHT;
         },
 
+        colorRangeFromModel: function(modelName) {
+
+            var model = appState.models[modelName];
+            var modelMap = model ? model.colorMap : null;
+
+            var modelDefaultMap;
+            var info = SIREPO.APP_SCHEMA.model[modelName];
+            if(info) {
+                var mapInfo = info.colorMap;
+                modelDefaultMap = mapInfo ? mapInfo[SIREPO.INFO_INDEX_DEFAULT_VALUE] : null;
+            }
+
+            return this.colorMapOrDefault(modelMap, modelDefaultMap);
+        },
 
         colorMapNameOrDefault: function (mapName, defaultMapName) {
             return mapName || defaultMapName || SIREPO.PLOTTING_COLOR_MAP || SIREPO.DEFAULT_COLOR_MAP;
         },
+
         colorMapOrDefault: function (mapName, defaultMapName) {
             return COLOR_MAP[this.colorMapNameOrDefault(mapName, defaultMapName)];
         },
 
         initImage: function(zMin, zMax, heatmap, cacheCanvas, imageData, modelName) {
-
-            var model = appState.models[modelName];
-            var modelColorMapName = model ? model.colorMap : null;
-            var info = SIREPO.APP_SCHEMA.model[modelName];
-            var infoColorMapName;
-            if(info) {
-                var mapInfo = info.colorMap;
-                infoColorMapName = mapInfo ? mapInfo[SIREPO.INFO_INDEX_DEFAULT_VALUE] : null;
-            }
-
-            srdbg('plotting.init image with map', modelColorMapName, 'default', infoColorMapName);
-
-            var colorRange = this.colorMapOrDefault(modelColorMapName, infoColorMapName);
+            var colorRange = this.colorRangeFromModel(modelName);
             var colorScale = d3.scale.linear()
                 .domain(linspace(zMin, zMax, colorRange.length))
                 .range(colorRange);

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -333,32 +333,26 @@ SIREPO.app.factory('plotting', function(appState, d3Service, frameCache, panelSt
 
 
         colorMapNameOrDefault: function (mapName, defaultMapName) {
-            /*
-            srdbg('finding map', mapName, 'default', defaultMapName);
-            if(mapName) {
-                srdbg('found map', mapName);
-                return mapName;
-            }
-            if( defaultMapName ) {
-                srdbg('found report default', defaultMapName);
-                return defaultMapName;
-            }
-            if( SIREPO.PLOTTING_COLOR_MAP ) {
-                srdbg('found app default', SIREPO.PLOTTING_COLOR_MAP);
-                return SIREPO.PLOTTING_COLOR_MAP;
-            }
-            srdbg('found global default', SIREPO.DEFAULT_COLOR_MAP);
-            */
             return mapName || defaultMapName || SIREPO.PLOTTING_COLOR_MAP || SIREPO.DEFAULT_COLOR_MAP;
         },
         colorMapOrDefault: function (mapName, defaultMapName) {
             return COLOR_MAP[this.colorMapNameOrDefault(mapName, defaultMapName)];
         },
 
-        initImage: function(zMin, zMax, heatmap, cacheCanvas, imageData, colorMapName, defaultColorMapName) {
-            //var colorRange = COLOR_MAP[SIREPO.PLOTTING_COLOR_MAP || 'viridis'];
-            //srdbg('plotting.init image with map', colorMapName, 'default', defaultColorMapName);
-            var colorRange = this.colorMapOrDefault(colorMapName, defaultColorMapName);
+        initImage: function(zMin, zMax, heatmap, cacheCanvas, imageData, modelName) {
+
+            var model = appState.models[modelName];
+            var modelColorMapName = model ? model.colorMap : null;
+            var info = SIREPO.APP_SCHEMA.model[modelName];
+            var infoColorMapName;
+            if(info) {
+                var mapInfo = info.colorMap;
+                infoColorMapName = mapInfo ? mapInfo[SIREPO.INFO_INDEX_DEFAULT_VALUE] : null;
+            }
+
+            srdbg('plotting.init image with map', modelColorMapName, 'default', infoColorMapName);
+
+            var colorRange = this.colorMapOrDefault(modelColorMapName, infoColorMapName);
             var colorScale = d3.scale.linear()
                 .domain(linspace(zMin, zMax, colorRange.length))
                 .range(colorRange);
@@ -1316,10 +1310,7 @@ SIREPO.app.directive('plot3d', function(appState, plotting) {
                 }
                 bottomPanelYScale.domain([zmin, zmax]).nice();
                 rightPanelXScale.domain([zmax, zmin]).nice();
-                var modelColorMapName = appState.models[$scope.modelName].colorMap;
-                var mapModel = appState.modelInfo($scope.modelName).colorMap;
-                var reportDefaultColorMapName = mapModel ? mapModel[SIREPO.INFO_INDEX_DEFAULT_VALUE] : null;
-                plotting.initImage(zmin, zmax, heatmap, cacheCanvas, imageData, modelColorMapName, reportDefaultColorMapName);
+                plotting.initImage(zmin, zmax, heatmap, cacheCanvas, imageData, $scope.modelName);
                 $scope.resize();
             };
 
@@ -1411,11 +1402,7 @@ SIREPO.app.directive('heatmap', function(appState, plotting) {
             }
 
             function initDraw(zmin, zmax) {
-                var modelColorMapName = appState.models[$scope.modelName].colorMap;
-                var mapModel = appState.modelInfo($scope.modelName).colorMap;
-                var reportDefaultColorMapName = mapModel ? mapModel[SIREPO.INFO_INDEX_DEFAULT_VALUE] : null;
-
-                var colorScale = plotting.initImage(zmin, zmax, heatmap, cacheCanvas, imageData, modelColorMapName, reportDefaultColorMapName);
+                var colorScale = plotting.initImage(zmin, zmax, heatmap, cacheCanvas, imageData, $scope.modelName);
                 colorbar = Colorbar()
                     .scale(colorScale)
                     .thickness(30)

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -976,7 +976,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, frameCache, pan
     };
 });
 
-SIREPO.app.directive('impactDensityPlot', function(plotting) {
+SIREPO.app.directive('impactDensityPlot', function(appState, plotting) {
     return {
         restrict: 'A',
         scope: {
@@ -1089,7 +1089,9 @@ SIREPO.app.directive('impactDensityPlot', function(plotting) {
                 select('.x-axis-label').text(plotting.extractUnits($scope, 'x', json.x_label));
                 select('.main-title').text(json.title);
 
-                var colorRange = plotting.COLOR_MAP.coolwarm;
+                //var colorRange = plotting.COLOR_MAP.coolwarm;
+                srdbg('warpnvd density map', appState.models[$scope.modelName].colorMap, 'default', appState.modelInfo($scope.modelName).colorMap[SIREPO.INFO_INDEX_DEFAULT_VALUE]);
+                var colorRange = plotting.colorMapOrDefault(appState.models[$scope.modelName].colorMap, appState.modelInfo($scope.modelName).colorMap[SIREPO.INFO_INDEX_DEFAULT_VALUE]);
                 var colorScale = d3.scale.linear()
                     .domain(plotting.linspace(json.v_min, json.v_max, colorRange.length))
                     .range(colorRange);

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -1089,9 +1089,7 @@ SIREPO.app.directive('impactDensityPlot', function(appState, plotting) {
                 select('.x-axis-label').text(plotting.extractUnits($scope, 'x', json.x_label));
                 select('.main-title').text(json.title);
 
-                //var colorRange = plotting.COLOR_MAP.coolwarm;
-                srdbg('warpnvd density map', appState.models[$scope.modelName].colorMap, 'default', appState.modelInfo($scope.modelName).colorMap[SIREPO.INFO_INDEX_DEFAULT_VALUE]);
-                var colorRange = plotting.colorMapOrDefault(appState.models[$scope.modelName].colorMap, appState.modelInfo($scope.modelName).colorMap[SIREPO.INFO_INDEX_DEFAULT_VALUE]);
+                var colorRange = plotting.colorRangeFromModel($scope.modelName);
                 var colorScale = d3.scale.linear()
                     .domain(plotting.linspace(json.v_min, json.v_max, colorRange.length))
                     .range(colorRange);

--- a/sirepo/package_data/static/json/elegant-schema.json
+++ b/sirepo/package_data/static/json/elegant-schema.json
@@ -382,7 +382,8 @@
         "bunchReport": {
             "x": ["X Value", "PhaseSpaceCoordinate"],
             "y": ["Y Value", "PhaseSpaceCoordinate"],
-            "histogramBins": ["Histogram Bins", "Integer"]
+            "histogramBins": ["Histogram Bins", "Integer"],
+            "colorMap": ["Color Map", "ColorMap", "afmhot"]
         },
         "elementAnimation": {
             "x": ["X Value", "ValueList", ""],
@@ -391,7 +392,8 @@
             "histogramBins": ["Histogram Bins", "Integer"],
             "framesPerSecond": ["Frames per Second", "FramesPerSecond", "5"],
             "fileId": ["File ID", "String", ""],
-            "values": ["Values", "Array", []]
+            "values": ["Values", "Array", []],
+            "colorMap": ["Color Map", "ColorMap", "afmhot"]
         },
         "parameterTable": {
             "file": ["File", "ValueList", ""],
@@ -3577,7 +3579,8 @@
             "advanced": [
                 "x",
                 "y",
-                "histogramBins"
+                "histogramBins",
+                "colorMap"
             ]
         },
         "beamline": {
@@ -3593,7 +3596,8 @@
                 "yFile",
                 "y",
                 "histogramBins",
-                "framesPerSecond"
+                "framesPerSecond",
+                "colorMap"
             ]
         },
         "parameterTable": {

--- a/sirepo/package_data/static/json/hellweg-schema.json
+++ b/sirepo/package_data/static/json/hellweg-schema.json
@@ -127,7 +127,8 @@
         "beamAnimation": {
             "reportType": ["Report", "BeamReportType"],
             "histogramBins": ["Number of Bins", "Integer"],
-            "framesPerSecond": ["Frames per Second", "FramesPerSecond"]
+            "framesPerSecond": ["Frames per Second", "FramesPerSecond"],
+            "colorMap": ["Color Map", "ColorMap", "viridis"]
         },
         "beamHistogramAnimation": {
             "reportType": ["Report", "BeamHistogramReportType"],
@@ -140,7 +141,8 @@
         },
         "beamReport": {
             "reportType": ["Report", "BeamReportType"],
-            "histogramBins": ["Number of Bins", "Integer"]
+            "histogramBins": ["Number of Bins", "Integer"],
+            "colorMap": ["Color Map", "ColorMap", "viridis"]
         },
         "cellElement": {
             "phaseAdvance": ["Phase Advance [deg]", "Float", 120],
@@ -295,7 +297,8 @@
             "advanced": [
                 "reportType",
                 "histogramBins",
-                "framesPerSecond"
+                "framesPerSecond",
+                "colorMap"
             ]
         },
         "beamHistogramAnimation": {
@@ -316,7 +319,8 @@
             "title": "Beam Report",
             "advanced": [
                 "reportType",
-                "histogramBins"
+                "histogramBins",
+                "colorMap"
             ]
         },
         "cellElement": {

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -94,5 +94,14 @@
             "folder": ["Folder", "String"],
             "documentationUrl": ["Documentation URL", "OptionalString", ""]
         }
+    },
+    "commonEnums": {
+        "ColorMap": [
+            ["grayscale", "grayscale"],
+            ["viridis", "viridis"],
+            ["afmhot", "afmhot"],
+            ["coolwarm", "coolwarm"],
+            ["jet", "jet"]
+        ]
     }
 }

--- a/sirepo/package_data/static/json/shadow-schema.json
+++ b/sirepo/package_data/static/json/shadow-schema.json
@@ -515,7 +515,8 @@
             "horizontalSize": ["Horizontal Size [mm]", "Float"],
             "verticalSize": ["Vertical Size [mm]", "Float"],
             "horizontalOffset": ["Horizontal Offset [mm]", "Float"],
-            "verticalOffset": ["Vertical Offset [mm]", "Float"]
+            "verticalOffset": ["Vertical Offset [mm]", "Float"],
+            "colorMap": ["Color Map", "ColorMap", "viridis"]
         },
         "mirror": {
             "title": ["Element Name", "String", "Mirror"],
@@ -589,7 +590,8 @@
             "horizontalSize": ["Horizontal Size [mm]", "Float"],
             "verticalSize": ["Vertical Size [mm]", "Float"],
             "horizontalOffset": ["Horizontal Offset [mm]", "Float"],
-            "verticalOffset": ["Vertical Offset [mm]", "Float"]
+            "verticalOffset": ["Vertical Offset [mm]", "Float"],
+            "colorMap": ["Color Map", "ColorMap", "viridis"]
         },
         "rayFilter": {
             "f_bound_sour": ["Optimize Source", "BoundSource", "0"],
@@ -617,7 +619,8 @@
             "horizontalSize": ["Horizontal Size [mm]", "Float"],
             "verticalSize": ["Vertical Size [mm]", "Float"],
             "horizontalOffset": ["Horizontal Offset [mm]", "Float"],
-            "verticalOffset": ["Vertical Offset [mm]", "Float"]
+            "verticalOffset": ["Vertical Offset [mm]", "Float"],
+            "colorMap": ["Color Map", "ColorMap", "viridis"]
         },
         "wiggler": {
             "ph1": ["Minimum Energy [eV]", "Float", 20000.0],
@@ -995,7 +998,8 @@
                         "verticalSize",
                         "verticalOffset"
                     ]]
-                ]
+                ],
+                "colorMap"
             ]
         },
         "mirror": {
@@ -1107,7 +1111,8 @@
                         "verticalSize",
                         "verticalOffset"
                     ]]
-                ]
+                ],
+                "colorMap"
             ]
         },
         "simulation": {
@@ -1142,7 +1147,8 @@
                         "verticalSize",
                         "verticalOffset"
                     ]]
-                ]
+                ],
+                "colorMap"
             ]
         },
         "wiggler": {

--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -441,7 +441,8 @@
             "characteristic": ["Characteristic to be Extracted", "Characteristic"],
             "fieldUnits": ["Intensity Units", "FieldUnits"],
             "intensityPlotsWidth": ["Maximum Plot Width [pixels]", "IntensityPlotsWidth", "0"],
-            "intensityPlotsScale": ["Plot Scale", "IntensityPlotsScale", "linear"]
+            "intensityPlotsScale": ["Plot Scale", "IntensityPlotsScale", "linear"],
+            "colorMap": ["Color Map", "ColorMap", "grayscale"]
         },
         "intensityReport": {
             "distanceFromSource": ["Distance From Source [m]", "Float"],
@@ -454,7 +455,8 @@
             "method": ["Single-Electron Spectrum Computation Method", "IntensityMethod"],
             "precision": ["Relative Precision", "Float"],
             "polarization": ["Polarization Component to Extract", "Polarization"],
-            "fieldUnits": ["Intensity Units", "FieldUnits"]
+            "fieldUnits": ["Intensity Units", "FieldUnits"],
+            "colorMap": ["Color Map", "ColorMap", "grayscale"]
         },
         "lens": {
             "title": ["Element Name", "String", "Lens"],
@@ -615,7 +617,8 @@
             "samplingMethod": ["Sampling Method", "SamplingMethod"],
             "verticalPointCount": ["Number of Points vs Vertical Position", "Integer"],
             "verticalPosition": ["Vertical Center Position [mm]", "Float"],
-            "verticalRange": ["Range of Vertical Position [mm]", "Float"]
+            "verticalRange": ["Range of Vertical Position [mm]", "Float"],
+            "colorMap": ["Color Map", "ColorMap", "grayscale"]
         },
         "sphericalMirror": {
             "title": ["Element Name", "String", "Circular Cylinder Mirror"],
@@ -697,7 +700,8 @@
             "characteristic": ["Characteristic to be Extracted", "Characteristic"],
             "fieldUnits": ["Intensity Units", "FieldUnits"],
             "intensityPlotsWidth": ["Maximum Plot Width [pixels]", "IntensityPlotsWidth", "0"],
-            "intensityPlotsScale": ["Plot Scale", "IntensityPlotsScale", "linear"]
+            "intensityPlotsScale": ["Plot Scale", "IntensityPlotsScale", "linear"],
+            "colorMap": ["Color Map", "ColorMap", "grayscale"]
         }
     },
     "view": {
@@ -1051,6 +1055,9 @@
                 ["Scale", [
                     "intensityPlotsWidth",
                     "intensityPlotsScale"
+                ]],
+                ["Other", [
+                    "colorMap"
                 ]]
             ]
         },
@@ -1078,6 +1085,9 @@
                     "magneticField",
                     "method",
                     "precision"
+                ]],
+                ["Other", [
+                    "colorMap"
                 ]]
             ]
         },
@@ -1338,6 +1348,9 @@
                 ["Scale", [
                     "intensityPlotsWidth",
                     "intensityPlotsScale"
+                ]],
+                ["Other", [
+                    "colorMap"
                 ]]
             ]
         },
@@ -1518,6 +1531,9 @@
                 ["Scale", [
                     "intensityPlotsWidth",
                     "intensityPlotsScale"
+                ]],
+                ["Other", [
+                    "colorMap"
                 ]]
             ]
         }

--- a/sirepo/package_data/static/json/warppba-schema.json
+++ b/sirepo/package_data/static/json/warppba-schema.json
@@ -186,18 +186,21 @@
             "uyMin": ["Minimum UY [mc]", "Float"],
             "uyMax": ["Maximum UY [mc]", "Float"],
             "uzMin": ["Minimum UZ [mc]", "Float"],
-            "uzMax": ["Maximum UZ [mc]", "Float"]
+            "uzMax": ["Maximum UZ [mc]", "Float"],
+            "colorMap": ["Color Map", "ColorMap", "viridis"]
         },
         "fieldAnimation": {
             "field": ["Field", "Field"],
             "coordinate": ["Coordinate", "FieldCoordinate"],
             "mode": ["Mode", "FieldMode"],
-            "framesPerSecond": ["Frames per Second", "FramesPerSecond"]
+            "framesPerSecond": ["Frames per Second", "FramesPerSecond"],
+            "colorMap": ["Color Map", "ColorMap", "viridis"]
         },
         "laserPreviewReport": {
             "field": ["Field", "Field"],
             "coordinate": ["Coordinate", "FieldCoordinate"],
-            "mode": ["Mode", "FieldMode"]
+            "mode": ["Mode", "FieldMode"],
+            "colorMap": ["Color Map", "ColorMap", "viridis"]
         },
         "simulationStatus": {}
     },
@@ -337,7 +340,8 @@
                         "uyMax",
                         "uzMax"
                     ]]
-                ]
+                ],
+                "colorMap"
             ]
         },
         "fieldAnimation": {
@@ -346,7 +350,8 @@
                 "field",
                 "coordinate",
                 "mode",
-                "framesPerSecond"
+                "framesPerSecond",
+                "colorMap"
             ]
         },
         "laserPreviewReport": {
@@ -354,7 +359,8 @@
             "advanced": [
                 "field",
                 "coordinate",
-                "mode"
+                "mode",
+                "colorMap"
             ]
         }
     }

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -63,10 +63,15 @@
         },
         "fieldAnimation": {
             "field": ["Field", "Field"],
-            "framesPerSecond": ["Frames per Second", "FramesPerSecond"]
+            "framesPerSecond": ["Frames per Second", "FramesPerSecond"],
+            "colorMap": ["Color Map", "ColorMap", "viridis"]
         },
-        "fieldReport": {},
-        "impactDensityAnimation": {},
+        "fieldReport": {
+            "colorMap": ["Color Map", "ColorMap", "viridis"]
+        },
+        "impactDensityAnimation": {
+            "colorMap": ["Color Map", "ColorMap", "coolwarm"]
+        },
         "particleAnimation": {
             "renderCount": ["Particles to Render", "ParticleRenderCount"]
         },
@@ -154,16 +159,21 @@
             "title": "Field Animation",
             "advanced": [
                 "field",
-                "framesPerSecond"
+                "framesPerSecond",
+                "colorMap"
             ]
         },
         "fieldReport": {
             "title": "Field Report",
-            "advanced": []
+            "advanced": [
+                "colorMap"
+            ]
         },
         "impactDensityAnimation": {
             "title": "Impact Density",
-            "advanced": []
+            "advanced": [
+                "colorMap"
+            ]
         },
         "particleAnimation": {
             "title": "Particle Trace",

--- a/sirepo/simulation_db.py
+++ b/sirepo/simulation_db.py
@@ -239,6 +239,13 @@ def get_schema(sim_type):
             if model_field_name not in app_models[model_Name]:
                 app_models[model_Name][model_field_name] = common_models[model_Name][model_field_name]
 
+    # merge common enums into app models
+    common_enums = schema['commonEnums']
+    app_enums = schema['enum']
+    for enum_Name in common_enums:
+        if enum_Name not in app_enums:
+            app_enums[enum_Name] = common_enums[enum_Name]
+
     return schema
 
 


### PR DESCRIPTION
Notes:

Adding UI for simulation-wide defaults turns out to be a heavy task, as per @moellep - it requires a new mechanism to store data outside the simulation folder structure. That could prove useful for other things as well, but was outside the scope of this issue.

I added a 'commonEnums' object to schema-common.json, and put the various color map names in there. Might be a good home for Boolean etc.

The color map applied to a plot is the first one found in 1) the stored model data 2) the default for that report (in the schema) 3) the app-level default as stored in SIREPO.PLOTTING_COLOR_MAP (in the javascript) and 4) a global default SIREPO.DEFAULT_COLOR_MAP (which is currently 'viridis').

Since the reports for srw are pretty complex, I opted to put the color map menu in its own tab, labeled 'Other', for those.