### PR TITLE
Popup report drag fixes (#1059), characteristic copying to watchpoints (#1120), script download in options menu (#1160) 

### DIFF
--- a/sirepo/package_data/static/js/sirepo-beamline.js
+++ b/sirepo/package_data/static/js/sirepo-beamline.js
@@ -74,6 +74,14 @@ SIREPO.app.factory('beamlineService', function(appState, validationService, $win
         }
         return [];
     };
+    self.getWatchReports = function() {
+        var items = self.getWatchItems();
+        var rpts = [];
+        for(var iIndex = 0; iIndex < items.length;  ++iIndex) {
+            rpts.push(self.watchpointReportName(items[iIndex].id));
+        }
+        return rpts;
+    };
 
     self.isActiveItemValid = function() {
         return self.isItemValid(self.activeItem);

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -1756,6 +1756,7 @@ SIREPO.app.directive('settingsMenu', function(appState, appDataService, panelSta
                     '<li class="sr-settings-submenu" data-ng-transclude="appSettingsSlot"></li>',
                     '<li><a href data-ng-if="nav.modeIsDefault()" data-ng-click="showDocumentationUrl()"><span class="glyphicon glyphicon-book"></span> Simulation Documentation URL</a></li>',
                     '<li><a href data-ng-click="exportArchive(\'zip\')"><span class="glyphicon glyphicon-cloud-download"></span> Export as ZIP</a></li>',
+                    '<li><a href data-ng-click="pythonSource()"><span class="glyphicon glyphicon-cloud-download sr-nav-icon"></span> Python Source</a></li>',
                     '<li data-ng-if="canCopy()"><a href data-ng-click="copy()"><span class="glyphicon glyphicon-copy"></span> Open as a New Copy</a></li>',
                     '<li data-ng-if="isExample()"><a href data-target="#reset-confirmation" data-toggle="modal"><span class="glyphicon glyphicon-repeat"></span> Discard Changes to Example</a></li>',
                     '<li data-ng-if="! isExample()"><a href data-target="#delete-confirmation" data-toggle="modal"><span class="glyphicon glyphicon-trash"></span> Delete</a></li>',
@@ -1780,6 +1781,10 @@ SIREPO.app.directive('settingsMenu', function(appState, appDataService, panelSta
             $scope.showDocumentationUrl = function() {
                 panelState.showModalEditor('simDoc');
             };
+            $scope.pythonSource = function() {
+                panelState.pythonSource(simulationId());
+            };
+
 
             $scope.relatedSimulations = [];
 

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -586,6 +586,25 @@ SIREPO.app.controller('SRWBeamlineController', function (appState, beamlineServi
         });
     });
 
+    $scope.$on('modelChanged', function(e, name) {
+        if(name !== 'initialIntensityReport') {
+            return;
+        }
+        var rpt = appState.models.initialIntensityReport;
+        if(! rpt || ! parseInt(rpt.copyCharacteristic)) {
+            return;
+        }
+        var watchRpts = beamlineService.getWatchReports();
+        for(var wIndex = 0; wIndex < watchRpts.length; ++wIndex) {
+            var watchRptName = watchRpts[wIndex];
+            var watchRpt = appState.models[watchRptName];
+            if(watchRpt.characteristic !== rpt.characteristic) {
+                watchRpt.characteristic = rpt.characteristic;
+                appState.saveChanges(watchRptName);
+            }
+        }
+
+    });
 
     $scope.$on('$destroy', function() {
         // clear the coherence if we went away from the beamline tab

--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -479,6 +479,7 @@
         "initialIntensityReport": {
             "polarization": ["Polarization Component to Extract", "Polarization"],
             "characteristic": ["Characteristic to be Extracted", "Characteristic"],
+            "copyCharacteristic": ["Use Characteristic Across Reports", "Boolean", "0"],
             "fieldUnits": ["Intensity Units", "FieldUnits", "1"],
             "intensityPlotsWidth": ["Maximum Plot Width [pixels]", "IntensityPlotsWidth", "0"],
             "intensityPlotsScale": ["Plot Scale", "IntensityPlotsScale", "linear"],
@@ -1158,6 +1159,7 @@
                     "simulation.photonEnergy",
                     "polarization",
                     "characteristic",
+                    "copyCharacteristic",
                     "fieldUnits"
                 ]],
                 ["Scale", [

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -149,7 +149,7 @@ _RESOURCE_DIR = template_common.resource_dir(SIM_TYPE)
 
 _PREDEFINED = None
 
-_REPORT_STYLE_FIELDS = ['intensityPlotsWidth', 'intensityPlotsScale', 'colorMap', 'plotAxisX', 'plotAxisY', 'plotAxisY2']
+_REPORT_STYLE_FIELDS = ['intensityPlotsWidth', 'intensityPlotsScale', 'colorMap', 'plotAxisX', 'plotAxisY', 'plotAxisY2', 'copyCharacteristic']
 
 _RUN_ALL_MODEL = 'simulation'
 


### PR DESCRIPTION
Notes:

#1059: The driving conflict was between the DOM transform performed by ngDraggable and the d3 transform.  Resolved by resetting the former when drag completes.  This fix also keeps the popup in place during zoom

#1120: This toggle is set only in the initial intensity report, in a primary/replica arrangement.  Users can still change the characteristic for each watchpoint but that does not currently turn off the toggle, so they will be reset to match the initial report should it be run agan