### PR TITLE
Fullscreen reports (#1148) and watchpoint evaluation order (#1155)

### DIFF
--- a/sirepo/package_data/static/css/sirepo.css
+++ b/sirepo/package_data/static/css/sirepo.css
@@ -705,6 +705,9 @@
     div[data-report-panel] > .panel:-webkit-full-screen .sr-plot text.z-axis-label {
         font-size: 18px;
     }
+    div[data-report-panel] > .panel:-webkit-full-screen .sr-plot .axis text {
+        font-size: 16px;
+    }
 
     div[data-report-panel]:-moz-full-screen > .panel > div[data-panel-heading] > div[data-simple-heading] > .sr-panel-heading {
         font-weight: bold;
@@ -719,6 +722,9 @@
     div[data-report-panel]:-moz-full-screen > .panel .sr-plot text.y-axis-label,
     div[data-report-panel]:-moz-full-screen > .panel .sr-plot text.z-axis-label {
         font-size: 18px;
+    }
+    div[data-report-panel]:-moz-full-screen > .panel .sr-plot .axis text {
+        font-size: 16px;
     }
 
     div[data-report-panel] > .panel:-ms-fullscreen > div[data-panel-heading] > div[data-simple-heading] > .sr-panel-heading {
@@ -735,6 +741,9 @@
     div[data-report-panel] > .panel:-ms-fullscreen .sr-plot text.z-axis-label {
         font-size: 18px;
     }
+    div[data-report-panel] > .panel:-ms-fullscreen .sr-plot .axis text {
+        font-size: 16px;
+    }
 
     div[data-report-panel] > .panel:fullscreen > div[data-panel-heading] > div[data-simple-heading] > .sr-panel-heading {
         font-weight: bold;
@@ -749,6 +758,9 @@
     div[data-report-panel] > .panel:fullscreen .sr-plot text.y-axis-label,
     div[data-report-panel] > .panel:fullscreen .sr-plot text.y-axis-label {
         font-size: 18px;
+    }
+    div[data-report-panel] > .panel:fullscreen .sr-plot .axis text {
+        font-size: 16px;
     }
 
 table td.sr-center {

--- a/sirepo/package_data/static/css/sirepo.css
+++ b/sirepo/package_data/static/css/sirepo.css
@@ -94,7 +94,10 @@
         left: 4.5em;
         top: 2em;
     }
-
+    a.sr-disabled-link {
+        color:#aaa;
+        cursor: not-allowed;
+    }
 
     /* app styles */
     .srw-toolbar-button {
@@ -635,6 +638,118 @@
       }
     }
 
+
+    /* Full-screen styles */
+    div:not([data-report-panel='3d']) > .panel:-webkit-full-screen {
+        width: 75vw;
+    }
+    /* Firefox does its own thing */
+    div:not([data-report-panel='3d']):-moz-full-screen > .panel {
+        width: 75vw;
+        margin: auto;
+    }
+    div:not([data-report-panel='3d']):-moz-full-screen > .panel .has-transclude {
+        height: 90vh;
+        margin: auto;
+    }
+    div:not([data-report-panel='3d']) > .panel:-ms-fullscreen {
+        width: 75vw;
+    }
+    div:not([data-report-panel='3d']) > .panel:fullscreen {
+        width: 75vw;
+    }
+
+
+    /* 3d reports */
+    /* empty class to signify non-empty transclude - used to change layouts for some fullscreen reports */
+    .has-transclude {
+    }
+    div[data-report-panel="3d"] > .panel:-webkit-full-screen, div[data-report-panel="heatmap"] > .panel:-webkit-full-screen {
+        width: 60vw;
+    }
+    div[data-report-panel="3d"] > .panel:-webkit-full-screen .has-transclude {
+        display: flex;
+    }
+    div[data-report-panel="3d"]:-moz-full-screen > .panel, div[data-report-panel="heatmap"]:-moz-full-screen > .panel {
+        width: 60vw;
+        margin: auto;
+    }
+    div[data-report-panel="3d"]:-moz-full-screen > .panel .has-transclude {
+        display: flex;
+    }
+    div[data-report-panel="3d"] > .panel:-ms-fullscreen, div[data-report-panel="heatmap"] > .panel:-ms-fullscreen  {
+        height: 60vh;
+    }
+    div[data-report-panel="3d"] > .panel:-ms-fullscreen .has-transclude  {
+        display: flex;
+    }
+    div[data-report-panel="3d"] > .panel:fullscreen, div[data-report-panel="heatmap"] > .panel:fullscreen  {
+        height: 60vh;
+    }
+    div[data-report-panel="3d"] > .panel:fullscreen .has-transclude {
+        display: flex;
+    }
+
+    /* all reports */
+    div[data-report-panel] > .panel:-webkit-full-screen > div[data-panel-heading] > div[data-simple-heading] > .sr-panel-heading {
+        font-weight: bold;
+    }
+    div[data-report-panel] > .panel:-webkit-full-screen .sr-plot .main-title {
+        font-size: 24px;
+    }
+    div[data-report-panel] > .panel:-webkit-full-screen .sr-plot .sub-title {
+        font-size: 18px;
+    }
+    div[data-report-panel] > .panel:-webkit-full-screen .sr-plot text.x-axis-label,
+    div[data-report-panel] > .panel:-webkit-full-screen .sr-plot text.y-axis-label,
+    div[data-report-panel] > .panel:-webkit-full-screen .sr-plot text.z-axis-label {
+        font-size: 18px;
+    }
+
+    div[data-report-panel]:-moz-full-screen > .panel > div[data-panel-heading] > div[data-simple-heading] > .sr-panel-heading {
+        font-weight: bold;
+    }
+    div[data-report-panel]:-moz-full-screen > .panel .sr-plot .main-title {
+        font-size: 24px;
+    }
+    div[data-report-panel]:-moz-full-screen > .panel .sr-plot .sub-title {
+        font-size: 18px;
+    }
+    div[data-report-panel]:-moz-full-screen > .panel .sr-plot text.x-axis-label,
+    div[data-report-panel]:-moz-full-screen > .panel .sr-plot text.y-axis-label,
+    div[data-report-panel]:-moz-full-screen > .panel .sr-plot text.z-axis-label {
+        font-size: 18px;
+    }
+
+    div[data-report-panel] > .panel:-ms-fullscreen > div[data-panel-heading] > div[data-simple-heading] > .sr-panel-heading {
+        font-weight: bold;
+    }
+    div[data-report-panel] > .panel:-ms-fullscreen .sr-plot .main-title {
+        font-size: 24px;
+    }
+    div[data-report-panel] > .panel:-ms-fullscreen .sr-plot .sub-title {
+        font-size: 18px;
+    }
+    div[data-report-panel] > .panel:-ms-fullscreen .sr-plot text.x-axis-label,
+    div[data-report-panel] > .panel:-ms-fullscreen .sr-plot text.y-axis-label,
+    div[data-report-panel] > .panel:-ms-fullscreen .sr-plot text.z-axis-label {
+        font-size: 18px;
+    }
+
+    div[data-report-panel] > .panel:fullscreen > div[data-panel-heading] > div[data-simple-heading] > .sr-panel-heading {
+        font-weight: bold;
+    }
+    div[data-report-panel] > .panel:fullscreen .sr-plot .main-title {
+        font-size: 24px;
+    }
+    div[data-report-panel] > .panel:fullscreen .sr-plot .sub-title {
+        font-size: 18px;
+    }
+    div[data-report-panel] > .panel:fullscreen .sr-plot text.x-axis-label,
+    div[data-report-panel] > .panel:fullscreen .sr-plot text.y-axis-label,
+    div[data-report-panel] > .panel:fullscreen .sr-plot text.y-axis-label {
+        font-size: 18px;
+    }
 
 table td.sr-center {
   text-align: center;

--- a/sirepo/package_data/static/js/ext/canvg.js
+++ b/sirepo/package_data/static/js/ext/canvg.js
@@ -83,26 +83,52 @@
 	}
 
 	// see https://developer.mozilla.org/en-US/docs/Web/API/Element.matches
+	// 2018-05-15 MVK - added try/catch to ignore tricky css
 	var matchesSelector;
 	if (typeof(Element.prototype.matches) != 'undefined') {
 		matchesSelector = function(node, selector) {
-			return node.matches(selector);
+			try {
+				return node.matches(selector);
+            }
+            catch (e) {
+				return false;
+            }
 		};
 	} else if (typeof(Element.prototype.webkitMatchesSelector) != 'undefined') {
 		matchesSelector = function(node, selector) {
-			return node.webkitMatchesSelector(selector);
+			try {
+                return node.webkitMatchesSelector(selector);
+            }
+            catch (e) {
+				return false;
+            }
 		};
 	} else if (typeof(Element.prototype.mozMatchesSelector) != 'undefined') {
 		matchesSelector = function(node, selector) {
-			return node.mozMatchesSelector(selector);
+			try {
+                return node.mozMatchesSelector(selector);
+            }
+            catch (e) {
+				return false;
+            }
 		};
 	} else if (typeof(Element.prototype.msMatchesSelector) != 'undefined') {
 		matchesSelector = function(node, selector) {
-			return node.msMatchesSelector(selector);
+			try {
+                return node.msMatchesSelector(selector);
+            }
+            catch (e) {
+				return false;
+            }
 		};
 	} else if (typeof(Element.prototype.oMatchesSelector) != 'undefined') {
 		matchesSelector = function(node, selector) {
-			return node.oMatchesSelector(selector);
+			try {
+                return node.oMatchesSelector(selector);
+            }
+            catch (e) {
+				return false;
+            }
 		};
 	} else {
 		// requires Sizzle: https://github.com/jquery/sizzle/wiki/Sizzle-Documentation

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -2540,6 +2540,14 @@ SIREPO.app.service('utilities', function($window, $interval) {
         return $window.innerWidth > 767;
     };
 
+    // font utilities
+    this.fontSizeFromString = function(fsString) {
+        if(! fsString) {
+            return 0;
+        }
+        return parseFloat(fsString.substring(0, fsString.indexOf('px')));
+    }
+
     // fullscreen utilities
     this.getFullScreenElement = function() {
         return document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement || document.msFullscreenElement;

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -921,12 +921,12 @@ SIREPO.app.service('focusPointService', function(plotting) {
 
 });
 
-SIREPO.app.service('layoutService', function(plotting) {
+SIREPO.app.service('layoutService', function(plotting, utilities) {
 
     var svc = this;
 
+    this.tickFontSize = 12;
     this.plotAxis = function(margin, dimension, orientation, refresh, utilities) {
-        var FONT_SIZE = 12;
         var MAX_TICKS = 10;
         var ZERO_REGEX = /^\-?0(\.0+)?(e\+0)?$/;
         // global value, don't allow margin updates during zoom/pad handling
@@ -979,7 +979,7 @@ SIREPO.app.service('layoutService', function(plotting) {
             };
         }
 
-        function calcTickCount(format, canvasSize, unit, base) {
+        function calcTickCount(format, canvasSize, unit, base, fontSize) {
             var d = self.scale.domain();
             var width = Math.max(
                 4,
@@ -987,18 +987,18 @@ SIREPO.app.service('layoutService', function(plotting) {
             );
             var tickCount;
             if (dimension == 'x') {
-                tickCount = Math.min(MAX_TICKS, Math.round(canvasSize.width / (width * FONT_SIZE)));
+                tickCount = Math.min(MAX_TICKS, Math.round(canvasSize.width / (width * fontSize)));
             }
             else {
-                tickCount = Math.min(MAX_TICKS, Math.round(canvasSize.height / (5 * FONT_SIZE)));
+                tickCount = Math.min(MAX_TICKS, Math.round(canvasSize.height / (5 * fontSize)));
             }
             return Math.max(2, tickCount);
         }
 
         //TODO(pjm): this could be refactored, moving the base recalc out
-        function calcTicks(formatInfo, canvasSize, unit) {
+        function calcTicks(formatInfo, canvasSize, unit, fontSize) {
             var d = self.scale.domain();
-            var tickCount = calcTickCount(formatInfo.format, canvasSize, unit);
+            var tickCount = calcTickCount(formatInfo.format, canvasSize, unit, null, fontSize);
             formatInfo = calcFormat(tickCount, unit);
             if (formatInfo.decimals > 2) {
                 var baseFormat = calcFormat(tickCount, unit, null, true).format;
@@ -1007,7 +1007,7 @@ SIREPO.app.service('layoutService', function(plotting) {
                     unit = d3.formatPrefix(Math.max(Math.abs(d[0] - base), Math.abs(d[1] - base)), 0);
                 }
                 formatInfo = calcFormat(tickCount, unit, base);
-                tickCount = calcTickCount(formatInfo.format, canvasSize, unit, base);
+                tickCount = calcTickCount(formatInfo.format, canvasSize, unit, base, fontSize);
                 var f2 = calcFormat(tickCount, unit);
                 base = midPoint(f2, d);
                 if (unit) {
@@ -1019,7 +1019,7 @@ SIREPO.app.service('layoutService', function(plotting) {
             }
             if ((orientation == 'left' || orientation == 'right')) {
                 var w = Math.max(formatInfo.format(applyUnit(d[0] - (formatInfo.base || 0), unit)).length, formatInfo.format(applyUnit(d[1] - (formatInfo.base || 0), unit)).length);
-                margin[orientation] = (w + 6) * (FONT_SIZE / 2);
+                margin[orientation] = (w + 6) * (fontSize / 2);
             }
             self.svgAxis.ticks(tickCount);
             self.tickCount = tickCount;
@@ -1101,17 +1101,20 @@ SIREPO.app.service('layoutService', function(plotting) {
 
         self.updateLabelAndTicks = function(canvasSize, select, cssPrefix) {
             if (svc.plotAxis.allowUpdates) {
+                // update the axis to get the tick font size from the css
+                select((cssPrefix || '') + '.' + dimension + '.axis').call(self.svgAxis);
+                var fontSize = utilities.fontSizeFromString(select('.sr-plot .axis text').style('font-size')) || svc.tickFontSize;
                 var formatInfo, unit;
                 if (self.units) {
                     var d = self.scale.domain();
                     unit = d3.formatPrefix(Math.max(Math.abs(d[0]), Math.abs(d[1])), 0);
-                    formatInfo = calcTicks(calcFormat(MAX_TICKS, unit), canvasSize, unit);
+                    formatInfo = calcTicks(calcFormat(MAX_TICKS, unit), canvasSize, unit, fontSize);
                     select('.' + dimension + '-axis-label').text(
                         self.label + (formatInfo.base ? (' - ' + baseLabel()) : '')
                         + ' [' + formatInfo.unit.symbol + self.units + ']');
                 }
                 else {
-                    formatInfo = calcTicks(calcFormat(MAX_TICKS), canvasSize);
+                    formatInfo = calcTicks(calcFormat(MAX_TICKS), canvasSize, null, fontSize);
                     if (self.label) {
                         select('.' + dimension + '-axis-label').text(
                             self.label + (formatInfo.base ? (' - ' + baseLabel()) : ''));
@@ -1139,6 +1142,7 @@ SIREPO.app.service('layoutService', function(plotting) {
             }
             select((cssPrefix || '') + '.' + dimension + '.axis').call(self.svgAxis);
         };
+
         return self;
     };
 
@@ -1597,7 +1601,7 @@ SIREPO.app.directive('popupReport', function(plotting, d3Service, focusPointServ
                 var tbw = parseFloat(rptWindow.attr('width'));
                 var tbh = parseFloat(rptWindow.attr('height'));
                 var bw = rptWindow.style('stroke-width');
-                var borderWidth = parseFloat(bw.substring(0, bw.indexOf('px')));
+                var borderWidth = utilities.fontSizeFromString(bw);
 
                 newX = Math.min(reportWidth - tbw - popupMargin, newX);
                 newY = Math.min(reportHeight - tbh - popupMargin, newY);
@@ -2201,7 +2205,7 @@ SIREPO.app.directive('plot3d', function(appState, plotting, utilities, focusPoin
                 var focusText = select('.focus-text');
                 var fs = focusText.style('font-size');
 
-                var currentFontSize = parseFloat(fs.substring(0, fs.indexOf('px')));
+                var currentFontSize = utilities.fontSizeFromString(fs);
                 var newFontSize = currentFontSize;
 
                 var textWidth = focusText.node().getComputedTextLength();
@@ -2862,7 +2866,7 @@ SIREPO.app.directive('parameterPlot', function(plotting, utilities, layoutServic
 });
 
 //TODO(pjm): consolidate plot code with plotting service
-SIREPO.app.directive('particle', function(plotting) {
+SIREPO.app.directive('particle', function(plotting, layoutService, utilities) {
     return {
         restrict: 'A',
         scope: {
@@ -2904,6 +2908,17 @@ SIREPO.app.directive('particle', function(plotting) {
                 select('.y.axis').call(yAxis);
                 select('.y.axis.grid').call(yAxisGrid);
                 select('.plot-viewport').selectAll('.line').attr('d', graphLine);
+
+                // do the margin adjustment that other plots do inside layoutService.plotAxis
+                var fontSize = utilities.fontSizeFromString(select('.sr-plot .axis text').style('font-size')) || layoutService.tickFontSize;
+                var w = select('.y.axis').selectAll('text')[0]
+                    .map(function (txt) {
+                    return txt.textContent.length;
+                })
+                    .reduce(function(currentMax, next) {
+                        return next > currentMax ? next : currentMax;
+                    }, 0);
+                $scope.margin.left = Math.max(75, (w + 6) * (fontSize / 2));
             }
 
             function resetZoom() {

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1587,6 +1587,7 @@ SIREPO.app.factory('simulationQueue', function($rootScope, $interval, requestSen
 SIREPO.app.factory('requestQueue', function($rootScope, requestSender) {
     var self = {};
     var queueMap = {};
+    self.currentQI = null;
 
     function getQueue(name) {
         if (! queueMap[name] ) {
@@ -1601,12 +1602,14 @@ SIREPO.app.factory('requestQueue', function($rootScope, requestSender) {
             return;
         }
         var qi = q[0];
+        self.currentQI = qi;
         if ( qi.requestSent ) {
             return;
         }
         qi.requestSent = true;
         qi.params = qi.paramsCallback();
         var process = function(ok, resp, status) {
+            self.currentQI = null;
             if (qi.canceled) {
                 sendNextItem(name);
                 return;
@@ -1630,6 +1633,7 @@ SIREPO.app.factory('requestQueue', function($rootScope, requestSender) {
         var q = getQueue(queueName);
         q.forEach(function(qi) {qi.canceled = true;});
         q.length = 0;
+        self.currentQI = null;
     };
 
     self.addItem = function(queueName, paramsCallback) {
@@ -1639,6 +1643,9 @@ SIREPO.app.factory('requestQueue', function($rootScope, requestSender) {
         });
         sendNextItem(queueName);
     };
+    self.getCurrentQI = function(queueName) {
+        return self.currentQI;
+    }
     return self;
 });
 


### PR DESCRIPTION
Notes:

#1148: Users can make reports fullscreen with a button in the panel header using the built-in javascript API.  The 3rd-party canvg.js file required some modification since it freaks out on a lot of the CSS required to handle multiple browsers.  Other items of interest:

- The fullscreen button is disabled when the report is collapsed
- Reports cannot be edited or collapsed when in fullscreen, but animations and simulations can be run
- Popup reports are not scaled yet

#1155: Two parts to this one:

- First, when a new watchpoint was created, it was evaluated as soon as it initialized. However, the simulation is also saved at the same moment, after which each WP gets evaluated.  When the new WP runs depends on the timing of the save, making it essentially random. We now avoid evaluation if currently saving, via examination of the request queue, with the knowledge that the WP will get its turn after the save is complete
- Second is a fun feature of the AngularJS ng-repeat directive. It is designed not to re-evaluate repeated items if they do not change; however, the priority of each WP - which determines the run order - lives on the scope.  When WPs are added, deleted, or rearranged, the priority for existing WPs does not change, since they don't get re-evaluated. That leads to duplicated or mis-applied priorities and unexpected run order.  Priorities are now managed and dynamically assigned so there should never be gaps or duplicates