### PR TITLE
More dynamic (and now static) loading of files (#1299) plus #1330

### DIFF
--- a/sirepo/package_data/static/html/index.html
+++ b/sirepo/package_data/static/html/index.html
@@ -7,11 +7,9 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <link rel="icon" href="/static/img/favicon.ico{{ source_cache_key }}">
     <title data-ng-bind="nav.pageTitle()">Radiasoft</title>
-    <link href="/static/css/ext/bootstrap-3.3.7.min.css{{ source_cache_key }}" rel="stylesheet">
-    <link href="/static/css/ext/bootstrap-colxl.css{{ source_cache_key }}" rel="stylesheet">
-    <link href="/static/css/ext/bootstrap-toggle.min.css{{ source_cache_key }}" rel="stylesheet">
-    <link href="/static/css/ext/cookieconsent.min.css{{ source_cache_key }}" rel="stylesheet">
-    <link href="/static/css/sirepo.css{{ source_cache_key }}" rel="stylesheet">
+    {% for c in static_css_files %}
+      <link href="{{c}}{{ source_cache_key }}" rel="stylesheet"></script>
+    {% endfor %}
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="/static/js/ext/msie/html5shiv-3.7.2.min.js{{ source_cache_key }}"></script>
@@ -73,36 +71,8 @@
     <div data-ng-view></div>
     <div data-app-footer="nav"></div>
     <div data-msie-font-disabled-detector=""></div>
-    <script src="/static/js/ext/msie/innersvg.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/fontdetect-0.3.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/ie10-viewport-bug-workaround.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/angular.min.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/angular-route.min.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/angular-cookies.min.js{{ source_cache_key }}"></script>
-    <!-- jquery needs to be included after angularjs or draggable won't work on IOS -->
-    <script src="/static/js/ext/jquery-2.2.4.min.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/bootstrap-3.3.7.min.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/ngDraggable.js{{ source_cache_key }}"></script>
-    <!--<script src="/static/js/ext/angular-d3.js{{ source_cache_key }}"></script>-->
-    <!--<script src="/static/js/ext/angular-vtk.js{{ source_cache_key }}"></script>-->
-    <script src="/static/js/ext/colorbar.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/Blob.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/canvas-toBlob.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/FileSaver.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/rgbcolor.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/StackBlur.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/canvg.js{{ source_cache_key }}"></script>
-    <!--<script src="/static/js/ext/dom-to-image.min.js{{ source_cache_key }}"></script>-->
-    <script src="/static/js/ext/stacktrace-0.6.4.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/split-1.3.5.min.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/bootstrap-toggle.min.js{{ source_cache_key }}"></script>
-    <script src="/static/js/ext/cookieconsent.min.js{{ source_cache_key }}"></script>
-    <script src="/static/js/sirepo.js{{ source_cache_key }}"></script>
-    <script src="/static/js/sirepo-components.js{{ source_cache_key }}"></script>
-    <script src="/static/js/sirepo-plotting.js{{ source_cache_key }}"></script>
-    <!--<script src="/static/js/sirepo-beamline.js{{ source_cache_key }}"></script>-->
-    <!--<script src="/static/js/sirepo-lattice.js{{ source_cache_key }}"></script>-->
-    <script src="/static/js/{{ app_name }}.js{{ source_cache_key }}"></script>
-    <script src="/static/js/sirepo-common.js{{ source_cache_key }}"></script>
+    {% for m in static_js_files %}
+      <script src="{{m}}{{ source_cache_key }}"></script>
+    {% endfor %}
   </body>
 </html>

--- a/sirepo/package_data/static/js/rs4pi.js
+++ b/sirepo/package_data/static/js/rs4pi.js
@@ -640,7 +640,7 @@ SIREPO.app.directive('dicomHistogram', function(appState, plotting, rs4piService
                 }
                 var dx = (extent[1] - extent[0]) / (extent[2] - 1);
                 xScale.domain([extent[0], extent[1]]);
-                bins = plotting.linspace(extent[0], extent[1], extent[2]).map(function(d) {
+                bins = plotting.linearlySpacedArray(extent[0], extent[1], extent[2]).map(function(d) {
                     return {
                         x: d,
                         dx: dx,
@@ -1377,7 +1377,7 @@ SIREPO.app.directive('dicomPlot', function(activeSection, appState, frameCache, 
                     if (doseDomain && doseFeature) {
                         var colorMap = plotting.colorMapFromModel($scope.modelName);
                         var colorScale = d3.scale.linear()
-                            .domain(plotting.linspace(0, appState.models.dicomDose.max * 0.6, colorMap.length))
+                            .domain(plotting.linearlySpacedArray(0, appState.models.dicomDose.max * 0.6, colorMap.length))
                             .range(colorMap)
                             .clamp(true);
                         doseFeature.setColorScale(colorScale, appState.models[$scope.modelName].doseTransparency);
@@ -1518,8 +1518,8 @@ SIREPO.app.directive('dicomPlot', function(activeSection, appState, frameCache, 
                 }
                 var preserveZoom = xValues ? true : false;
                 dicomDomain = appState.clone(json.domain);
-                xValues = plotting.linspace(dicomDomain[0][0], dicomDomain[1][0], json.shape[1]);
-                yValues = plotting.linspace(dicomDomain[0][1], dicomDomain[1][1], json.shape[0]);
+                xValues = plotting.linearlySpacedArray(dicomDomain[0][0], dicomDomain[1][0], json.shape[1]);
+                yValues = plotting.linearlySpacedArray(dicomDomain[0][1], dicomDomain[1][1], json.shape[0]);
                 if (! preserveZoom) {
                     xAxisScale.domain(getRange(xValues));
                     yAxisScale.domain(getRange(yValues));

--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -1,0 +1,658 @@
+'use strict';
+
+var srlog = SIREPO.srlog;
+var srdbg = SIREPO.srdbg;
+SIREPO.DEFAULT_COLOR_MAP = 'viridis';
+
+SIREPO.app.factory('vtkPlotting', function(appState, plotting, panelState, utilities, plotUtilities, $window) {
+
+    var self = {};
+
+    function identityTransform(lpoint) {
+        return lpoint;
+    }
+
+    function testTansformInverse(xform, invXform, lpoint) {
+        var lpoint2 = invXform(xform(lpoint));
+        if(lpoint2[0] != lpoint[0] || lpoint2[1] != lpoint[1] || lpoint2[2] != lpoint[2]) {
+            throw 'transform(inverse) != identity:' + lpoint + '->' + lpoint2;
+        }
+    }
+
+    // Find where the "scene" (bounds of the rendered objects) intersects the screen (viewport)
+    // Returns the properties of the first set of corners that fit - order them by desired location.
+    // Could be none fit, in which case no properties are defined
+    function edgeIntersections(vpEdges, cornersArr, bounds, dim, reverse) {
+        var props = {};
+        //srdbg('checking for edges that include corners', cornersArr);
+        for(var corners in cornersArr) {
+            var edges = plotUtilities.edgesWithCorners(vpEdges, cornersArr[corners])[0];
+            //srdbg('edges that include corners', cornersArr[corners], edges);
+            var sceneEnds = plotUtilities.sortInDimension(edges, dim);
+            //srdbg('scene ends', sceneEnds);
+            var screenEnds = plotUtilities.boundsIntersections(bounds, sceneEnds[0], sceneEnds[1]);
+            //srdbg('screen ends', screenEnds);
+            var sceneLen = plotUtilities.dist(sceneEnds[0], sceneEnds[1]);
+            var clippedEnds = plotUtilities.sortInDimension(
+                plotUtilities.edgesInsideBounds(screenEnds, bounds),
+                dim, reverse);
+            if(clippedEnds && clippedEnds.length == 2) {
+             var clippedLen = plotUtilities.dist(clippedEnds[0], clippedEnds[1]);
+                if(clippedLen / sceneLen > 0.5) {
+                    props.edges = edges;
+                    props.sceneEnds = sceneEnds;
+                    props.screenEnds = screenEnds;
+                    props.sceneLen = sceneLen;
+                    props.clippedEnds = clippedEnds;
+                    return props;
+                }
+            }
+        }
+        return props;
+    }
+
+    self.vtkPlot = function(scope, element) {
+
+        scope.element = element[0];
+        var requestData = plotting.initAnimation(scope);
+
+        scope.windowResize = utilities.debounce(function() {
+            scope.resize();
+        }, 250);
+
+        scope.$on('$destroy', function() {
+            scope.destroy();
+            scope.element = null;
+            $($window).off('resize', scope.windowResize);
+        });
+
+        scope.$on(
+            scope.modelName + '.changed',
+            function() {
+                scope.prevFrameIndex = -1;
+                if (scope.modelChanged) {
+                    scope.modelChanged();
+                }
+                panelState.clear(scope.modelName);
+                requestData();
+            });
+        scope.isLoading = function() {
+            return panelState.isLoading(scope.modelName);
+        };
+        $($window).resize(scope.windowResize);
+
+        scope.init();
+        if (appState.isLoaded()) {
+            requestData();
+        }
+    };
+
+    self.coordMapper = function(transform) {
+
+        return {
+
+            xform: transform || identityTransform,
+
+            // These functions take an optional transformation to go from "lab"
+            // coordinates to vtk screen coordinates and return the appropriate vtkActor
+            setPlane: function(planeSource, lo, lp1, lp2) {
+                var vo = this.xform(lo);
+                var vp1 = this.xform(lp1);
+                var vp2 = this.xform(lp2);
+                planeSource.setOrigin(vo[0], vo[1], vo[2]);
+                planeSource.setPoint1(vp1[0], vp1[1], vp1[2]);
+                planeSource.setPoint2(vp2[0], vp2[1], vp2[2]);
+            },
+            buildBox: function(lsize, lcenter) {
+                var vsize = this.xform(lsize);
+                var vcenter = this.xform(lcenter);
+                return vtk.Filters.Sources.vtkCubeSource.newInstance({
+                    xLength: vsize[0],
+                    yLength: vsize[1],
+                    zLength: vsize[2],
+                    center: vcenter
+                });
+            },
+            buildLine: function(lp1, lp2, colorArray) {
+                var vp1 = this.xform(lp1);
+                var vp2 = this.xform(lp2);
+                var ls = vtk.Filters.Sources.vtkLineSource.newInstance({
+                    point1: [vp1[0], vp1[1], vp1[2]],
+                    point2: [vp2[0], vp2[1], vp2[2]],
+                    resolution: 2
+                });
+
+                var lm = vtk.Rendering.Core.vtkMapper.newInstance();
+                lm.setInputConnection(ls.getOutputPort());
+
+                var la = vtk.Rendering.Core.vtkActor.newInstance();
+                la.getProperty().setColor(colorArray[0], colorArray[1], colorArray[2]);
+                la.setMapper(lm);
+                return la;
+            },
+            buildSphere: function(lcenter, radius, colorArray, transform) {
+                var vcenter = this.xform(lcenter);
+                var ps = vtk.Filters.Sources.vtkSphereSource.newInstance({
+                    center: vcenter,
+                    radius: radius,
+                    thetaResolution: 16,
+                    phiResolution: 16
+                });
+
+                var pm = vtk.Rendering.Core.vtkMapper.newInstance();
+                pm.setInputConnection(ps.getOutputPort());
+
+                var pa = vtk.Rendering.Core.vtkActor.newInstance();
+                pa.getProperty().setColor(colorArray[0], colorArray[1], colorArray[2]);
+                pa.getProperty().setLighting(false);
+                pa.setMapper(pm);
+                return pa;
+            },
+        };
+    };
+
+    self.orientations = {
+        horizontal: 'h',
+        vertical: 'v'
+    };
+
+    // "Superclass" for representation of vtk source objects in viewport coordinates
+    self.vpObject = function(vtkSource, renderer) {
+
+        var vpObj = {};
+
+        var worldCoord = vtk.Rendering.Core.vtkCoordinate.newInstance({
+            renderer: renderer
+        });
+        worldCoord.setCoordinateSystemToWorld();
+
+        vpObj.source = vtkSource;
+        vpObj.wCoord = worldCoord;
+
+        // Override in subclass.  getEdges() should return a mapping
+        // of names to pairs of points
+        vpObj.getEdges = function() {
+            return {};
+        };
+        vpObj.getEdge = function(name) {
+            return vpObj.getEdges()[name];
+        };
+
+        // Attaches a plotAxis to any of the named edges (an edge being a pair of points) -- when updated the axis will
+        // shift and rotate along that edge.  The orientation indicates where for example
+        // a z-axis starts (h[orizontal] or v[ertical]) before it is rotated into position.  This is
+        // used for sorting and angle calculation.
+        // edgeSelector is what determines which edge to use when updating
+        //vpObj.bindAxis = function(axis, orientation, edgeNames, edgeSelector) {
+        vpObj.bindAxis = function(axis, orientation, edgeNames, dynamicCorners) {
+            function validateEdge(name) {
+                if(! vpObj.getEdge(name)) {
+                    throw 'No such edge ' + name;
+                }
+            }
+            for(var nIndex = 0; nIndex < edgeNames.length; ++nIndex) {
+                validateEdge(edgeNames[nIndex]);
+            }
+
+            var boundAxis = {};
+            boundAxis.axis = axis;
+            boundAxis.edges = edgeNames;
+            boundAxis.orientation = orientation;
+            boundAxis.minVal = axis.values[0];
+            boundAxis.maxVal = axis.values[axis.values.length - 1];
+
+            boundAxis.getEdge = function(name) {
+                return vpObj.getEdge(name);
+            };
+            boundAxis.update = function(bounds, dynamicCorners, edgeSelector) {
+                self.updateAxis(this, bounds, dynamicCorners, edgeSelector);
+            };
+            //boundAxis.update = function(bounds, edgeSelector) {
+            //    self.updateAxis(this, bounds, edgeSelector);
+            //};
+
+            return boundAxis;
+        };
+
+        return vpObj;
+    };
+
+    // Takes a vtk cube source and renderer and returns a box in viewport coordinates with a bunch of useful
+    // geometric properties and methods
+    //
+    self.vpBox = function(vtkCubeSource, renderer) {
+
+        var box = self.vpObject(vtkCubeSource, renderer);
+
+        // It's easiest to keep world coordinates in arrays rather than objects, since
+        // we're mapping them a good deal and we will not refer to them directly
+        function wCenter() {
+            return box.source.getCenter();
+        }
+
+        function wCorners() {
+            var c = wCenter();
+            var corners = [];
+            for(var zSide in [-0.5, 0.5]) {
+                for (var ySide in [-0.5, 0.5]) {
+                    for (var xSide in [-0.5, 0.5]) {
+                        corners.push([
+                            [
+                                c[0] + xSide * box.source.getXLength(),
+                                c[1] + ySide * box.source.getYLength(),
+                                c[2] + zSide * box.source.getZLength()
+                            ]
+                        ]);
+                    }
+                }
+            }
+            return corners;
+            /*
+            return [
+                [c[0] - 0.5 * box.source.getXLength(), c[1] - 0.5 * box.source.getYLength(), c[2] + 0.5 * box.source.getZLength()],  //leftBottomOut 0 -> 4
+                [c[0] - 0.5 * box.source.getXLength(), c[1] + 0.5 * box.source.getYLength(), c[2] + 0.5 * box.source.getZLength()],  //leftTopOut 1 -> 6
+                [c[0] + 0.5 * box.source.getXLength(), c[1] + 0.5 * box.source.getYLength(), c[2] + 0.5 * box.source.getZLength()],  //rightTopOut 2 -> 7
+                [c[0] + 0.5 * box.source.getXLength(), c[1] - 0.5 * box.source.getYLength(), c[2] + 0.5 * box.source.getZLength()],  //rightBottomOut 3 -> 5
+                [c[0] - 0.5 * box.source.getXLength(), c[1] - 0.5 * box.source.getYLength(), c[2] - 0.5 * box.source.getZLength()],  //leftBottomIn 4 -> 0
+                [c[0] - 0.5 * box.source.getXLength(), c[1] + 0.5 * box.source.getYLength(), c[2] - 0.5 * box.source.getZLength()],  //leftTopIn 5 -> 2
+                [c[0] + 0.5 * box.source.getXLength(), c[1] + 0.5 * box.source.getYLength(), c[2] - 0.5 * box.source.getZLength()],  //rightTopIn 6 -> 3
+                [c[0] + 0.5 * box.source.getXLength(), c[1] - 0.5 * box.source.getYLength(), c[2] - 0.5 * box.source.getZLength()]   //rightBottomIn 7 -> 1
+            ];
+            */
+        }
+        function vpCorners() {
+            return wCorners().map(function (p) {
+                return self.localCoordFromWorld(box.wCoord, p);
+            });
+        }
+        function wCenterLines() {
+            var c = wCenter();
+            var cls = [];
+            for(var dim = 0; dim < 3; ++dim) {
+                for(var side in [-0.5, 0.5]) {
+                    cls.push(
+                        [
+                            c[0] + (dim == 0 ? side : 0) * box.source.getXLength(),
+                            c[1] + (dim == 1 ? side : 0) * box.source.getYLength(),
+                            c[2] + (dim == 2 ? side : 0) * box.source.getZLength()
+                        ]
+                    );
+                }
+            }
+            return cls;
+            /*
+            return [
+                [c[0] - 0.5 * box.source.getXLength(), c[1], c[2]],
+                [c[0] + 0.5 * box.source.getXLength(), c[1], c[2]],
+                [c[0], c[1] - 0.5 * box.source.getYLength(), c[2]],
+                [c[0], c[1] + 0.5 * box.source.getYLength(), c[2]],
+                [c[0], c[1], c[2] - 0.5 * box.source.getZLength()],
+                [c[0], c[1], c[2] + 0.5 * box.source.getZLength()]
+            ];
+            */
+        }
+        function vpCenterLines() {
+            return wCenterLines().map(function (p) {
+                return self.localCoordFromWorld(box.wCoord, p);
+            });
+        }
+
+        // These member functions use descriptive names for the geometry,
+        // to simplify usage
+
+        // A list of the keys used by getCorners(), for convenience in specifying edge names
+        box.corners = {
+                leftBottomOut: 'leftBottomOut',
+                leftTopOut: 'leftTopOut',
+                rightTopOut: 'rightTopOut',
+                rightBottomOut: 'rightBottomOut',
+                leftBottomIn: 'leftBottomIn',
+                leftTopIn: 'leftTopIn',
+                rightTopIn: 'rightTopIn',
+                rightBottomIn: 'rightBottomIn'
+        };
+        box.getCorners = function() {
+            var cArr = vpCorners();
+            var c = {};
+            c[box.corners.leftBottomOut] = cArr[0];
+            c[box.corners.leftTopOut] = cArr[1];
+            c[box.corners.rightTopOut] = cArr[2];
+            c[box.corners.rightBottomOut] = cArr[3];
+            c[box.corners.leftBottomIn] = cArr[4];
+            c[box.corners.leftTopIn] = cArr[5];
+            c[box.corners.rightTopIn] = cArr[6];
+            c[box.corners.rightBottomIn] = cArr[7];
+            return c;
+            /*
+            return {
+                leftBottomOut: cArr[0],
+                leftTopOut: cArr[1],
+                rightTopOut: cArr[2],
+                rightBottomOut: cArr[3],
+                leftBottomIn: cArr[4],
+                leftTopIn: cArr[5],
+                rightTopIn: cArr[6],
+                rightBottomIn: cArr[7]
+            };
+            */
+        };
+        box.extrema = {
+                lowestCorners: 'lowestCorners',
+                leftmostCorners: 'leftmostCorners',
+                highestCorners: 'highestCorners',
+                rightmostCorners: 'rightmostCorners'
+        };
+        box.getExtrema = function() {
+            var corners = vpCorners();
+            /*
+            var e = {};
+            e[box.extrema.lowestCorners] =  plotUtilities.extrema(corners, 1, true);
+            e[box.extrema.leftmostCorners] =  plotUtilities.extrema(corners, 0, false);
+            e[box.extrema.highestCorners] =  plotUtilities.extrema(corners, 1, false);
+            e[box.extrema.rightmostCorners] =  plotUtilities.extrema(corners, 0, true);
+            return e;
+            */
+
+            return {
+                //lowestCorners: self.pointArrToObj(plotUtilities.extrema(corners, 1, true)),
+                //leftmostCorners: self.pointArrToObj(plotUtilities.extrema(corners, 0, false)),
+                //highestCorners: self.pointArrToObj(plotUtilities.extrema(corners, 1, false)),
+                //rightmostCorners: self.pointArrToObj(plotUtilities.extrema(corners, 0, true))
+                lowestCorners: plotUtilities.extrema(corners, 1, true),
+                leftmostCorners: plotUtilities.extrema(corners, 0, false),
+                highestCorners: plotUtilities.extrema(corners, 1, false),
+                rightmostCorners: plotUtilities.extrema(corners, 0, true)
+            };
+
+        };
+
+        // A list of the keys used by getEdges(), for convenience in specifying edge names
+        box.edges = {
+                bottomOut: 'bottomOut',
+                bottomIn: 'bottomIn',
+                topOut: 'topOut',
+                topIn: 'topIn',
+                leftBottom: 'leftBottom',
+                rightBottom: 'rightBottom',
+                leftTop: 'leftTop',
+                rightTop: 'rightTop',
+                leftOut: 'leftOut',
+                leftIn: 'leftIn',
+                rightOut: 'rightOut',
+                rightIn: 'rightIn'
+        };
+        box.getEdges = function() {
+            var corners = box.getCorners();
+            var e = {};
+            e[box.edges.bottomOut] = [corners.leftBottomOut, corners.rightBottomOut];
+            e[box.edges.bottomIn] = [corners.leftBottomIn, corners.rightBottomIn];
+            e[box.edges.topOut] = [corners.leftTopOut, corners.rightTopOut];
+            e[box.edges.topIn] = [corners.leftTopIn, corners.rightTopIn];
+            e[box.edges.leftBottom] = [corners.leftBottomOut, corners.leftBottomIn];
+            e[box.edges.rightBottom] = [corners.rightBottomOut, corners.rightBottomIn];
+            e[box.edges.leftTop] = [corners.leftTopOut, corners.leftTopIn];
+            e[box.edges.rightTop] = [corners.rightTopOut, corners.rightTopIn];
+            e[box.edges.leftOut] = [corners.leftBottomOut, corners.leftTopOut];
+            e[box.edges.leftIn] = [corners.leftBottomIn, corners.leftTopIn];
+            e[box.edges.rightOut] = [corners.rightBottomOut, corners.rightTopOut];
+            e[box.edges.rightIn] = [corners.rightBottomIn, corners.rightTopIn];
+            return e;
+        };
+
+        return box;
+    };
+
+    // Attaches a plotAxis to any of the edges of the given viewport object -- when updated the axis will
+    // shift and rotate along that edge.  The direction indicates where for example
+    // a z-axis starts (h[orizontal] or v[ertical]) before it is rotated into position.  This is
+    // used for sorting and angle calculation
+    self.bindAxis = function(axis, vpObj, edgeNames, orientation) {
+        function validateEdge(name) {
+            if(! vpObj.getEdge(name)) {
+                throw 'No such edge ' + name;
+            }
+        }
+        for(var nIndex = 0; nIndex < edgeNames.length; ++nIndex) {
+            validateEdge(edgeNames[nIndex]);
+        }
+
+        var boundAxis = {};
+        boundAxis.axis = axis;
+        boundAxis.obj = vpObj;
+        boundAxis.edges = edgeNames;
+        boundAxis.orientation = orientation;
+        boundAxis.minVal = axis.values[0];
+        boundAxis.maxVal = axis.values[axis.values.length - 1];
+
+        // invoke these to get "live" values of the edges
+        boundAxis.getEdge = function(name) {
+            return vpObj.getEdge(name);
+        };
+        boundAxis.getEdges = function() {
+            return boundAxis.edges.map(function (name) {
+                return boundAxis.getEdge(name);
+            });
+        };
+
+        return boundAxis;
+    };
+
+    // Updates the axis position within the given bounds.  The
+    // dynamic corners are those, in order of preference, that currently
+    // determine which edge (provided above) is selected
+    //self.updateAxis  = function(boundAxis, bounds, dynamicCorners, edgeSelector, selectorData) {
+    //self.updateAxis  = function(boundAxis, bounds, edgeSelector, selectorData) {
+    self.updateAxis  = function(boundAxis, edgeSelector, edgeSorter) {
+
+        var projLen = 0;
+        var axisGeom = {};
+        var isReversed = false;
+        var sceneEnds = [[0, 0], [0, 0]];
+        var screenEnds = sceneEnds;
+        var clippedEnds = sceneEnds;
+        var sceneLen = 0;
+        var showAxisEnds = false;
+
+        // this needs to be done just-in-time so that the values of the points
+        // are current
+        var boundEdges = boundAxis.getEdges();
+
+        // If any of the bound edges now has the original left (top) point now right of (below)
+        // the original right (bottom) point, the image is reversed on the screen
+        if(boundAxis.orientation == self.orientations.horizontal) {
+            isReversed = boundEdges[0][0][0] >  boundEdges[0][0][1];
+        }
+        if(boundAxis.orientation == self.orientations.vertical) {
+            isReversed = boundEdges[0][0][1] < boundEdges[0][1][1];
+        }
+
+        var edgeProps = edgeSelector.select(boundEdges, edgeSorter);
+
+        if(! edgeProps) {
+            return false;
+        }
+
+        // all the edges that we want to bind to are offscreen, so we will show little markers in the
+        // middle to indicate the range of values without clutter
+            /*
+        else {
+            showAxisEnds = true;
+            //sceneEnds = plotUtilities.sortInDimension(vpLeftRight, 0);
+            screenEnds = plotUtilities.boundsIntersections(bounds, sceneEnds[0], sceneEnds[1]);
+            clippedEnds = plotUtilities.sortInDimension(
+                plotUtilities.edgesInsideBounds(screenEnds, bounds),
+                0, false);
+            axisGeom.left = Math.max(sceneEnds[0][0], clippedEnds[0][0]);
+            axisGeom.top = axisGeom.left == sceneEnds[0][0] ? sceneEnds[0][1] : clippedEnds[0][1];
+            axisGeom.right = Math.min(sceneEnds[1][0], clippedEnds[1][0]);
+            axisGeom.bottom = axisGeom.right == sceneEnds[1][0] ? sceneEnds[1][1] : clippedEnds[1][1];
+            projLen = plotUtilities.dist([axisGeom.left, axisGeom.top], [axisGeom.right, axisGeom.bottom]);
+            sceneLen = plotUtilities.dist(sceneEnds[0], sceneEnds[1]);
+            var tanPsi = (sceneEnds[0][1] - sceneEnds[1][1]) / (sceneEnds[0][0] - sceneEnds[1][0]);
+            axisGeom.angle = 180 * Math.atan(tanPsi) / Math.PI;
+        }
+        */
+
+            ///srdbg('selected', edgeProps);
+            axisGeom = axisGeometery(boundAxis, edgeProps);
+        //srdbg('axis', axisGeom);
+
+        // TODO(mvk): plotAxis should handle arbitrary rotated axes instead of doing it here
+        var range = Math.min(axisGeom.length, plotUtilities.dist(edgeProps.sceneEnds[0], edgeProps.sceneEnds[1]));
+
+        // Change the domain if axis ends go offscreen
+
+        var newMin = boundAxis.minVal;
+        var newMax = boundAxis.maxVal;
+        var domainPct = 0.0;
+        var domainPart = 0.0;
+        /*
+        if(! plotUtilities.isPointWithinBounds(edgeProps.sceneEnds[0], bounds)) {
+            //srdbg('projected pct', domainPct);
+            domainPct = plotUtilities.dist(edgeProps.sceneEnds[0], edgeProps.clippedEnds[0]) / edgeProps.sceneLen;
+            domainPart = (boundAxis.maxVal - boundAxis.minVal) * domainPct;
+            if(isReversed) {
+                newMax = boundAxis.maxVal - domainPart;
+            }
+            else {
+                newMin = boundAxis.minVal + domainPart;
+            }
+        }
+        if(! plotUtilities.isPointWithinBounds(edgeProps.sceneEnds[1], bounds)) {
+            domainPct = plotUtilities.dist(edgeProps.sceneEnds[1], edgeProps.clippedEnds[1]) / edgeProps.sceneLen;
+            domainPart = (boundAxis.maxVal - boundAxis.minVal) * domainPct;
+            if(isReversed) {
+                newMin = boundAxis.minVal + domainPart;
+            }
+            else {
+               newMax = boundAxis.maxVal - domainPart;
+            }
+        }
+*/
+        /*
+        axis.scale.domain([newMin, newMax]).nice();
+        axis.scale.range([isXReversed ? xrange : 0, isXReversed ? 0 :xrange]);
+        // we use the axis for calculations but show no ticks if both ends are off-screen
+        if(showXAxisEnds) {
+            axis.svgAxis.ticks(0);
+            select('.x.axis').call(axis.svgAxis);
+        }
+        else {
+            axes.x.updateLabelAndTicks({
+                width: xrange,
+                height: 0
+            }, select);
+        }
+
+        // adjust axis position to account for tick labels
+        var xlabels = d3self.selectAll('.x.axis text');
+        var xxform = 'translate(' +
+            Math.min(xAxisLeft, xAxisRight) + ',' +
+            xAxisTop +') ' +
+            'rotate(' + xAxisAngle + ')';
+        //srdbg('show ends?', showXAxisEnds);
+        select('.x.axis').attr('transform', xxform);
+
+*/
+        return true;
+    };
+
+    function axisGeometery(boundAxis, edgeProps) {
+        var left = 0;  var top = 0;
+        var right = 0;  var bottom = 0;
+        var length = 0;  var angle = 0;
+
+        var tanAngle = (edgeProps.sceneEnds[0][1] - edgeProps.sceneEnds[1][1]) / (edgeProps.sceneEnds[0][0] - edgeProps.sceneEnds[1][0]);
+        if(boundAxis.orientation == self.orientations.horizontal) {
+            if(edgeProps.sceneEnds[0][0] > edgeProps.clippedEnds[0][0]) {
+                left = edgeProps.sceneEnds[0][0];
+                top = edgeProps.sceneEnds[0][1];
+            }
+            else {
+                left = edgeProps.clippedEnds[0][0];
+                top = edgeProps.clippedEnds[0][1];
+            }
+            if(edgeProps.sceneEnds[1][0] < edgeProps.clippedEnds[1][0]) {
+                right = edgeProps.sceneEnds[1][0];
+                bottom = edgeProps.sceneEnds[1][1];
+            }
+            else {
+                right = edgeProps.clippedEnds[1][0];
+                bottom = edgeProps.clippedEnds[1][1];
+            }
+            angle = 180 * Math.atan(tanAngle) / Math.PI;
+        }
+        if(boundAxis.orientation == self.orientations.vertical) {
+            if(edgeProps.sceneEnds[0][1] > edgeProps.clippedEnds[0][1]) {
+                left = edgeProps.sceneEnds[0][0];
+                top = edgeProps.sceneEnds[0][1];
+            }
+            else {
+                left = edgeProps.clippedEnds[0][0];
+                top = edgeProps.clippedEnds[0][1];
+            }
+            if(edgeProps.sceneEnds[1][1] < edgeProps.clippedEnds[1][1]) {
+                right = edgeProps.sceneEnds[1][0];
+                bottom = edgeProps.sceneEnds[1][1];
+            }
+            else {
+                right = edgeProps.clippedEnds[1][0];
+                bottom = edgeProps.clippedEnds[1][1];
+            }
+            angle = 180 * Math.atan(tanAngle) / Math.PI - 90;
+            if(angle < -90 ) {
+                angle += 180;
+            }
+        }
+        length = plotUtilities.dist([left, top], [right, bottom]);
+
+        return {
+            left: left,
+            top: top,
+            right: right,
+            bottom: bottom,
+            length: length,
+            angle: angle,
+
+        };
+    }
+
+
+    self.addActors = function(renderer, actorArr) {
+        for(var aIndex = 0; aIndex < actorArr.length; ++aIndex) {
+            renderer.addActor(actorArr[aIndex]);
+        }
+    };
+    self.removeActors = function(renderer, actorArr) {
+        for(var aIndex = 0; aIndex < actorArr.length; ++aIndex) {
+            renderer.removeActor(actorArr[aIndex]);
+        }
+    };
+    self.showActors = function(renderWindow, actorArray, doShow, visibleOpacity, hiddenOpacity) {
+        for(var aIndex = 0; aIndex < actorArray.length; ++aIndex) {
+            actorArray[aIndex].getProperty().setOpacity(doShow ? visibleOpacity || 1.0 : hiddenOpacity || 0.0);
+        }
+        renderWindow.render();
+    };
+
+    self.localCoordFromWorld = function (coord, point) {
+        // this is required to do conversions for different displays/devices
+        var pixels = window.devicePixelRatio;
+        coord.setCoordinateSystemToWorld();
+        coord.setValue(point);
+        var lCoord = coord.getComputedLocalDisplayValue();
+        return [lCoord[0] / pixels, lCoord[1] / pixels];
+    };
+    self.worldCoordFromLocal = function (coord, point, view) {
+        var pixels = window.devicePixelRatio;
+        var newPoint = [pixels * point[0], pixels * point[1]];
+        // must first convert from "localDisplay" to "display"  - this is the inverse of
+        // what is done by vtk to get from display to localDisplay
+        var newPointView = [newPoint[0], view.getFramebufferSize()[1] - newPoint[1] - 1];
+        coord.setCoordinateSystemToDisplay();
+        coord.setValue(newPointView);
+        return coord.getComputedWorldValue();
+    };
+
+    return self;
+});

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -194,13 +194,16 @@ SIREPO.app.factory('plotting', function(appState, frameCache, panelState, utilit
         return requestData;
     }
 
-    function linspace(start, stop, nsteps) {
+    function linearlySpacedArray(start, stop, nsteps) {
+        if (nsteps < 1) {
+            throw "linearlySpacedArray: steps " + nsteps + " < 1";
+        }
         var delta = (stop - start) / (nsteps - 1);
         var res = d3.range(nsteps).map(function(d) { return start + d * delta; });
         res[res.length - 1] = stop;
 
         if (res.length != nsteps) {
-            throw "invalid linspace steps: " + nsteps + " != " + res.length;
+            throw "linearlySpacedArray: steps " + nsteps + " != " + res.length;
         }
         return res;
     }
@@ -380,7 +383,7 @@ SIREPO.app.factory('plotting', function(appState, frameCache, panelState, utilit
             }
             var colorMap = this.colorMapFromModel(modelName);
             return d3.scale.linear()
-                .domain(linspace(zMin, zMax, colorMap.length))
+                .domain(linearlySpacedArray(zMin, zMax, colorMap.length))
                 .range(colorMap)
                 .clamp(true);
         },
@@ -480,7 +483,7 @@ SIREPO.app.factory('plotting', function(appState, frameCache, panelState, utilit
             }
         },
 
-        linspace: linspace,
+        linearlySpacedArray: linearlySpacedArray,
 
         min2d: function(data) {
             return d3.min(data, function(row) {
@@ -1788,7 +1791,7 @@ SIREPO.app.directive('plot2d', function(plotting, utilities, focusPointService, 
                 $scope.dataCleared = false;
                 var xPoints = json.x_points
                     ? json.x_points
-                    : plotting.linspace(json.x_range[0], json.x_range[1], json.points.length);
+                    : plotting.linearlySpacedArray(json.x_range[0], json.x_range[1], json.points.length);
                 var xdom = [json.x_range[0], json.x_range[1]];
                 if (!(axes.x.domain && axes.x.domain[0] == xdom[0] && axes.x.domain[1] == xdom[1])) {
                     axes.x.domain = xdom;
@@ -2248,8 +2251,8 @@ SIREPO.app.directive('plot3d', function(appState, plotting, utilities, focusPoin
                     || ! appState.deepEquals(fullDomain, newFullDomain)) {
                     fullDomain = newFullDomain;
                     lineOuts = {};
-                    axes.x.values = plotting.linspace(fullDomain[0][0], fullDomain[0][1], json.x_range[2]);
-                    axes.y.values = plotting.linspace(fullDomain[1][0], fullDomain[1][1], json.y_range[2]);
+                    axes.x.values = plotting.linearlySpacedArray(fullDomain[0][0], fullDomain[0][1], json.x_range[2]);
+                    axes.y.values = plotting.linearlySpacedArray(fullDomain[1][0], fullDomain[1][1], json.y_range[2]);
                     axes.x.scale.domain(fullDomain[0]);
                     axes.x.indexScale.domain(fullDomain[0]);
                     axes.y.scale.domain(fullDomain[1]);
@@ -2483,7 +2486,7 @@ SIREPO.app.directive('heatmap', function(appState, plotting, utilities, layoutSe
                 select('.main-title').text(json.title);
                 select('.sub-title').text(json.subtitle);
                 $.each(axes, function(dim, axis) {
-                    axis.values = plotting.linspace(json[dim + '_range'][0], json[dim + '_range'][1], json[dim + '_range'][2]);
+                    axis.values = plotting.linearlySpacedArray(json[dim + '_range'][0], json[dim + '_range'][1], json[dim + '_range'][2]);
                     axis.parseLabelAndUnits(json[dim + '_label']);
                     select('.' + dim + '-axis-label').text(json[dim + '_label']);
                     axis.scale.domain(getRange(axis.values));
@@ -2731,7 +2734,7 @@ SIREPO.app.directive('parameterPlot', function(plotting, utilities, layoutServic
                     json.y_label = plots[0].label;
                 }
                 axes.x.points = json.x_points
-                    || plotting.linspace(json.x_range[0], json.x_range[1], json.x_range[2] || json.points.length);
+                    || plotting.linearlySpacedArray(json.x_range[0], json.x_range[1], json.x_range[2] || json.points.length);
                 var xdom = [json.x_range[0], json.x_range[1]];
                 axes.x.domain = xdom;
                 axes.x.scale.domain(xdom);
@@ -3428,17 +3431,17 @@ SIREPO.app.directive('particle3d', function(appState, panelState, requestSender,
                 var numInterPoints = 50;
 
                 axes.x.init();
-                axes.x.values = plotting.linspace(xmin, xmax, xpoints.length);
+                axes.x.values = plotting.linearlySpacedArray(xmin, xmax, xpoints.length);
                 axes.x.scale.domain([xmin, xmax]);
                 axes.x.parseLabelAndUnits(pointData.x_label);
 
                 axes.y.init();
-                axes.y.values = plotting.linspace(zmin, zmax, zpoints.length);
+                axes.y.values = plotting.linearlySpacedArray(zmin, zmax, zpoints.length);
                 axes.y.scale.domain([zmin, zmax]);
                 axes.y.parseLabelAndUnits(pointData.y_label);
 
                 axes.z.init();
-                axes.z.values = plotting.linspace(ymin, ymax, ypoints.length);
+                axes.z.values = plotting.linearlySpacedArray(ymin, ymax, ypoints.length);
                 axes.z.scale.domain([ymin, ymax]);
                 axes.z.parseLabelAndUnits(pointData.z_label);
 
@@ -3934,7 +3937,7 @@ SIREPO.app.directive('particle3d', function(appState, panelState, requestSender,
 
                 // domain is the value of the data points
                 // range is the position on the screen
-                // TODO (mvk): plotAxis should handle arbitrary rotated axes instead of doing it here
+                // TODO(mvk): plotAxis should handle arbitrary rotated axes instead of doing it here
                 //axes.x.scale.range([0, $scope.vtkCanvasGeometry().size.width - 96]);
                 axes.x.scale.range([0, vpWidth]);
                 //axes.y.scale.range([$scope.vtkCanvasGeometry().size.height - 360, 0]);

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -595,7 +595,7 @@ SIREPO.app.factory('appState', function(errorService, requestSender, requestQueu
     };
 
     self.viewInfo = function(name) {
-        return SIREPO.APP_SCHEMA.view[name] || SIREPO.APP_SCHEMA.commonViews[name];
+        return SIREPO.APP_SCHEMA.view[name] || SIREPO.APP_SCHEMA.common.view[name];
     };
 
     self.watchModelFields = function($scope, modelFields, callback) {

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -26,7 +26,7 @@ angular.element(document).ready(function() {
 
     function loadDynamicModules() {
         return $.map(
-            SIREPO.APP_SCHEMA.dynamicModules || [],
+            (SIREPO.APP_SCHEMA.dynamicModules || []).concat(SIREPO.APP_SCHEMA.dynamicFiles.libURLs || []),
             function(src) {
                 return loadDynamicModule(src);
             });

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -72,7 +72,7 @@ SIREPO.app.factory('warpvndService', function(appState, panelState, plotting) {
     function gridRange(sizeField, countField) {
         var grid = appState.models.simulationGrid;
         var channel = grid[sizeField];
-        return plotting.linspace(-channel / 2, channel / 2, grid[countField] + 1);
+        return plotting.linearlySpacedArray(-channel / 2, channel / 2, grid[countField] + 1);
     }
 
     self.getXRange = function() {
@@ -85,7 +85,7 @@ SIREPO.app.factory('warpvndService', function(appState, panelState, plotting) {
 
     self.getZRange = function() {
         var grid = appState.models.simulationGrid;
-        return plotting.linspace(0, grid.plate_spacing, grid.num_z + 1);
+        return plotting.linearlySpacedArray(0, grid.plate_spacing, grid.num_z + 1);
     };
 
     self.is3D = function() {
@@ -961,9 +961,9 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
 
                 var grid = appState.models.simulationGrid;
                 var channel = toMicron(grid.channel_width);
-                axes.y.grid.tickValues(plotting.linspace(-channel / 2, channel / 2, grid.num_x + 1));
+                axes.y.grid.tickValues(plotting.linearlySpacedArray(-channel / 2, channel / 2, grid.num_x + 1));
                 var depth = toMicron(grid.channel_height);
-                axes.z.grid.tickValues(plotting.linspace(-depth / 2, depth / 2, grid.num_y + 1));
+                axes.z.grid.tickValues(plotting.linearlySpacedArray(-depth / 2, depth / 2, grid.num_y + 1));
                 resetZoom();
                 select('.plot-viewport').call(zoom);
                 select('.z-plot-viewport').call(zoom);
@@ -1459,7 +1459,7 @@ SIREPO.app.directive('impactDensityPlot', function(appState, layoutService, plot
 
                 var colorMap = plotting.colorMapFromModel($scope.modelName);
                 var colorScale = d3.scale.linear()
-                    .domain(plotting.linspace(json.v_min, json.v_max, colorMap.length))
+                    .domain(plotting.linearlySpacedArray(json.v_min, json.v_max, colorMap.length))
                     .range(colorMap);
                 colorbar = Colorbar()
                     .scale(colorScale)
@@ -1474,7 +1474,7 @@ SIREPO.app.directive('impactDensityPlot', function(appState, layoutService, plot
                     if (! lineInfo.density.length) {
                         lineInfo.density = [0];
                     }
-                    var lineSegments = plotting.linspace(p[0], p[1], lineInfo.density.length + 1);
+                    var lineSegments = plotting.linearlySpacedArray(p[0], p[1], lineInfo.density.length + 1);
                     var j;
                     for (j = 0; j < lineSegments.length - 1; j++) {
                         var v;

--- a/sirepo/package_data/static/json/elegant-schema.json
+++ b/sirepo/package_data/static/json/elegant-schema.json
@@ -1,7 +1,17 @@
 {
-    "dynamicModules": [
-        "/static/js/sirepo-lattice.js"
-    ],
+    "dynamicFiles": {
+        "external": {
+            "js": [
+                "split-1.3.5.min.js"
+            ]
+        },
+        "local": {
+            "js": [
+                "elegant.js",
+                "sirepo-lattice.js"
+            ]
+        }
+    },
     "localRoutes": {
         "source": {
           "config": {

--- a/sirepo/package_data/static/json/elegant-schema.json
+++ b/sirepo/package_data/static/json/elegant-schema.json
@@ -1,11 +1,11 @@
 {
     "dynamicFiles": {
-        "external": {
+        "externalLibs": {
             "js": [
                 "split-1.3.5.min.js"
             ]
         },
-        "local": {
+        "sirepoLibs": {
             "js": [
                 "elegant.js",
                 "sirepo-lattice.js"

--- a/sirepo/package_data/static/json/hellweg-schema.json
+++ b/sirepo/package_data/static/json/hellweg-schema.json
@@ -1,4 +1,9 @@
 {
+    "dynamicFiles": {
+        "local": {
+            "js": ["hellweg.js"]
+        }
+    },
     "localRoutes": {
         "source": {
             "config": {

--- a/sirepo/package_data/static/json/hellweg-schema.json
+++ b/sirepo/package_data/static/json/hellweg-schema.json
@@ -1,6 +1,6 @@
 {
     "dynamicFiles": {
-        "local": {
+        "sirepoLibs": {
             "js": ["hellweg.js"]
         }
     },

--- a/sirepo/package_data/static/json/jspec-schema.json
+++ b/sirepo/package_data/static/json/jspec-schema.json
@@ -1,4 +1,9 @@
 {
+    "dynamicFiles": {
+        "local": {
+            "js": ["jspec.js"]
+        }
+    },
     "localRoutes": {
         "source": {
             "config": {

--- a/sirepo/package_data/static/json/jspec-schema.json
+++ b/sirepo/package_data/static/json/jspec-schema.json
@@ -1,6 +1,6 @@
 {
     "dynamicFiles": {
-        "local": {
+        "sirepoLibs": {
             "js": ["jspec.js"]
         }
     },

--- a/sirepo/package_data/static/json/myapp-schema.json
+++ b/sirepo/package_data/static/json/myapp-schema.json
@@ -1,4 +1,9 @@
 {
+    "dynamicFiles": {
+        "local": {
+            "js": ["myapp.js"]
+        }
+    },
     "localRoutes": {
         "source": {
             "config": {

--- a/sirepo/package_data/static/json/myapp-schema.json
+++ b/sirepo/package_data/static/json/myapp-schema.json
@@ -1,6 +1,6 @@
 {
     "dynamicFiles": {
-        "local": {
+        "sirepoLibs": {
             "js": ["myapp.js"]
         }
     },

--- a/sirepo/package_data/static/json/rs4pi-schema.json
+++ b/sirepo/package_data/static/json/rs4pi-schema.json
@@ -1,4 +1,9 @@
 {
+    "dynamicFiles": {
+        "local": {
+            "js": ["rs4pi.js"]
+        }
+    },
     "localRoutes": {
         "source": {
             "config": {

--- a/sirepo/package_data/static/json/rs4pi-schema.json
+++ b/sirepo/package_data/static/json/rs4pi-schema.json
@@ -1,6 +1,6 @@
 {
     "dynamicFiles": {
-        "local": {
+        "sirepoLibs": {
             "js": ["rs4pi.js"]
         }
     },

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -87,7 +87,7 @@
     },
     "common": {
         "staticFiles": {
-            "external": {
+            "externalLibs": {
                 "js": [
                     "angular.min.js",
                     "jquery-2.2.4.min.js",
@@ -100,13 +100,13 @@
                     "cookieconsent.min.css"
                 ]
             },
-            "local": {
+            "sirepoLibs": {
                 "js": ["sirepo.js"],
                 "css": ["sirepo.css"]
             }
         },
         "dynamicFiles": {
-            "external": {
+            "externalLibs": {
                 "js": [
                     "angular-cookies.min.js",
                     "angular-route.min.js",
@@ -126,14 +126,16 @@
                     "ie10-viewport-bug-workaround.js"
                 ]
             },
-            "local": {
+            "sirepoLibs": {
                 "js": [
-                    "/user-state",
                     "sirepo-common.js",
                     "sirepo-components.js",
                     "sirepo-plotting.js"
                 ]
-            }
+            },
+            "libURLs": [
+                "/user-state"
+            ]
         },
         "appModes": {
            "default": {

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -84,111 +84,158 @@
         "updateFolder": "/update-folder",
         "uploadFile": "/upload-file/<simulation_type>/<simulation_id>/<file_type>"
     },
-    "commonDynamicModules": [
-        "/static/js/ext/d3-3.5.9.min.js"
-    ],
-    "commonLocalRoutes": {
-        "simulations": {
-            "route": "/simulations",
-            "config": {
-              "controller": "SimulationsController as simulations",
-              "templateUrl": "/static/html/simulations.html"
+    "common": {
+        "staticFiles": {
+            "external": {
+                "js": [
+                    "angular.min.js",
+                    "jquery-2.2.4.min.js",
+                    "cookieconsent.min.js"
+                ],
+                "css": [
+                    "bootstrap-3.3.7.min.css",
+                    "bootstrap-colxl.css",
+                    "bootstrap-toggle.min.css",
+                    "cookieconsent.min.css"
+                ]
+            },
+            "local": {
+                "js": ["sirepo.js"],
+                "css": ["sirepo.css"]
             }
         },
-        "simulationsFolder": {
-            "route": "/simulations/:folderPath?",
-            "config": {
-              "controller": "SimulationsController as simulations",
-              "templateUrl": "/static/html/simulations.html"
+        "dynamicFiles": {
+            "external": {
+                "js": [
+                    "angular-cookies.min.js",
+                    "angular-route.min.js",
+                    "bootstrap-3.3.7.min.js",
+                    "bootstrap-toggle.min.js",
+                    "ngDraggable.js",
+                    "stacktrace-0.6.4.js",
+                    "colorbar.js",
+                    "rgbcolor.js",
+                    "canvg.js",
+                    "FileSaver.js",
+                    "Blob.js",
+                    "canvas-toBlob.js",
+                    "StackBlur.js",
+                    "d3-3.5.9.min.js",
+                    "fontdetect-0.3.js",
+                    "ie10-viewport-bug-workaround.js"
+                ]
+            },
+            "local": {
+                "js": [
+                    "sirepo-common.js",
+                    "sirepo-components.js",
+                    "sirepo-plotting.js"
+                ]
             }
         },
-        "source": {
-            "route": "/source/:simulationId"
-        },
-        "loggedOut": {
-            "isFinal": true,
-            "doDefer": true,
-            "route": "/logged-out",
-            "config": {
-              "controller": "LoggedOutController as loggedOut",
-              "templateUrl": "/static/html/logged-out.html"
+        "appModes": {
+           "default": {
+                "localRoute": "source",
+                "includeMode": false
             }
         },
-        "forbidden": {
-            "route": "/forbidden",
-            "config": {
-              "templateUrl": "/static/html/forbidden.html"
-            }
-        },
-        "notFound": {
-            "route": "/not-found",
-            "config": {
-              "templateUrl": "/static/html/not-found.html"
-            }
-        },
-        "notFoundCopy": {
-            "route": "/copy-session/:simulationIds/:section",
-            "config": {
-              "controller": "NotFoundCopyController as notFoundCopy",
-              "templateUrl": "/static/html/copy-session.html"
-            }
-        },
-        "fallback": {
-            "isFinal": true,
-            "isRedirect": true,
-            "localRoute": "simulations"
-        }
-    },
-    "commonAppModes": {
-        "default": {
-            "localRoute": "source",
-            "includeMode": false
-        }
-    },
-    "commonViews": {
-        "simDoc": {
-            "model": "simulation",
-            "title": "Simulation Documentation",
-            "advanced": [
-                "documentationUrl"
+        "enum": {
+            "ColorMap": [
+                ["grayscale", "grayscale"],
+                ["viridis", "viridis"],
+                ["afmhot", "afmhot"],
+                ["coolwarm", "coolwarm"],
+                ["jet", "jet"]
             ]
         },
-        "simFolder": {
-            "title": "New Folder",
-            "advanced": [
-                "name",
-                "parent"
-            ]
+        "localRoutes": {
+            "simulations": {
+                "route": "/simulations",
+                "config": {
+                  "controller": "SimulationsController as simulations",
+                  "templateUrl": "/static/html/simulations.html"
+                }
+            },
+            "simulationsFolder": {
+                "route": "/simulations/:folderPath?",
+                "config": {
+                  "controller": "SimulationsController as simulations",
+                  "templateUrl": "/static/html/simulations.html"
+                }
+            },
+            "source": {
+                "route": "/source/:simulationId"
+            },
+            "loggedOut": {
+                "isFinal": true,
+                "doDefer": true,
+                "route": "/logged-out",
+                "config": {
+                  "controller": "LoggedOutController as loggedOut",
+                  "templateUrl": "/static/html/logged-out.html"
+                }
+            },
+            "forbidden": {
+                "route": "/forbidden",
+                "config": {
+                  "templateUrl": "/static/html/forbidden.html"
+                }
+            },
+            "notFound": {
+                "route": "/not-found",
+                "config": {
+                  "templateUrl": "/static/html/not-found.html"
+                }
+            },
+            "notFoundCopy": {
+                "route": "/copy-session/:simulationIds/:section",
+                "config": {
+                  "controller": "NotFoundCopyController as notFoundCopy",
+                  "templateUrl": "/static/html/copy-session.html"
+                }
+            },
+            "fallback": {
+                "isFinal": true,
+                "isRedirect": true,
+                "localRoute": "simulations"
+            }
         },
-        "simulation": {
-            "title": "Simulation",
-            "advanced": [
-                "name",
-                "folder",
-                "notes"
-            ]
-        }
-    },
-    "commonModels": {
-        "simFolder": {
-            "name": ["Folder Name", "SafePath"],
-            "parent": ["Parent Folder", "UserFolder"]
+        "model": {
+            "simFolder": {
+                "name": ["Folder Name", "SafePath"],
+                "parent": ["Parent Folder", "UserFolder"]
+            },
+            "simulation": {
+                "name": ["Name", "SimulationName"],
+                "folder": ["Folder", "UserFolder"],
+                "documentationUrl": ["Documentation URL", "OptionalString", ""],
+                "notes": ["Notes", "Text", ""]
+            }
         },
-        "simulation": {
-            "name": ["Name", "SimulationName"],
-            "folder": ["Folder", "UserFolder"],
-            "documentationUrl": ["Documentation URL", "OptionalString", ""],
-            "notes": ["Notes", "Text", ""]
+        "view": {
+            "simDoc": {
+                "model": "simulation",
+                "title": "Simulation Documentation",
+                "advanced": [
+                    "documentationUrl"
+                ]
+            },
+            "simFolder": {
+                "title": "New Folder",
+                "advanced": [
+                    "name",
+                    "parent"
+                ]
+            },
+            "simulation": {
+                "title": "Simulation",
+                "advanced": [
+                    "name",
+                    "folder",
+                    "notes"
+                ]
+            }
         }
-    },
-    "commonEnums": {
-        "ColorMap": [
-            ["grayscale", "grayscale"],
-            ["viridis", "viridis"],
-            ["afmhot", "afmhot"],
-            ["coolwarm", "coolwarm"],
-            ["jet", "jet"]
-        ]
     },
     "customErrors": {
         "404": {"url": "not-found.html", "msg": "File Not Found"},

--- a/sirepo/package_data/static/json/shadow-schema.json
+++ b/sirepo/package_data/static/json/shadow-schema.json
@@ -1,11 +1,11 @@
 {
     "dynamicFiles": {
-        "external": {
+        "externalLibs": {
             "js": [
                 "dom-to-image.min.js"
             ]
         },
-        "local": {
+        "sirepoLibs": {
             "js": [
                 "shadow.js",
                 "sirepo-beamline.js"

--- a/sirepo/package_data/static/json/shadow-schema.json
+++ b/sirepo/package_data/static/json/shadow-schema.json
@@ -1,8 +1,17 @@
 {
-    "dynamicModules": [
-        "/static/js/sirepo-beamline.js",
-        "/static/js/ext/dom-to-image.min.js"
-    ],
+    "dynamicFiles": {
+        "external": {
+            "js": [
+                "dom-to-image.min.js"
+            ]
+        },
+        "local": {
+            "js": [
+                "shadow.js",
+                "sirepo-beamline.js"
+            ]
+        }
+    },
     "localRoutes": {
         "source": {
             "config": {

--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -1,8 +1,17 @@
 {
-    "dynamicModules": [
-        "/static/js/sirepo-beamline.js",
-        "/static/js/ext/dom-to-image.min.js"
-    ],
+    "dynamicFiles": {
+        "external": {
+            "js": [
+                "dom-to-image.min.js"
+            ]
+        },
+        "local": {
+            "js": [
+                "srw.js",
+                "sirepo-beamline.js"
+            ]
+        }
+    },
     "localRoutes": {
         "source": {
             "config": {

--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -1,11 +1,11 @@
 {
     "dynamicFiles": {
-        "external": {
+        "externalLibs": {
             "js": [
                 "dom-to-image.min.js"
             ]
         },
-        "local": {
+        "sirepoLibs": {
             "js": [
                 "srw.js",
                 "sirepo-beamline.js"

--- a/sirepo/package_data/static/json/synergia-schema.json
+++ b/sirepo/package_data/static/json/synergia-schema.json
@@ -1,11 +1,11 @@
 {
     "dynamicFiles": {
-        "external": {
+        "externalLibs": {
             "js": [
                 "split-1.3.5.min.js"
             ]
         },
-        "local": {
+        "sirepoLibs": {
             "js": [
                 "synergia.js",
                 "sirepo-lattice.js"

--- a/sirepo/package_data/static/json/synergia-schema.json
+++ b/sirepo/package_data/static/json/synergia-schema.json
@@ -1,7 +1,17 @@
 {
-    "dynamicModules": [
-        "/static/js/sirepo-lattice.js"
-    ],
+    "dynamicFiles": {
+        "external": {
+            "js": [
+                "split-1.3.5.min.js"
+            ]
+        },
+        "local": {
+            "js": [
+                "synergia.js",
+                "sirepo-lattice.js"
+            ]
+        }
+    },
     "localRoutes": {
         "source": {
             "config": {

--- a/sirepo/package_data/static/json/warppba-schema.json
+++ b/sirepo/package_data/static/json/warppba-schema.json
@@ -1,4 +1,11 @@
 {
+    "dynamicFiles": {
+        "local": {
+            "js": [
+                "warppba.js"
+            ]
+        }
+    },
     "localRoutes": {
         "source": {
             "config": {

--- a/sirepo/package_data/static/json/warppba-schema.json
+++ b/sirepo/package_data/static/json/warppba-schema.json
@@ -1,6 +1,6 @@
 {
     "dynamicFiles": {
-        "local": {
+        "sirepoLibs": {
             "js": [
                 "warppba.js"
             ]

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -1,11 +1,11 @@
 {
     "dynamicFiles": {
-        "external": {
+        "externalLibs": {
             "js": [
                 "vtk.min.js"
             ]
         },
-        "local": {
+        "sirepoLibs": {
             "js": [
                 "warpvnd.js"
             ]

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -1,7 +1,16 @@
 {
-    "dynamicModules": [
-        "/static/js/ext/vtk.min.js"
-    ],
+    "dynamicFiles": {
+        "external": {
+            "js": [
+                "vtk.min.js"
+            ]
+        },
+        "local": {
+            "js": [
+                "warpvnd.js"
+            ]
+        }
+    },
     "localRoutes": {
         "source": {
             "config": {

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -754,6 +754,8 @@ def _parse_data_input(validate=False):
 def _render_root_page(page, values):
     values.source_cache_key = _source_cache_key()
     values.app_version = simulation_db.app_version()
+    values.static_js_files = simulation_db.static_modules()
+    values.static_css_files = simulation_db.static_css()
     return flask.render_template(
         'html/{}.html'.format(page),
         **values

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -18,10 +18,8 @@ def err(obj, format='', *args, **kwargs):
 def raise_bad_request(*args, **kwargs):
     _raise('BadRequest', *args, **kwargs)
 
-
 def raise_forbidden(*args, **kwargs):
     _raise('Forbidden', *args, **kwargs)
-
 
 def raise_not_found(*args, **kwargs):
     _raise('NotFound', *args, **kwargs)


### PR DESCRIPTION
Notes:

- ```schema-common``` and the app schemae now list out "dynamicFiles" and "staticFiles" that refer only to the file name.  Static files are loaded by ```index.html``` with jinja loops, while dynamic files get loaded by sirepo.  Most ```<script>``` tags have been removed.  Consequently, each app's javascript is now referenced in its schema and dynamically loaded
- Files are grouped into "local" and "external" which map to directories
- Also in ```schema-common```,  things like "commonModels" have been moved under a single "common" section and named the same as in the app schema (so just "model").  The idea is to eventually loop over them to merge
- The schema fetch and validation in ```simulation_db``` use ``` pkcollections.Dict``` and dot syntax
- ```merge_dicts``` now allows unbounded merge depth and a ```merge_style``` keyword that lets values in arrays from the base dict be added to the corresponding arrays in the derived dict (this specifically to let us merge the dynamic file lists)

I have not yet split out the schema stuff into its own file

Also #1330 is in there