### PR TITLE
Bootstrap toggle fixes for Issues #936 and #950 and settings menu fix for Issue #892

### DIFF
--- a/sirepo/package_data/static/css/sirepo.css
+++ b/sirepo/package_data/static/css/sirepo.css
@@ -268,8 +268,8 @@
     }
 
     .sr-bs-toggle + .toggle-group {
-        transition: none;
-        -webkit-transition: none;
+        transition: left 0.1s;
+        -webkit-transition: left 0.1s;
     }
 
     .sr-notify {

--- a/sirepo/package_data/static/css/sirepo.css
+++ b/sirepo/package_data/static/css/sirepo.css
@@ -255,12 +255,21 @@
             justify-content: flex-end;
             float: right;
         }
+        .sr-navbar-right .dropdown-menu {
+            right: 0;
+            left: auto;
+        }
     }
 
     .toggle-group label.btn-default.toggle-off {
         color: black;
         background-color: white;
         box-shadow: none;
+    }
+
+    .sr-bs-toggle + .toggle-group {
+        transition: none;
+        -webkit-transition: none;
     }
 
     .sr-notify {

--- a/sirepo/package_data/static/js/sirepo-beamline.js
+++ b/sirepo/package_data/static/js/sirepo-beamline.js
@@ -425,7 +425,7 @@ SIREPO.app.directive('beamlineItem', function(beamlineService, $timeout) {
             item: '=',
         },
         template: [
-            '<span class="srw-beamline-badge badge">{{ item.position ? item.position + \'m\' : \'⚠ \' }}</span>',
+            '<span class="srw-beamline-badge badge">{{ item.position ? item.position + \'m\' : (item.position === 0 ? \'0m\' : \'⚠ \') }}</span>',
             '<span data-ng-if="showItemButtons()" data-ng-click="beamlineService.removeElement(item)" class="srw-beamline-close-icon glyphicon glyphicon-remove-circle" title="Delete Element"></span>',
             '<span data-ng-if="showItemButtons()" data-ng-click="toggleDisableElement(item)" class="srw-beamline-disable-icon glyphicon glyphicon-off" title="Disable Element"></span>',
             '<div class="srw-beamline-image">',
@@ -545,6 +545,7 @@ SIREPO.app.directive('beamlineItemEditor', function(appState, beamlineService) {
         },
         template: [
             '<div>',
+              '<button type="button" class="close" ng-click="beamlineService.dismissPopup()"><span>&times;</span></button>',
               '<div data-help-button="{{ title }}"></div>',
               '<form name="form" class="form-horizontal" autocomplete="off" novalidate>',
                 '<div class="sr-beamline-element-title">{{ title }}</div>',

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -1155,7 +1155,6 @@ SIREPO.app.directive('colorMapMenu', function(appState, plotting) {
             $scope.enum = SIREPO.APP_SCHEMA.enum;
             $scope.info = appState.modelInfo($scope.modelName)[$scope.field];
             $scope.reportDefaultMap = $scope.info[SIREPO.INFO_INDEX_DEFAULT_VALUE];
-            //srdbg('report default is', $scope.reportDefaultMap);
             if (!$scope.info) {
                 throw 'invalid model field: ' + $scope.modelName + '.' + $scope.field;
             }


### PR DESCRIPTION
I added @moellep 's suggestions and got rid of the timeout. However:

Angular hates checkboxes in particular, so I use ng-open (irrelevant to checkboxes) to keep the value updated as it changes in the background. A one-time initialization fails in a couple of cases that this trick handles.

I also added a couple of cosmetic changes to the beamline: a close "x" at the top of the item editor and fixing the position label so 0 displays as "0m", not a warning symbol.
