### PR TITLE
Focus point keyboard input and example folders

### DIFF
--- a/sirepo/package_data/static/css/sirepo.css
+++ b/sirepo/package_data/static/css/sirepo.css
@@ -420,6 +420,10 @@
     .sr-hide-report {
       opacity: 0;
     }
+    .sr-panel-active {
+        border-width: 2px;
+        border-color: green;
+    }
 
     /* plot styles */
     .sr-plot .axis text {

--- a/sirepo/package_data/static/css/sirepo.css
+++ b/sirepo/package_data/static/css/sirepo.css
@@ -601,7 +601,13 @@
     .sr-plot .popup-group .report-window-close {
         fill: #222;
         cursor: pointer;
+        user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        -webkit-user-select: none;
     }
+
+
     .sr-plot .plot-visibility {
         cursor: pointer;
         font-size: 16px;

--- a/sirepo/package_data/static/html/plot2d.html
+++ b/sirepo/package_data/static/html/plot2d.html
@@ -33,7 +33,7 @@
           <path class="line line-9"></path>
           <path class="line line-10"></path>
         </svg>
-        <rect class="overlay mouse-zoom" data-interactive-overlay="" data-focus-points="focusPoints" data-hide-focus-points="hideFocusPoints()" data-plot-info-delegates="plotInfoDelegates" data-focus-strategy="focusStrategy" data-ng-attr-width="{{ width }}" data-ng-attr-height="{{ height }}"></rect>
+        <rect class="overlay mouse-zoom" data-interactive-overlay="" data-report-id="reportId" data-focus-points="focusPoints" data-hide-focus-points="hideFocusPoints()" data-plot-info-delegates="plotInfoDelegates" data-focus-strategy="focusStrategy" data-ng-attr-width="{{ width }}" data-ng-attr-height="{{ height }}"></rect>
         <svg data-popup-report="" class="popup-report" data-ng-if="focusPoints && focusPoints.length" data-focus-points="focusPoints" data-plot-info-delegate="popupDelegate" data-ng-attr-width="{{ width }}" data-ng-attr-height="{{ height }}" data-ng-drop="true">
         </svg>
       </g>

--- a/sirepo/package_data/static/html/plot3d.html
+++ b/sirepo/package_data/static/html/plot3d.html
@@ -65,8 +65,8 @@
           </g>
           <text class="z-axis-label" ng-attr-x="{{ canvasSize + rightPanelWidth / 2 }}" ng-attr-y="{{ canvasSize + margin.top + 10 }}"></text>
           <rect class="mouse-rect-xy mouse-zoom" ng-attr-width="{{ canvasSize }}" ng-attr-height="{{ canvasSize }}" style="pointer-events: all; fill: none;"></rect>
-          <rect class="mouse-rect-y mouse-zoom" data-interactive-overlay="" data-focus-points="[focusPointY]"  data-plot-info-delegates="plotInfoDelegatesRight" data-hide-focus-points="hideFocusPoints()" ng-attr-x="{{ canvasSize }}" ng-attr-width="{{ rightPanelWidth }}" ng-attr-height="{{ canvasSize }}" style="pointer-events: all; fill: none;"></rect>
-          <rect class="mouse-rect-x mouse-zoom" data-interactive-overlay="" data-focus-points="[focusPointX]" data-plot-info-delegates="plotInfoDelegatesBottom" data-hide-focus-points="hideFocusPoints()" ng-attr-y="{{ canvasSize }}" ng-attr-width="{{ canvasSize }}" ng-attr-height="{{ bottomPanelHeight }}" style="pointer-events: all; fill: none;"></rect>
+          <rect class="mouse-rect-y mouse-zoom" data-interactive-overlay="" data-report-id="reportId" data-focus-points="[focusPointY]"  data-plot-info-delegates="plotInfoDelegatesRight" data-hide-focus-points="hideFocusPoints()" ng-attr-x="{{ canvasSize }}" ng-attr-width="{{ rightPanelWidth }}" ng-attr-height="{{ canvasSize }}" style="pointer-events: all; fill: none;"></rect>
+          <rect class="mouse-rect-x mouse-zoom" data-interactive-overlay="" data-report-id="reportId" data-focus-points="[focusPointX]" data-plot-info-delegates="plotInfoDelegatesBottom" data-hide-focus-points="hideFocusPoints()" ng-attr-y="{{ canvasSize }}" ng-attr-width="{{ canvasSize }}" ng-attr-height="{{ bottomPanelHeight }}" style="pointer-events: all; fill: none;"></rect>
         </g>
       </svg></div>
       <div data-animation-buttons=""></div>

--- a/sirepo/package_data/static/html/simulations.html
+++ b/sirepo/package_data/static/html/simulations.html
@@ -1,7 +1,7 @@
 <script type="text/ng-template" id="sr-folder">
   <a href data-ng-click="simulations.toggleFolder(item)">
     <span class="glyphicon sr-small-nav-icon" data-ng-class="{'glyphicon-chevron-down': item.isOpen, 'glyphicon-chevron-right': ! item.isOpen}"></span>
-    <span class="glyphicon sr-nav-icon" data-ng-class="{'glyphicon-folder-open': item.isOpen, 'glyphicon-folder-close': ! item.isOpen}"></span> {{ item.name }}
+    <span class="glyphicon sr-nav-icon" data-ng-class="{'sr-user-item': ! simulations.isRootFolder(item) && ! simulations.fileManager.isFolderExample(item), 'glyphicon-folder-open': item.isOpen, 'glyphicon-folder-close': ! item.isOpen}"></span> <span data-ng-class="{ 'sr-user-item': ! simulations.isRootFolder(item) && ! simulations.fileManager.isFolderExample(item) }">{{ item.name }}</span>
   </a>
   <ul data-ng-if="item.isOpen" class="nav sr-nav-sidebar">
     <li data-ng-repeat="item in item.children | filter:{isFolder: true} | orderBy:'name'" data-ng-include="'sr-folder'" data-ng-class="{'active': simulations.isActiveFolder(item)}"></li>
@@ -18,7 +18,7 @@
     <div class="col-sm-8 col-md-9">
       <div class="sr-iconset">
         <div class="sr-folder-nav visible-xs clearfix">
-          <a href data-ng-repeat="item in simulations.activeFolderPath" data-ng-click="simulations.openItem(item)"><span data-ng-if="simulations.isRootFolder(item)" class="glyphicon glyphicon-folder-open sr-nav-icon"></span><span data-ng-if="! simulations.isRootFolder(item)" class="glyphicon glyphicon-chevron-right sr-small-nav-icon"></span>{{ item.name }} </a>
+          <a href data-ng-repeat="item in simulations.activeFolderPath" data-ng-click="simulations.openItem(item)"><span data-ng-if="simulations.isRootFolder(item)" class="glyphicon glyphicon-folder-open sr-nav-icon"></span><span data-ng-if="! simulations.isRootFolder(item)" class="glyphicon glyphicon-chevron-right sr-small-nav-icon"></span><span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isFolderExample(item) }">{{ item.name }}</span> </a>
         </div>
         <div class="col-sm-12" data-sr-notify="" data-notification-name="'net.sirepo.get_started_notify'" data-notification-class="'alert-info'"></div>
         <div class="sr-icon-view-toggle"><a href data-ng-click="simulations.toggleIconView()"><span class="glyphicon" data-ng-class="{'glyphicon-th-list': simulations.isIconView, 'glyphicon-th-large': ! simulations.isIconView }"></span> View as {{ simulations.isIconView ? 'List' : 'Icons' }}</a></div>
@@ -34,7 +34,7 @@
           </thead>
           <tbody>
             <tr data-ng-repeat="item in simulations.activeFolder.children | orderBy:['isFolder', simulations.sortField]">
-              <td><a href data-ng-click="simulations.openItem(item)"><span class="glyphicon" data-ng-class="{'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder}"></span> {{ item.name | simulationName }}</a></td>
+              <td><a href data-ng-click="simulations.openItem(item)"><span class="glyphicon" data-ng-class="{'sr-user-item': ! simulations.fileManager.isItemExample(item), 'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder && item.isExample, 'sr-transparent-icon-user': ! item.isFolder && ! item.isExample}"></span> <span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a></td>
               <td>{{ item.lastModified }}</td>
             </tr>
             <tr data-ng-show="simulations.isWaitingForSim">
@@ -51,14 +51,14 @@
           <div data-ng-repeat="item in simulations.activeFolder.children | orderBy:['isFolder', 'name']" class="sr-icon-col">
             <div class="sr-thumbnail text-center dropdown">
               <a href data-ng-dblclick="simulations.openItem(item)" class="sr-item-icon" data-toggle="dropdown">
-                <span class="caret" style="visibility: hidden"></span><span class="glyphicon" data-ng-class="{'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder}"></span><span class="caret"></span>
+                <span class="caret" style="visibility: hidden"></span><span class="glyphicon" data-ng-class="{'sr-user-item': ! simulations.fileManager.isItemExample(item), 'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder && item.isExample, 'sr-transparent-icon-user': ! item.isFolder && ! item.isExample}"></span><span data-ng-if="simulations.fileManager.isItemExample(item)" class="glyphicon glyphicon-cog sr-example-item" data-ng-class="{ 'sr-example-folder': item.isFolder, 'sr-example-sim': ! item.isFolder }"></span><span class="caret"></span>
               </a>
-              <a class="sr-item-text" href data-ng-click="simulations.openItem(item)">{{ item.name | simulationName }}</a>
+              <a class="sr-item-text" href data-ng-click="simulations.openItem(item)"><span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a>
               <ul class="dropdown-menu">
                 <li><a href data-ng-click="simulations.openItem(item)"><span class="glyphicon sr-nav-icon" data-ng-class="{'glyphicon-folder-open': item.isFolder, 'glyphicon-open-file': ! item.isFolder}"></span> Open</a></li>
                 <li data-ng-if="! item.isFolder"><a href data-ng-click="simulations.copyItem(item)"><span class="glyphicon glyphicon-duplicate sr-nav-icon"></span> Open as a New Copy</a></li>
                 <li data-ng-if="! item.isExample"><a href data-ng-click="simulations.renameItem(item)"><span class="glyphicon glyphicon-edit sr-nav-icon"></span> Rename</a></li>
-                <li><a href data-ng-click="simulations.moveItem(item)"><span class="glyphicon glyphicon-arrow-right sr-nav-icon"></span> Move</a></li>
+                <li data-ng-if="! simulations.fileManager.isItemExample(item)"><a href data-ng-click="simulations.moveItem(item)"><span class="glyphicon glyphicon-arrow-right sr-nav-icon"></span> Move</a></li>
                 <li data-ng-if="! item.isFolder"><a href data-ng-click="simulations.exportArchive(item, 'zip')"><span class="glyphicon glyphicon-save-file sr-nav-icon"></span> Export as Zip</a></li>
                 <li data-ng-if="! item.isFolder"><a href data-ng-click="simulations.exportArchive(item, 'html')"><span class="glyphicon glyphicon-export sr-nav-icon"></span> Self-Extracting Simulation</a></li>
                 <li data-ng-if="! item.isFolder"><a href data-ng-click="simulations.pythonSource(item)"><span class="glyphicon glyphicon-cloud-download sr-nav-icon"></span> Python Source</a></li>
@@ -94,12 +94,20 @@
 </div>
 
 <div data-confirmation-modal="" data-id="sr-copy-confirmation" data-title="Copy {{ simulations.selectedItemType() }}" data-ok-text="Create Copy" data-ok-clicked="simulations.copySelected()">
-  <form class="form-horizontal"autocomplete="off">
+  <form class="form-horizontal" autocomplete="off">
+    <div class="form-group">
     <label class="col-sm-3 control-label">New Name</label>
     <div class="col-sm-9">
       <input data-safe-path="" class="form-control" data-ng-model="simulations.copyName" required/>
       <div class="sr-input-warning" data-ng-show="showWarning">{{warningText}}</div>
     </div>
+    </div>
+    <div class="form-group" data-ng-if="simulations.fileManager.getUserFolderPaths().length > 1">
+      <label class="col-sm-3 control-label">Folder</label>
+      <div class="col-sm-9">
+        <div data-user-folder-list="" data-model="simulations" data-field="'copyFolder'"></div>
+      </div>
+  </div>
   </form>
 </div>
 

--- a/sirepo/package_data/static/js/ext/ngDraggable.js
+++ b/sirepo/package_data/static/js/ext/ngDraggable.js
@@ -46,7 +46,7 @@ angular.module("ngDraggable", [])
                     var initialize = function () {
                         element.attr('draggable', 'false'); // prevent native drag
                         // check to see if drag handle(s) was specified
-                        var dragHandles = element.find('[ng-drag-handle]');
+                        var dragHandles = $(element).find('[ng-drag-handle]');
                         if (dragHandles.length) {
                             _dragHandle = dragHandles;
                         }

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -362,7 +362,7 @@ SIREPO.app.directive('labelWithTooltip', function() {
     };
 });
 
-SIREPO.app.directive('fieldEditor', function(appState, utilities, validationService) {
+SIREPO.app.directive('fieldEditor', function(appState, utilities, keypressService, $timeout) {
     return {
         restrict: 'A',
         scope: {
@@ -419,6 +419,9 @@ SIREPO.app.directive('fieldEditor', function(appState, utilities, validationServ
               '<div data-ng-switch-when="Text" data-ng-class="fieldClass">',
                 '<div data-collapsable-notes=""></div>',
               '</div>',
+              '<div data-ng-switch-when="UserFolder" data-ng-class="fieldClass">',
+                '<div data-user-folder-list="" data-model="model" data-field="field"></div>',
+              '</div>',
               SIREPO.appFieldEditors || '',
               // assume it is an enum
               '<div data-ng-switch-default data-ng-class="fieldClass">',
@@ -430,7 +433,8 @@ SIREPO.app.directive('fieldEditor', function(appState, utilities, validationServ
             '</div>',
             '</div>',
         ].join(''),
-        controller: function($scope) {
+        controller: function($scope, $element) {
+
             $scope.utilities = utilities;
             function fieldClass(fieldType, fieldSize, wantEnumButtons) {
                 return 'col-sm-' + (fieldSize || (
@@ -471,6 +475,23 @@ SIREPO.app.directive('fieldEditor', function(appState, utilities, validationServ
             if (! $scope.info) {
                 throw 'invalid model field: ' + $scope.modelName + '.' + $scope.field;
             }
+
+            // wait until the switch gets fully evaluated, then set event handlers for input fields
+            // to disable keypress listener set by plots
+            $timeout(function () {
+                var inputElement =  $($element).find('input');
+                if(inputElement.length > 0) {
+                    inputElement
+                        .on('focus', function () {
+                        keypressService.enableListener(false);
+                    })
+                        .on('blur', function () {
+                        keypressService.enableListener(true);
+                    });
+                }
+            },
+                100);
+
             $scope.fieldDelegate = {};
             $scope.labelClass = 'col-sm-' + ($scope.labelSize || '5');
             $scope.wantEnumButtons = wantEnumButtons($scope.info[1], $scope.labelSize);
@@ -489,6 +510,10 @@ SIREPO.app.directive('fieldEditor', function(appState, utilities, validationServ
                 model.$setViewValue('');
                 model.$render();
             };
+
+            $scope.$on('destroy', function (event) {
+                $($element).find('input').off('focus').off('blur');
+            });
         },
     };
 });
@@ -1313,6 +1338,25 @@ SIREPO.app.directive('collapsableNotes', function(appState) {
     };
 });
 
+SIREPO.app.directive('userFolderList', function(appState, fileManager) {
+
+    return {
+        restrict: 'A',
+        scope: {
+            model: '=',
+            field: '=',
+        },
+        template: [
+            '<select class="form-control" data-ng-model="model[field]" data-ng-if="! model.isExample" data-ng-options="item for item in fileManager.getUserFolderPaths()"></select>',
+            '<div class="form-control" data-ng-if="model.isExample" readonly>{{ model.folder }}</div>',
+        ].join(''),
+        controller: function($scope) {
+            $scope.fileManager = fileManager;
+        },
+    };
+});
+
+
 //TODO(pjm): this directive is only needed for old data which might have enum values as a number rather than string
 SIREPO.app.directive('numberToString', function() {
     return {
@@ -1449,6 +1493,7 @@ SIREPO.app.directive('reportContent', function(panelState) {
         restrict: 'A',
         transclude: true,
         scope: {
+            reportId: '<',
             reportContent: '@',
             modelKey: '@',
         },
@@ -1457,11 +1502,11 @@ SIREPO.app.directive('reportContent', function(panelState) {
               '<div data-ng-show="panelState.isLoading(modelKey)" class="lead sr-panel-wait"><span class="glyphicon glyphicon-hourglass"></span> {{ panelState.getStatusText(modelKey) }}</div>',
               '<div data-ng-show="panelState.getError(modelKey)" class="lead sr-panel-wait"><span class="glyphicon glyphicon-exclamation-sign"></span> {{ panelState.getError(modelKey) }}</div>',
               '<div data-ng-switch="reportContent" class="{{ panelState.getError(modelKey) ? \'sr-hide-report\' : \'\' }}">',
-                '<div data-ng-switch-when="2d" data-plot2d="" class="sr-plot" data-model-name="{{ modelKey }}"></div>',
-                '<div data-ng-switch-when="3d" data-plot3d="" class="sr-plot" data-model-name="{{ modelKey }}"></div>',
+                '<div data-ng-switch-when="2d" data-plot2d="" class="sr-plot" data-model-name="{{ modelKey }}" data-report-id="reportId"></div>',
+                '<div data-ng-switch-when="3d" data-plot3d="" class="sr-plot" data-model-name="{{ modelKey }}" data-report-id="reportId"></div>',
                 '<div data-ng-switch-when="heatmap" data-heatmap="" class="sr-plot" data-model-name="{{ modelKey }}"></div>',
                 '<div data-ng-switch-when="particle" data-particle="" class="sr-plot" data-model-name="{{ modelKey }}"></div>',
-                '<div data-ng-switch-when="parameter" data-parameter-plot="" class="sr-plot" data-model-name="{{ modelKey }}"></div>',
+                '<div data-ng-switch-when="parameter" data-parameter-plot="" class="sr-plot" data-model-name="{{ modelKey }}" data-report-id="reportId"></div>',
                 SIREPO.appReportTypes || '',
               '</div>',
               '<div data-ng-transclude=""></div>',
@@ -1486,12 +1531,16 @@ SIREPO.app.directive('reportPanel', function(appState) {
             requestPriority: '@',
         },
         template: [
-            '<div class="panel panel-info">',
+            '<div class="panel panel-info" data-ng-attr-id="{{ ::reportId }}">',
               '<div class="panel-heading clearfix" data-panel-heading="{{ reportTitle() }}" data-model-key="modelKey" data-allow-full-screen="1"></div>',
-              '<div data-report-content="{{ reportPanel }}" data-model-key="{{ modelKey }}"><div data-ng-transclude=""></div></div>',
+              '<div data-report-content="{{ reportPanel }}" data-model-key="{{ modelKey }}" data-report-id="reportId"><div data-ng-transclude=""></div></div>',
             '</div>',
         ].join(''),
-        controller: function($scope) {
+        controller: function($scope, $element) {
+
+            // random id for the keypress service to track
+            $scope.reportId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+
             $scope.modelKey = $scope.modelName;
             if ($scope.modelData) {
                 $scope.modelKey = $scope.modelData.modelKey;
@@ -1651,9 +1700,11 @@ SIREPO.app.directive('appHeaderRight', function(panelState, appState, appDataSer
                 return '';
             };
             $scope.showNewFolderModal = function() {
+                appState.models.simFolder.parent = fileManager.defaultCreationFolderPath();
                 panelState.showModalEditor('simFolder');
             };
             $scope.showSimulationModal = function() {
+                appState.models.simulation.folder = fileManager.defaultCreationFolderPath();
                 panelState.showModalEditor('simulation');
             };
 
@@ -2299,6 +2350,130 @@ SIREPO.app.service('fileUpload', function($http) {
                 srlog('file upload failed');
             });
     };
+});
+
+SIREPO.app.service('keypressService', function(d3Service) {
+
+    var listeners = {};
+    var reports = {};
+    var activeListeners = [];
+    var activeListenerId = null;
+
+    this.addListener = function(listenerId, listener, reportId) {
+        if(! reportId) {
+            return;
+        }
+        listeners[listenerId] = listener;
+        if (! reports[reportId]) {
+                reports[reportId] = [];
+        }
+        reports[reportId].push(listenerId);
+        if(activeListeners.indexOf(listenerId) < 0) {
+            activeListeners.push(listenerId);
+        }
+
+        // turn off highlighting for active report panel, if any
+        showPanelActive(reportForListener(activeListenerId), false);
+
+        activeListenerId = listenerId;
+        this.enableListener(true);
+    };
+    this.hasListener = function(listenerId) {
+        return activeListeners.indexOf(listenerId) >= 0;
+    }
+    this.removeListener = function(listenerId) {
+        var lIndex = activeListeners.indexOf(listenerId);
+        if(lIndex >= 0) {
+            activeListeners.splice(lIndex, 1);
+        }
+        delete listeners[listenerId];
+
+        var reportId = reportForListener(listenerId);
+        showPanelActive(reportId, false);
+        if(reportId) {
+            reports[reportId].splice(reports[reportId].indexOf(listenerId), 1);
+        }
+
+        // activate the last one added, if any remain
+        if(activeListeners.length > 0) {
+            activeListenerId = activeListeners[activeListeners.length - 1];
+            this.enableListener(true);
+        }
+        else {
+            activeListenerId = null;
+            this.enableListener(false);
+        }
+    };
+
+    this.removeListenersForReport = function(reportId) {
+        if(! reportId || ! reports[reportId]) {
+            return;
+        }
+        var rlArr = reports[reportId];
+        for(var rlIndex = 0; rlIndex < rlArr.length; ++rlIndex) {
+            this.removeListener(rlArr[rlIndex]);
+        }
+    };
+    this.removeReport = function(reportId) {
+        if(! reportId) {
+            return;
+        }
+        this.removeListenersForReport(reportId);
+        delete reports[reportId];
+    };
+
+
+    // set the active listener, or
+    // remove keydown listener from body element leaving the keys in place
+    this.enableListener = function(doListen, listenerId) {
+        if(! listenerId)  {
+            listenerId = activeListenerId;
+        }
+        activeListenerId = listenerId;
+        var reportId = reportForListener(activeListenerId);
+        if(doListen && activeListenerId) {
+            d3.select('body').on('keydown', listeners[activeListenerId]);
+            showPanelActive(reportId, true);
+            return;
+        }
+        d3.select('body').on('keydown', null);
+        showPanelActive(reportId, false);
+    };
+    this.enableNextListener = function(direction) {
+        var lIndex = activeListeners.indexOf(activeListenerId);
+        if(lIndex < 0) {
+            return;
+        }
+        this.enableListener(false);
+        var d = direction < 0 ? -1 : 1;
+        var newIndex = (lIndex + d + activeListeners.length) % activeListeners.length;
+        this.enableListener(true, activeListeners[newIndex]);
+    };
+
+    function reportForListener(listenerId) {
+        if(! listenerId) {
+            return null;
+        }
+        for(var reportId in reports) {
+            var rlIndex = reports[reportId].indexOf(listenerId);
+            if(rlIndex < 0) {
+                continue;
+            }
+            return reportId;
+        }
+    }
+
+    function showPanelActive(reportId, isActive) {
+        if(! reportId) {
+            return;
+        }
+        if(isActive) {
+            $('#' + reportId).addClass('sr-panel-active');
+            return;
+        }
+        $('#' + reportId).removeClass('sr-panel-active');
+    }
+
 });
 
 SIREPO.app.service('utilities', function($window, $interval) {

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -1127,10 +1127,11 @@ SIREPO.app.service('layoutService', function(plotting) {
 
 });
 
-SIREPO.app.directive('interactiveOverlay', function(plotting, focusPointService, d3Service, $window) {
+SIREPO.app.directive('interactiveOverlay', function(plotting, focusPointService, d3Service, keypressService, $window) {
     return {
         restrict: 'A',
         scope: {
+            reportId: '<',
             focusPoints: '=',
             hideFocusPoints: '&',
             plotInfoDelegates: '=',
@@ -1139,6 +1140,9 @@ SIREPO.app.directive('interactiveOverlay', function(plotting, focusPointService,
         template: [
         ].join(''),
         controller: function($scope, $element) {
+
+            // random id for this listener
+            var listenerId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 
             var d3self;
             var keyListener;
@@ -1173,6 +1177,9 @@ SIREPO.app.directive('interactiveOverlay', function(plotting, focusPointService,
                 }
                 return self.geometries[fpIndex];
             };
+            self.removeKeyListener = function () {
+                keypressService.removeListener(listenerId);
+            };
 
             function init() {
 
@@ -1184,18 +1191,6 @@ SIREPO.app.directive('interactiveOverlay', function(plotting, focusPointService,
 
                 d3self = d3.selectAll($element);
                 d3self
-                    .on('mouseover', function() {
-                        if (! keyListener) {
-                            keyListener = true;
-                            d3.select('body').on('keydown', function() {
-                                onKeyDown();
-                            });
-                        }
-                    })
-                    .on('mouseout', function() {
-                        d3.select('body').on('keydown', null);
-                        keyListener = false;
-                    })
                     .on('mousedown', function() {
                          if($scope.focusPoints) {
                              for(var fpIndex = 0; fpIndex < $scope.focusPoints.length; ++fpIndex) {
@@ -1212,6 +1207,9 @@ SIREPO.app.directive('interactiveOverlay', function(plotting, focusPointService,
                         // This is to hide the info across all "sibling" plots that this overlay does not know about
                         // Must be defined in the parent directive (plot2d, etc.)
                         $scope.hideFocusPoints();
+
+                        // start listening on clicks instead of mouseover
+                        keypressService.addListener(listenerId, onKeyDown, $scope.reportId);
 
                         if($scope.focusPoints) {
                             for(var fpIndex = 0; fpIndex < $scope.focusPoints.length; ++fpIndex) {
@@ -1238,32 +1236,42 @@ SIREPO.app.directive('interactiveOverlay', function(plotting, focusPointService,
             }
 
             function onKeyDown() {
+
+                var keyCode = d3.event.keyCode;
+                var shiftFactor = d3.event.shiftKey ? 10 : 1;
+
+                // do some focusPoint-independent work outside the loop
+                if (keyCode == 27) { // escape
+                    self.removeKeyListener();
+                }
+                if(keyCode == 9) {  // tab
+                    keypressService.enableNextListener(d3.event.shiftKey ? -1 : 1);
+                    d3.event.preventDefault();
+                }
                 for(var fpIndex = 0; fpIndex < $scope.focusPoints.length; ++fpIndex) {
                     if (!$scope.focusPoints[fpIndex].data.isActive) {
                         return;
                     }
-                    var keyCode = d3.event.keyCode;
-                    var shiftFactor = d3.event.shiftKey ? 10 : 1;
                     var doUpdate = false;
                     var fp = $scope.focusPoints[fpIndex];
                     var geometry = self.geometries[fpIndex];
                     geometry.isMainFocus = false;
                     if (keyCode == 27) { // escape
-                        $scope.focusPoints[fpIndex].unset();
+                        fp.unset();
                         focusPointService.invokeDelegatesForFocusPoint($scope.plotInfoDelegates, fp, 'hideFocusPointInfo');
                     }
                     if (keyCode == 37 || keyCode == 40) { // left & down
-                        $scope.focusPoints[fpIndex].move(-1 * shiftFactor);
+                        fp.move(-1 * shiftFactor);
                         doUpdate = true;
                         d3.event.preventDefault();
                     }
                     if (keyCode == 39 || keyCode == 38) { // right & up
-                        $scope.focusPoints[fpIndex].move(1 * shiftFactor);
+                        fp.move(1 * shiftFactor);
                         doUpdate = true;
                         d3.event.preventDefault();
                     }
                     if (doUpdate) {
-                        if (focusPointService.updateFocusData($scope.focusPoints[fpIndex])) {
+                        if (focusPointService.updateFocusData(fp)) {
                             focusPointService.invokeDelegatesForFocusPoint($scope.plotInfoDelegates, fp, 'moveFocusPointInfo');
                         }
                         else {
@@ -1283,6 +1291,9 @@ SIREPO.app.directive('interactiveOverlay', function(plotting, focusPointService,
             }
 
             function copyToClipboard() {
+                if(! $scope.focusPoints) {
+                    return;
+                }
                 var focusHint = select('.focus-hint');
                 var focusText = select('.focus-text');
                 focusText.style('display', 'none');
@@ -1317,6 +1328,10 @@ SIREPO.app.directive('interactiveOverlay', function(plotting, focusPointService,
             // not all delegates may be added at init - listen for them being added
             $scope.$on('delegate.added', function (event, delegate) {
                 delegate.interface = self;
+            });
+
+            $scope.$on('$destroy', function (event) {
+                keypressService.removeReport($scope.reportId);
             });
         },
     };
@@ -1439,7 +1454,7 @@ SIREPO.app.directive('popupReport', function(plotting, d3Service, focusPointServ
             var moveEventDetected = false;
             var didDragToNewPositon = false;
 
-            if( $scope.plotInfoDelegate) {
+            if($scope.plotInfoDelegate) {
                 $scope.plotInfoDelegate.showFocusPointInfo = showPopup;
                 $scope.plotInfoDelegate.hideFocusPointInfo = hidePopup;
                 $scope.plotInfoDelegate.moveFocusPointInfo = movePopup;
@@ -1599,6 +1614,7 @@ SIREPO.app.directive('popupReport', function(plotting, d3Service, focusPointServ
             }
 
             function closePopup() {
+                $scope.plotInfoDelegate.interface.removeKeyListener();
                 didDragToNewPositon = false;
                 hidePopup();
             }
@@ -1630,6 +1646,7 @@ SIREPO.app.directive('plot2d', function(plotting, utilities, focusPointService, 
     return {
         restrict: 'A',
         scope: {
+            reportId: '<',
             modelName: '@',
         },
         templateUrl: '/static/html/plot2d.html' + SIREPO.SOURCE_CACHE_KEY,
@@ -1798,15 +1815,15 @@ SIREPO.app.directive('plot2d', function(plotting, utilities, focusPointService, 
     };
 });
 
-SIREPO.app.directive('plot3d', function(appState, plotting, utilities, focusPointService, layoutService) {
+SIREPO.app.directive('plot3d', function(appState, plotting, utilities, focusPointService, layoutService, keypressService) {
     return {
         restrict: 'A',
         scope: {
+            reportId: '<',
             modelName: '@',
         },
         templateUrl: '/static/html/plot3d.html' + SIREPO.SOURCE_CACHE_KEY,
         controller: function($scope) {
-
             var MIN_PIXEL_RESOLUTION = 10;
             $scope.margin = {
                 top: 50,
@@ -2253,6 +2270,7 @@ SIREPO.app.directive('plot3d', function(appState, plotting, utilities, focusPoin
             };
 
             $scope.hideFocusPoints = function() {
+                keypressService.removeListenersForReport($scope.reportId);
                 $scope.focusPointX.unset();
                 $scope.focusPointY.unset();
                 var dIndex = 0;
@@ -2466,6 +2484,7 @@ SIREPO.app.directive('parameterPlot', function(plotting, utilities, layoutServic
     return {
         restrict: 'A',
         scope: {
+            reportId: '<',
             modelName: '@',
         },
         templateUrl: '/static/html/plot2d.html' + SIREPO.SOURCE_CACHE_KEY,

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -1427,7 +1427,7 @@ SIREPO.app.directive('popupReport', function(plotting, d3Service, focusPointServ
                 '<g data-is-svg="true" data-ng-drag="true" data-ng-drag-data="focusPoints" data-ng-drag-success="dragDone($data, $event)">',
                     '<g>',
                         '<rect class="report-window" rx="4px" ry="4px" data-ng-attr-width="{{ popupWindowSize().width }}" data-ng-attr-height="{{ popupWindowSize().height }}" x="0" y="0"></rect>',
-                        '<g>',
+                        '<g ng-drag-handle>',
                             '<rect class="report-window-title-bar" data-ng-attr-width="{{ popupTitleSize().width }}" data-ng-attr-height="{{ popupTitleSize().height }}" x="1" y="1"></rect>',
                             '<text class="report-window-close close" data-ng-attr-x="{{ popupWindowSize().width }}" y="0" dy="1em" dx="-1em">&#215;</text>',
                         '</g>',

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -39,7 +39,9 @@ SIREPO.appLocalRoutes = {
 };
 
 SIREPO.appDefaultSimulationValues = {
-    simulation: {},
+    simulation: {
+        folder: '/'
+    },
     simFolder: {},
 };
 
@@ -274,7 +276,7 @@ SIREPO.app.factory('appState', function(errorService, requestSender, requestQueu
         return self.clone(val);
     };
 
-    self.copySimulation = function(simulationId, op, name) {
+    self.copySimulation = function(simulationId, op, name, folder) {
         requestSender.sendRequest(
             'copySimulation',
             op,
@@ -282,6 +284,7 @@ SIREPO.app.factory('appState', function(errorService, requestSender, requestQueu
                 simulationId: simulationId,
                 simulationType: SIREPO.APP_SCHEMA.simulationType,
                 name: name,
+                folder: folder || '/',
             });
     };
 
@@ -1926,6 +1929,44 @@ SIREPO.app.factory('fileManager', function(requestSender) {
         return compoundPathToPath(decodeURIComponent(path));
     };
 
+    self.pathName = function(folder) {
+        if (folder == self.rootFolder()) {
+            return '/';
+        }
+        var path = '/' + folder.name;
+        while (folder.parent != self.rootFolder()) {
+            folder = folder.parent;
+            path = '/' + folder.name + path;
+        }
+        return path;
+    };
+    self.getFolderWithPath = function(pathName) {
+        if(pathName === '/') {
+            return self.rootFolder();
+        }
+        var pathArr = pathName.split('/').filter(function (value) {
+            return value !== "";
+        });
+        var folder = self.rootFolder();
+        for(var pIndex = 0; pIndex < pathArr.length; ++pIndex) {
+            var child = null;
+            for(var cIndex = 0; cIndex < folder.children.length; ++cIndex) {
+                child = folder.children[cIndex];
+                if(child.isFolder && child.name === pathArr[pIndex]) {
+                    break;
+                }
+            }
+            if(child == null) {
+                return null;
+            }
+            if(pIndex == pathArr.length - 1) {
+                return child;
+            }
+            folder = child;
+        }
+        return null;
+    };
+
     self.rootFolder = function() {
         return self.fileTree[0];
     };
@@ -1978,6 +2019,23 @@ SIREPO.app.factory('fileManager', function(requestSender) {
             return item.isExample;
         }
         return self.isFolderExample(item);
+    };
+    self.getUserFolders = function(excludeFolder) {
+        return self.flattenTree().filter(function(item) {
+            return item != excludeFolder && item.isFolder && ! self.isFolderExample(item);
+        });
+    };
+    self.getUserFolderPaths = function() {
+        return self.getUserFolders().map(function (item) {
+            return self.pathName(item);
+        });
+    };
+    self.defaultCreationFolder = function() {
+        var cf = self.getUserFolderPaths().indexOf(self.getActiveFolderPath()) >= 0 ? self.getActiveFolder() : self.rootFolder();
+        return cf;
+    };
+    self.defaultCreationFolderPath = function() {
+        return self.pathName(self.defaultCreationFolder());
     };
 
     function findSimInTree(simId) {
@@ -2117,6 +2175,20 @@ SIREPO.app.factory('fileManager', function(requestSender) {
             parent.children.splice(parent.children.indexOf(item), 1);
             self.updateFlatTree();
         }
+    };
+    self.doesFolderContainFolder = function(f1, f2) {
+        if(f1 == self.rootFolder() || f1.children.indexOf(f2) >= 0) {
+            return true;
+        }
+        if(f2 == self.rootFolder() || ! f1.children) {
+            return false;
+        }
+        for(var cIndex = 0; cIndex < f1.children.length; ++cIndex) {
+            if(self.doesFolderContainFolder(f1.children[cIndex], f2)) {
+                return true;
+            }
+        }
+        return false;
     };
 
     self.redirectToPath = function(path) {
@@ -2412,6 +2484,7 @@ SIREPO.app.controller('SimulationsController', function (appState, fileManager, 
             count++;
         }
         self.copyName = name + ' ' + count;
+        self.copyFolder = fileManager.defaultCreationFolderPath();
         $('#sr-copy-confirmation').modal('show');
     };
 
@@ -2421,7 +2494,8 @@ SIREPO.app.controller('SimulationsController', function (appState, fileManager, 
             function(data) {
                 self.openItem(data.models.simulation);
             },
-            self.copyName);
+            self.copyName,
+            self.copyFolder);
     };
 
     self.deleteItem = function(item) {
@@ -2458,7 +2532,12 @@ SIREPO.app.controller('SimulationsController', function (appState, fileManager, 
     self.moveItem = function(item) {
         self.selectedItem = item;
         self.targetFolder = item.parent;
-        self.moveFolderList = fileManager.folderList(item);
+        self.moveFolderList =  fileManager.getUserFolders(item);
+        if(item.isFolder) {
+            self.moveFolderList = self.moveFolderList.filter(function (userFolder) {
+                return ! fileManager.doesFolderContainFolder(item, userFolder);
+            });
+        }
         $('#sr-move-confirmation').modal('show');
     };
 
@@ -2498,15 +2577,7 @@ SIREPO.app.controller('SimulationsController', function (appState, fileManager, 
     };
 
     self.pathName = function(folder) {
-        if (self.isRootFolder(folder)) {
-            return '/';
-        }
-        var path = '/' + folder.name;
-        while (folder.parent != rootFolder()) {
-            folder = folder.parent;
-            path = '/' + folder.name + path;
-        }
-        return path;
+        return fileManager.pathName(folder);
     };
 
     self.pythonSource = function(item) {
@@ -2584,7 +2655,6 @@ SIREPO.app.controller('SimulationsController', function (appState, fileManager, 
     $scope.$on('simulation.changed', function() {
         self.isWaitingForSim = true;
         self.newSimName = appState.models.simulation.name;
-        appState.models.simulation.folder = self.pathName(self.activeFolder);
         appState.newSimulation(
             appState.models.simulation,
             function(data) {
@@ -2599,7 +2669,7 @@ SIREPO.app.controller('SimulationsController', function (appState, fileManager, 
         name = name.replace(/[\/]/g, '');
         fileManager.addToTree({
             name: name,
-            parent: self.activeFolder,
+            parent: fileManager.getFolderWithPath(appState.models.simFolder.parent) || self.activeFolder,
             isFolder: true,
             children: [],
         });

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -86,24 +86,27 @@
         "simFolder": {
             "title": "New Folder",
             "advanced": [
-                "name"
+                "name",
+                "parent"
             ]
         },
         "simulation": {
             "title": "Simulation",
             "advanced": [
                 "name",
+                "folder",
                 "notes"
             ]
         }
     },
     "commonModels": {
         "simFolder": {
-            "name": ["Folder Name", "SafePath"]
+            "name": ["Folder Name", "SafePath"],
+            "parent": ["Parent Folder", "UserFolder"]
         },
         "simulation": {
             "name": ["Name", "SimulationName"],
-            "folder": ["Folder", "String"],
+            "folder": ["Folder", "UserFolder"],
             "documentationUrl": ["Documentation URL", "OptionalString", ""],
             "notes": ["Notes", "Text", ""]
         }

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -133,6 +133,7 @@ def api_copySimulation():
     req = _json_input()
     sim_type = req['simulationType']
     name = req['name'] if 'name' in req else None
+    folder = req['folder'] if 'folder' in req else '/'
     data = simulation_db.read_simulation_json(sim_type, sid=req['simulationId'])
     if not name:
         base_name = data['models']['simulation']['name']
@@ -145,6 +146,7 @@ def api_copySimulation():
                 continue
             break
     data['models']['simulation']['name'] = name
+    data['models']['simulation']['folder'] = folder
     data['models']['simulation']['isExample'] = False
     data['models']['simulation']['outOfSessionSimulationId'] = ''
     return _save_new_and_reply(data)


### PR DESCRIPTION
Notes:

#1154: Keyboard manipulation of focus points no longer requires the cursor to be over the plot in question. This comes with other features:
- Multiple plots can be be active, though only one at a time can process input
- The plot currently processing input is highlighted
- Deactivating the the current plot (by mouse or ESC) automatically moves input to the next plot, if any
- Users can TAB between active plots to change which one moves its focus points
- When input fields (for numbers etc.) receive focus they take over receiving the keyboard input if any plots are active.  The plots regain processing after input fields lose focus

#990: Users can no longer create new or move existing simulations or folders inside example folders.  Note that:
- Example folders and simulations in icon view now have a "gear" decoration to suggest their status:

![image](https://user-images.githubusercontent.com/30352290/39655538-64cc57ae-4fb7-11e8-9ff0-faded32f1cfb.png) ![image](https://user-images.githubusercontent.com/30352290/39655624-eb80401c-4fb7-11e8-89c7-041dd89f72bf.png)

- Example simulations cannot be moved
- Example simulations can still be copied, but the copy must live in a user folder (or root)
- Any items a user previously added to an example folder remain in place
- User-created items have a different color to distinguish them from example items
- Creation of both simulations and folders requires specifying a folder to contain them

Other items:
- Users could move folders into their own child folders, causing an infinite loop. That is no longer an option
- Fixed a bug where double-clicking on a particle plot (such as SRW brightness) threw an error
