### PR TITLE
SRW crystal properties (#1201), fullscreen tweaks (#1148)

### DIFF
--- a/sirepo/package_data/static/css/sirepo.css
+++ b/sirepo/package_data/static/css/sirepo.css
@@ -681,6 +681,20 @@
         width: 75vw;
     }
 
+    div[data-report-panel='lattice'] > .panel:-webkit-full-screen {
+        height: 90vh;
+    }
+    div[data-report-panel='lattice']:-moz-full-screen > .panel {
+        height: 90vh;
+        margin: auto;
+    }
+    div[data-report-panel='lattice'] > .panel:-ms-fullscreen {
+        height: 90vh;
+    }
+    div[data-report-panel='lattice'] > .panel:fullscreen {
+        height: 90vh;
+    }
+
 
     /* 3d reports */
     /* empty class to signify non-empty transclude - used to change layouts for some fullscreen reports */

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -1436,7 +1436,7 @@ SIREPO.app.directive('panelHeading', function(appState, frameCache, panelState, 
         ].join(''),
         controller: function($scope, $element) {
             //TODO(pjm): enable when full screen doesn't cut off reports
-            $scope.fullScreenEnabled = false;
+            $scope.fullScreenEnabled = true;
             $scope.panelState = panelState;
             $scope.utilities = utilities;
 

--- a/sirepo/package_data/static/js/sirepo-lattice.js
+++ b/sirepo/package_data/static/js/sirepo-lattice.js
@@ -733,7 +733,7 @@ SIREPO.app.directive('elementPicker', function(latticeService) {
     };
 });
 
-SIREPO.app.directive('lattice', function(appState, latticeService, panelState, plotting, rpnService, $window) {
+SIREPO.app.directive('lattice', function(appState, latticeService, panelState, plotting, rpnService, utilities, $window) {
     return {
         restrict: 'A',
         scope: {
@@ -1190,8 +1190,9 @@ SIREPO.app.directive('lattice', function(appState, latticeService, panelState, p
                 $scope.width = width;
                 $scope.height = $scope.width;
                 var windowHeight = $($window).height();
-                if ($scope.height > windowHeight / 2.5) {
-                    $scope.height = windowHeight / 2.5;
+                var maxHeightFactor = utilities.isFullscreen() ? 1.5 : 2.5;
+                if ($scope.height > windowHeight / maxHeightFactor) {
+                        $scope.height = windowHeight / maxHeightFactor;
                 }
 
                 if (svgBounds) {

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -1727,6 +1727,11 @@ SIREPO.app.directive('plot2d', function(plotting, utilities, focusPointService, 
             $scope.plotInfoDelegates.push($scope.popupDelegate);
             $scope.plotInfoDelegates.push($scope.focusCircleDelegate);
 
+            function fullscreenChangehandler(evt) {
+                refresh();
+            }
+            document.addEventListener(utilities.fullscreenListenerEvent(), fullscreenChangehandler);
+
             var graphLine, points, zoom;
             var axes = {
                 x: layoutService.plotAxis($scope.margin, 'x', 'bottom', refresh, utilities),
@@ -1872,6 +1877,10 @@ SIREPO.app.directive('plot2d', function(plotting, utilities, focusPointService, 
                 }
             };
 
+            $scope.$on('$destroy', function() {
+                document.removeEventListener(utilities.fullscreenListenerEvent(), fullscreenChangehandler);
+            });
+
         },
         link: function link(scope, element) {
             plotting.linkPlot(scope, element);
@@ -1920,6 +1929,10 @@ SIREPO.app.directive('plot3d', function(appState, plotting, utilities, focusPoin
             $scope.plotInfoDelegatesBottom.push($scope.focusCircleDelegateBottom);
             $scope.plotInfoDelegatesRight.push($scope.focusCircleDelegateRight);
 
+            function fullscreenChangehandler(evt) {
+                refresh();
+            }
+            document.addEventListener(utilities.fullscreenListenerEvent(), fullscreenChangehandler);
 
             var canvas, ctx, fullDomain, heatmap, lineOuts, prevDomain, xyZoom;
             var cacheCanvas, imageData;
@@ -2356,6 +2369,11 @@ SIREPO.app.directive('plot3d', function(appState, plotting, utilities, focusPoin
                     [xHeading + ' [' + $scope.xunits +']', select('.z-axis-label').text()],
                     points);
             });
+
+            $scope.$on('$destroy', function() {
+                document.removeEventListener(utilities.fullscreenListenerEvent(), fullscreenChangehandler);
+            });
+
         },
         link: function link(scope, element) {
             plotting.linkPlot(scope, element);
@@ -2378,6 +2396,11 @@ SIREPO.app.directive('heatmap', function(appState, plotting, utilities, layoutSe
             };
             $scope.dataCleared = true;
             $scope.margin = {top: 40, left: 70, right: 100, bottom: 50};
+
+            function fullscreenChangehandler(evt) {
+                refresh();
+            }
+            document.addEventListener(utilities.fullscreenListenerEvent(), fullscreenChangehandler);
 
             var aspectRatio = 1.0;
             var canvas, ctx, heatmap, mouseMovePoint, pointer, zoom;
@@ -2539,6 +2562,11 @@ SIREPO.app.directive('heatmap', function(appState, plotting, utilities, layoutSe
                 }
                 refresh();
             };
+
+            $scope.$on('$destroy', function() {
+                document.removeEventListener(utilities.fullscreenListenerEvent(), fullscreenChangehandler);
+            });
+
         },
         link: function link(scope, element) {
             plotting.linkPlot(scope, element);
@@ -2575,6 +2603,11 @@ SIREPO.app.directive('parameterPlot', function(plotting, utilities, layoutServic
                 $scope.modelName + '-popup-delegate'
             );
             $scope.plotInfoDelegates = [$scope.popupDelegate];
+
+            function fullscreenChangehandler(evt) {
+                refresh();
+            }
+            document.addEventListener(utilities.fullscreenListenerEvent(), fullscreenChangehandler);
 
             var graphLine, zoom;
             var axes = {
@@ -2851,6 +2884,10 @@ SIREPO.app.directive('parameterPlot', function(plotting, utilities, layoutServic
                 return isVisible ? '\ue105' : '\ue106';
             }
 
+            $scope.$on('$destroy', function() {
+                document.removeEventListener(utilities.fullscreenListenerEvent(), fullscreenChangehandler);
+            });
+
         },
         link: function link(scope, element) {
             plotting.linkPlot(scope, element);
@@ -2871,6 +2908,12 @@ SIREPO.app.directive('particle', function(plotting, layoutService, utilities) {
             $scope.margin = {top: 50, right: 23, bottom: 50, left: 75};
             $scope.width = $scope.height = 0;
             $scope.dataCleared = true;
+
+            function fullscreenChangehandler(evt) {
+                refresh();
+            }
+            document.addEventListener(utilities.fullscreenListenerEvent(), fullscreenChangehandler);
+
             var graphLine, xAxis, xAxisGrid, xAxisScale, xDomain, yAxis, yAxisGrid, yAxisScale, yDomain, zoom;
 
             function refresh() {
@@ -3008,8 +3051,10 @@ SIREPO.app.directive('particle', function(plotting, layoutService, utilities) {
                 }
                 $scope.width = width;
                 $scope.height = ASPECT_RATIO * $scope.width;
+                // Some browsers omit the last vertical grid line in fullscreen, so add a bit of width to
+                // cover it.  Other browsers don't seem to mind the extra space
                 select('svg')
-                    .attr('width', $scope.width + $scope.margin.left + $scope.margin.right)
+                    .attr('width', $scope.width + $scope.margin.left + $scope.margin.right + 4)
                     .attr('height', $scope.height + $scope.margin.top + $scope.margin.bottom);
                 plotting.ticks(xAxis, $scope.width, true);
                 plotting.ticks(xAxisGrid, $scope.width, true);
@@ -3021,6 +3066,11 @@ SIREPO.app.directive('particle', function(plotting, layoutService, utilities) {
                 yAxisGrid.tickSize(-$scope.width);
                 refresh();
             };
+
+            $scope.$on('$destroy', function() {
+                document.removeEventListener(utilities.fullscreenListenerEvent(), fullscreenChangehandler);
+            });
+
         },
         link: function link(scope, element) {
             plotting.linkPlot(scope, element);

--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -848,9 +848,11 @@
             "title": "Crystal",
             "basic": [],
             "advanced": [
-                ["Geometry", [
+                ["Main", [
                     "title",
-                    "position",
+                    "position"
+                ]],
+                ["Material", [
                     [
                         ["Material of the crystal", [
                             "material"
@@ -860,25 +862,15 @@
                             "k",
                             "l"
                         ]]
-                    ],
+                    ]
+                ]],
+                ["Geometry", [
                     "energy",
                     "grazingAngle",
                     "asymmetryAngle",
                     "rotationAngle",
                     "crystalThickness",
                     "dSpacing",
-                    [
-                        ["Real part of crystal polarizability", [
-                            "psi0r",
-                            "psiHr",
-                            "psiHBr"
-                        ]],
-                        ["Imaginary part of crystal polarizability", [
-                            "psi0i",
-                            "psiHi",
-                            "psiHBi"
-                        ]]
-                    ],
                     [
                         ["Outward normal vector", [
                             "nvx",
@@ -888,6 +880,20 @@
                         ["Central tangential vector", [
                             "tvx",
                             "tvy"
+                        ]]
+                    ]
+                ]],
+                ["Polarizability", [
+                    [
+                        ["Real part", [
+                            "psi0r",
+                            "psiHr",
+                            "psiHBr"
+                        ]],
+                        ["Imaginary part", [
+                            "psi0i",
+                            "psiHi",
+                            "psiHBi"
                         ]]
                     ]
                 ]],


### PR DESCRIPTION
Notes:

#1148: To address plots not fully displayed in fullscreen, added call to ``refresh()`` in listeners;  needed an additional soupçon of margin to get Safari to work.  Also improved fullscreen for the elegant beamline/lattice

#1201: Split the Geometry tab into Main, Material, Geometry, and Polarizability, based on what seems to belong together, with the idea that we can hone it based on user feedback