### PR TITLE
Fix broken link for JSPEC manual in landing page.

### DIFF
--- a/sirepo/package_data/static/html/landing-page-jspec.html
+++ b/sirepo/package_data/static/html/landing-page-jspec.html
@@ -13,7 +13,7 @@
         <div class="lp-info-panel-docs-header">Documentation</div>
         <ul>
           <li>Full source code is <a href="https://github.com/zhanghe9704/electroncooling">available from GitHub</a>.</li>
-          <li>A detailed <a href="https://github.com/zhanghe9704/electroncooling/blob/master/User%20manual.md" "target="_blank">JSPEC User Manual</a> is provided.</li>
+          <li>A detailed <a href="https://github.com/zhanghe9704/electroncooling/blob/master/JSPEC%20User%20manual.md" "target="_blank">JSPEC User Manual</a> is provided.</li>
         </ul>
       </lp-info-docs>
       <lp-info-pubs>

--- a/sirepo/package_data/static/js/jspec.js
+++ b/sirepo/package_data/static/js/jspec.js
@@ -3,7 +3,7 @@
 var srlog = SIREPO.srlog;
 var srdbg = SIREPO.srdbg;
 
-SIREPO.USER_MANUAL_URL = 'https://github.com/zhanghe9704/electroncooling/blob/master/JSPEC%20User%20Manual.pdf';
+SIREPO.USER_MANUAL_URL = 'https://github.com/zhanghe9704/electroncooling/blob/master/JSPEC%20User%20manual.md';
 SIREPO.PLOTTING_SUMMED_LINEOUTS = true;
 SIREPO.SINGLE_FRAME_ANIMATION = ['beamEvolutionAnimation', 'coolingRatesAnimation'];
 SIREPO.FILE_UPLOAD_TYPE = {


### PR DESCRIPTION
Link changed to https://github.com/zhanghe9704/electroncooling/blob/master/JSPEC%20User%20manual.md suggested by @robnagler 