### PR TITLE
Fete tweaks

### DIFF
--- a/sirepo/package_data/static/html/particle3d.html
+++ b/sirepo/package_data/static/html/particle3d.html
@@ -16,46 +16,38 @@
               </div>
             </div>
             <div class="col-sm-6">
-                <div class="btn btn-default pull-right" data-ng-class="{'btn-primary': side == 'z'}" style="margin: 2px;" data-ng-click="showSide('z')">Z{{ zdir == 1 ? '+' : '-' }}</div>
-                <div class="btn btn-default pull-right" data-ng-class="{'btn-primary': side == 'y'}" style="margin: 2px;" data-ng-click="showSide('y')">Y{{ ydir == 1 ? '+' : '-' }}</div>
-                <div class="btn btn-default pull-right" data-ng-class="{'btn-primary': side == 'x'}" style="margin: 2px;" data-ng-click="showSide('x')">X{{ xdir == 1 ? '+' : '-' }}</div>
-                <div class="btn btn-default pull-right" data-ng-class="{'btn-primary': mode == 'move'}" style="margin: 2px;" data-ng-click="selectMode('move')"><span class="glyphicon glyphicon-hand-up"></span></div>
-                <div class="btn btn-default pull-right" data-ng-class="{'btn-primary': mode == 'select'}" style="margin: 2px;" data-ng-click="selectMode('select')">&#x2B09;</div>
+                <div data-toggle="tooltip" title="View along z axis" class="btn btn-default pull-right" data-ng-class="{'btn-primary': side == 'z'}" style="margin: 2px;" data-ng-click="showSide('z')">Z{{ zdir == 1 ? '+' : '-' }}</div>
+                <div data-toggle="tooltip" title="View along y axis" class="btn btn-default pull-right" data-ng-class="{'btn-primary': side == 'y'}" style="margin: 2px;" data-ng-click="showSide('y')">Y{{ ydir == 1 ? '+' : '-' }}</div>
+                <div data-toggle="tooltip" title="View along x axis" class="btn btn-default pull-right" data-ng-class="{'btn-primary': side == 'x'}" style="margin: 2px;" data-ng-click="showSide('x')">X{{ xdir == 1 ? '+' : '-' }}</div>
+                <div data-toggle="tooltip" title="Manipulate" class="btn btn-default pull-right" data-ng-class="{'btn-primary': mode == 'move'}" style="margin: 2px;" data-ng-click="selectMode('move')"><span class="glyphicon glyphicon-hand-up"></span></div>
+                <div data-toggle="tooltip" title="Select" class="btn btn-default pull-right" data-ng-class="{'btn-primary': mode == 'select'}" style="margin: 2px;" data-ng-click="selectMode('select')">&#x2B09;</div>
             </div>
         </div>
     </div>
     <!-- the canvas holder is the container for the vtk render window -->
-    <div class="vtk-canvas-holder">
+    <div class="vtk-canvas-holder" data-ng-style="interactionStyle()">
     </div>
     <div class="vtk-info-overlay" data-ng-class="{'vtk-info-overlay-move': mode == 'move', 'vtk-info-overlay-select': mode == 'select'}" data-ng-attr-width="{{ vtkCanvasGeometry().size.width }}px" data-ng-attr-height="{{ vtkCanvasGeometry().size.height }}px" data-ng-attr-style="top:{{ vtkCanvasGeometry().pos.top }}px; left:{{ vtkCanvasGeometry().pos.left }}px;">
       <svg data-ng-attr-width="{{ vtkCanvasGeometry().size.width }}" data-ng-attr-height="{{ vtkCanvasGeometry().size.height }}">
 
-       <!-- <g class="x axis" data-ng-attr-transform="translate({{ xAxisLeft }}, {{ labelGeometry().x.pos.top - labelGeometry().x.size.height - 24 }})"></g>
-        -->
         <g class="x axis"></g>
-        <!--<text class="x-axis-label" data-ng-attr-x="{{ vtkCanvasGeometry().size.width / 2 }}" data-ng-attr-y="{{ vtkCanvasGeometry().size.height - labelGeometry.x.size.height - 4}}"></text>-->
         <text class="x-axis-label"></text>
-          <text class="x axis-end low"></text>
-          <text class="x axis-end high"></text>
+        <text class="x axis-end low"></text>
+        <text class="x axis-end high"></text>
 
-        <!--<g class="y axis" data-ng-attr-transform="translate({{ labelGeometry().y.pos.left + labelGeometry().y.size.width + 32 }}, {{ yAxisTop }})"></g>-->
         <g class="y axis"></g>
-        <!--<text class="y-axis-label" transform="rotate(-90)" data-ng-attr-x="{{ -vtkCanvasGeometry().size.height / 2 }}" data-ng-attr-y="0" dy="1.1em"></text>-->
         <text class="y-axis-label" transform="rotate(-90)"></text>
-          <text class="y axis-end low"></text>
-          <text class="y axis-end high"></text>
+        <text class="y axis-end low"></text>
+        <text class="y axis-end high"></text>
 
-        <!--<g class="z axis" data-ng-attr-transform="translate({{ xAxisLeft }}, {{ vtkCanvasGeometry().size.height - 64 }} ) rotate({{ zAxisAngle }}, {{ 0 }}, {{ 0 }})"></g>-->
         <g class="z axis"></g>
-        <!--<text class="z-axis-label" data-ng-attr-transform=" translate(90, {{ vtkCanvasGeometry().size.height - 120 }}) "></text>-->
         <text class="z-axis-label"></text>
-          <text class="z axis-end low"></text>
-          <text class="z axis-end high"></text>
+        <text class="z axis-end low"></text>
+        <text class="z axis-end high"></text>
 
         <!-- little test boxes are useful for translating vtk space to screen space -->
 
         <rect data-ng-repeat="testBoxPos in testBoxes" data-ng-attr-x="{{ testBoxPos.x - 2.5 }}" data-ng-attr-y="{{ testBoxPos.y - 2.5 }}" class="test-rect" height="5" width="5" style="fill: black;" data-ng-attr-style="fill:{{ testBoxPos.color }}"></rect>
-
 
       </svg>
     </div>

--- a/sirepo/package_data/static/js/sirepo-geometry.js
+++ b/sirepo/package_data/static/js/sirepo-geometry.js
@@ -253,15 +253,7 @@ SIREPO.app.service('geometry', function() {
         }
 
         function trans(matrix) {
-            var m = [];
-            for(var i in matrix) {
-                var r = [];
-                for(var j in matrix) {
-                    r.push(matrix[j][i]);
-                }
-                m.push(r);
-            }
-            return m;
+            return svc.transpose(matrix);
         }
 
         function vectorMult(m1, v) {
@@ -356,6 +348,30 @@ SIREPO.app.service('geometry', function() {
         };
 
         return xform;
+    };
+
+    this.transpose = function (matrix) {
+        var m = [];
+        var l = matrix.length;
+        if(! l ) {
+            return m;
+        }
+        // convert 1 x l into l x 1
+        var ll = matrix[0].length;
+        if(ll == 0) {
+            matrix.forEach(function (entry) {
+                m.push([entry]);
+            });
+            return m;
+        }
+        for(var j = 0; j < ll; ++j) {
+            var r = [];
+            for(var i = 0; i < l; ++i) {
+                r.push(matrix[i][j]);
+            }
+            m.push(r);
+        }
+        return m;
     };
 
     // Returns the point(s) that have the smallest (reverse == false) or largest value in the given dimension

--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -942,6 +942,9 @@ SIREPO.app.factory('vtkPlotting', function(appState, plotting, panelState, utili
     };
 
     self.addActor = function(renderer, actor) {
+        if(! actor) {
+            return;
+        }
         renderer.addActor(actor);
     };
 

--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -81,7 +81,9 @@ SIREPO.app.factory('vtkPlotting', function(appState, plotting, panelState, utili
         // "Bundles" a source, mapper, and actor together
         function actorBundle(source) {
             var m = vtk.Rendering.Core.vtkMapper.newInstance();
-            m.setInputConnection(source.getOutputPort());
+            if(source) {
+                m.setInputConnection(source.getOutputPort());
+            }
             var a = vtk.Rendering.Core.vtkActor.newInstance();
             a.setMapper(m);
 
@@ -104,18 +106,8 @@ SIREPO.app.factory('vtkPlotting', function(appState, plotting, panelState, utili
 
             xform: transform || geometry.transform(),
 
-            buildPlane: function(labOrigin, labP1, labP2) {
-                var src = vtk.Filters.Sources.vtkPlaneSource.newInstance({ xResolution: 8, yResolution: 8 });
-                this.setPlane(src, labOrigin, labP1, labP2);
-                return actorBundle(src);
-            },
-            setPlane: function(planeSource, labOrigin, labP1, labP2) {
-                var vo = labOrigin ? this.xform.doTransform(labOrigin) : [0, 0, 0];
-                var vp1 = labP1 ? this.xform.doTransform(labP1) : [0, 0, 1];
-                var vp2 = labP2 ? this.xform.doTransform(labP2) : [1, 0, 0];
-                planeSource.setOrigin(vo[0], vo[1], vo[2]);
-                planeSource.setPoint1(vp1[0], vp1[1], vp1[2]);
-                planeSource.setPoint2(vp2[0], vp2[1], vp2[2]);
+            buildActorBundle: function(source) {
+                return actorBundle(source);
             },
             buildBox: function(labSize, labCenter) {
                 var vsize = labSize ? this.xform.doTransform(labSize) :  [1, 1, 1];
@@ -151,6 +143,11 @@ SIREPO.app.factory('vtkPlotting', function(appState, plotting, panelState, utili
                 ab.actor.getProperty().setColor(colorArray[0], colorArray[1], colorArray[2]);
                 return ab;
             },
+            buildPlane: function(labOrigin, labP1, labP2) {
+                var src = vtk.Filters.Sources.vtkPlaneSource.newInstance({ xResolution: 8, yResolution: 8 });
+                this.setPlane(src, labOrigin, labP1, labP2);
+                return actorBundle(src);
+            },
             buildSphere: function(lcenter, radius, colorArray) {
                 var ps = vtk.Filters.Sources.vtkSphereSource.newInstance({
                     center: lcenter ? this.xform.doTransform(lcenter) : [0, 0, 0],
@@ -163,6 +160,14 @@ SIREPO.app.factory('vtkPlotting', function(appState, plotting, panelState, utili
                 ab.actor.getProperty().setColor(colorArray[0], colorArray[1], colorArray[2]);
                 ab.actor.getProperty().setLighting(false);
                 return ab;
+            },
+            setPlane: function(planeSource, labOrigin, labP1, labP2) {
+                var vo = labOrigin ? this.xform.doTransform(labOrigin) : [0, 0, 0];
+                var vp1 = labP1 ? this.xform.doTransform(labP1) : [0, 0, 1];
+                var vp2 = labP2 ? this.xform.doTransform(labP2) : [1, 0, 0];
+                planeSource.setOrigin(vo[0], vo[1], vo[2]);
+                planeSource.setPoint1(vp1[0], vp1[1], vp1[2]);
+                planeSource.setPoint2(vp2[0], vp2[1], vp2[2]);
             },
         };
     };

--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -932,14 +932,17 @@ SIREPO.app.factory('vtkPlotting', function(appState, plotting, panelState, utili
             bottom: bottom,
             length: length,
             angle: angle,
-
         };
     }
 
     self.addActors = function(renderer, actorArr) {
         actorArr.forEach(function(actor) {
-            renderer.addActor(actor);
+            self.addActor(renderer, actor);
         });
+    };
+
+    self.addActor = function(renderer, actor) {
+        renderer.addActor(actor);
     };
 
     self.removeActors = function(renderer, actorArr) {
@@ -947,16 +950,30 @@ SIREPO.app.factory('vtkPlotting', function(appState, plotting, panelState, utili
             return;
         }
         actorArr.forEach(function(actor) {
-            renderer.removeActor(actor);
+            self.removeActor(renderer, actor);
         });
         actorArr.length = 0;
     };
 
-    self.showActors = function(renderWindow, arr, doShow, visibleOpacity, hiddenOpacity) {
-        for(var aIndex = 0; aIndex < arr.length; ++aIndex) {
-            arr[aIndex].getProperty().setOpacity(doShow ? visibleOpacity || 1.0 : hiddenOpacity || 0.0);
+    self.removeActor = function(renderer, actor) {
+        if(! actor ) {
+            return;
         }
+        renderer.removeActor(actor);
+    };
+
+    self.showActors = function(renderWindow, arr, doShow, visibleOpacity, hiddenOpacity) {
+        arr.forEach(function (a) {
+            self.showActor(renderWindow, a, doShow, visibleOpacity, hiddenOpacity, true);
+        });
         renderWindow.render();
+    };
+
+    self.showActor = function(renderWindow, a, doShow, visibleOpacity, hiddenOpacity, waitToRender) {
+        a.getProperty().setOpacity(doShow ? visibleOpacity || 1.0 : hiddenOpacity || 0.0);
+        if(! waitToRender) {
+            renderWindow.render();
+        }
     };
 
     self.localCoordFromWorld = function (vtkCoord, point) {

--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -144,8 +144,11 @@ SIREPO.app.factory('vtkPlotting', function(appState, plotting, panelState, utili
                 return ab;
             },
             buildPlane: function(labOrigin, labP1, labP2) {
-                var src = vtk.Filters.Sources.vtkPlaneSource.newInstance({ xResolution: 8, yResolution: 8 });
-                this.setPlane(src, labOrigin, labP1, labP2);
+                //var src = vtk.Filters.Sources.vtkPlaneSource.newInstance({ xResolution: 8, yResolution: 8 });
+                var src = vtk.Filters.Sources.vtkPlaneSource.newInstance();
+                if(labOrigin && labP1 && labP2) {
+                    this.setPlane(src, labOrigin, labP1, labP2);
+                }
                 return actorBundle(src);
             },
             buildSphere: function(lcenter, radius, colorArray) {
@@ -161,13 +164,13 @@ SIREPO.app.factory('vtkPlotting', function(appState, plotting, panelState, utili
                 ab.actor.getProperty().setLighting(false);
                 return ab;
             },
-            setPlane: function(planeSource, labOrigin, labP1, labP2) {
+            setPlane: function(planeBundle, labOrigin, labP1, labP2) {
                 var vo = labOrigin ? this.xform.doTransform(labOrigin) : [0, 0, 0];
                 var vp1 = labP1 ? this.xform.doTransform(labP1) : [0, 0, 1];
                 var vp2 = labP2 ? this.xform.doTransform(labP2) : [1, 0, 0];
-                planeSource.setOrigin(vo[0], vo[1], vo[2]);
-                planeSource.setPoint1(vp1[0], vp1[1], vp1[2]);
-                planeSource.setPoint2(vp2[0], vp2[1], vp2[2]);
+                planeBundle.source.setOrigin(vo[0], vo[1], vo[2]);
+                planeBundle.source.setPoint1(vp1[0], vp1[1], vp1[2]);
+                planeBundle.source.setPoint2(vp2[0], vp2[1], vp2[2]);
             },
         };
     };

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -3188,6 +3188,8 @@ SIREPO.app.directive('particle3d', function(appState, panelState, requestSender,
             // lines
             var lineActors = [];
             var reflectedLineActors = [];
+            var lineActor;
+            var reflectedLineActor;
 
             // spheres
             var impactSphereActors = [];
@@ -3384,13 +3386,17 @@ SIREPO.app.directive('particle3d', function(appState, panelState, requestSender,
             $scope.load = function() {
                 $scope.dataCleared = false;
 
-                vtkPlotting.removeActors(renderer, lineActors);
-                vtkPlotting.removeActors(renderer, reflectedLineActors);
+                //vtkPlotting.removeActors(renderer, lineActors);
+                //vtkPlotting.removeActors(renderer, reflectedLineActors);
+                vtkPlotting.removeActor(renderer, lineActor);
+                vtkPlotting.removeActor(renderer, reflectedLineActor);
                 vtkPlotting.removeActors(renderer, impactSphereActors);
                 vtkPlotting.removeActors(renderer, conductorActors);
 
                 lineActors = [];
                 reflectedLineActors = [];
+                lineActor = null;
+                reflectedLineActor = null;
                 impactSphereActors = [];
                 fieldSphereActors = [];
                 conductorActors = [];
@@ -3662,10 +3668,11 @@ SIREPO.app.directive('particle3d', function(appState, panelState, requestSender,
                 var hm_zmax = plotting.max2d(heatmap);
                 fieldColorScale = plotting.colorScaleForPlot({ min: hm_zmin, max: hm_zmax }, 'particle3d');
 
-                buildLineActorsFromPoints(xpoints, ypoints, zpoints, null, true);
+                lineActor = buildLineActorFromPoints(xpoints, ypoints, zpoints, null, true);
                 if (pointData.lost_x) {
                     $scope.hasReflected = pointData.lost_x.length > 0;
-                    buildLineActorsFromPoints(pointData.lost_y, pointData.lost_z, pointData.lost_x, reflectedParticleTrackColor, false);
+                    reflectedLineActor =
+                        buildLineActorFromPoints(pointData.lost_y, pointData.lost_z, pointData.lost_x, reflectedParticleTrackColor, false);
                 }
 
                 // build conductors -- make them a tiny bit small so the edges do not bleed into each other
@@ -3711,7 +3718,7 @@ SIREPO.app.directive('particle3d', function(appState, panelState, requestSender,
             };
 
 
-            function buildLineActorsFromPoints(xpoints, ypoints, zpoints, color, includeImpact) {
+            function buildLineActorFromPoints(xpoints, ypoints, zpoints, color, includeImpact) {
                 var x = 0.0;
                 var y = 0.0;
                 var z = 0.0;
@@ -3777,7 +3784,8 @@ SIREPO.app.directive('particle3d', function(appState, panelState, requestSender,
                 // makes sure the colors get set by the scalars, not the actor
                 m.setScalarVisibility(true);
                 a.setMapper(m);
-                lineActors.push(a);
+                //lineActors.push(a);
+                return a;
 
                 function pushLineData(p1, p2, c) {
                     // we always have two points per line
@@ -3867,14 +3875,14 @@ SIREPO.app.directive('particle3d', function(appState, panelState, requestSender,
                     .attr('height', vtkCanvasSize.height);
 
                 // Note that vtk does not re-add actors to the renderer if they already exist
-                vtkPlotting.addActors(renderer, lineActors);
-                vtkPlotting.addActors(renderer, reflectedLineActors);
+                vtkPlotting.addActor(renderer, lineActor);
+                vtkPlotting.addActor(renderer, reflectedLineActor);
                 vtkPlotting.addActors(renderer, conductorActors);
                 vtkPlotting.addActors(renderer, impactSphereActors);
 
-                vtkPlotting.showActors(renderWindow, lineActors, $scope.showAbsorbed);
+                vtkPlotting.showActor(renderWindow, lineActor, $scope.showAbsorbed);
                 vtkPlotting.showActors(renderWindow, impactSphereActors, $scope.showAbsorbed && $scope.showImpact);
-                vtkPlotting.showActors(renderWindow, reflectedLineActors, $scope.showReflected);
+                vtkPlotting.showActor(renderWindow, reflectedLineActor, $scope.showReflected);
                 vtkPlotting.showActors(renderWindow, conductorActors, $scope.showConductors, 0.80);
 
                 // reset camera will negate zoom and pan but *not* rotation
@@ -4725,7 +4733,7 @@ SIREPO.app.directive('particle3d', function(appState, panelState, requestSender,
 
             $scope.toggleAbsorbed = function() {
                 $scope.showAbsorbed = ! $scope.showAbsorbed;
-                vtkPlotting.showActors(renderWindow, lineActors, $scope.showAbsorbed);
+                vtkPlotting.showActor(renderWindow, lineActor, $scope.showAbsorbed);
                 vtkPlotting.showActors(renderWindow, impactSphereActors, $scope.showAbsorbed && $scope.showImpact);
             };
             $scope.toggleImpact = function() {
@@ -4734,7 +4742,7 @@ SIREPO.app.directive('particle3d', function(appState, panelState, requestSender,
             };
             $scope.toggleReflected = function() {
                 $scope.showReflected = ! $scope.showReflected;
-                vtkPlotting.showActors(renderWindow, reflectedLineActors, $scope.showReflected);
+                vtkPlotting.showActor(renderWindow, reflectedLineActor, $scope.showReflected);
             };
             $scope.toggleConductors = function() {
                 $scope.showConductors = ! $scope.showConductors;

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -135,7 +135,8 @@
         },
         "particle3d": {
             "renderCount": ["Particles to Render", "ParticleRenderCount", "10"],
-            "joinEvery": ["Join Every N Points", "Integer", 5, "Reduce render times by drawing lines between fewer data points (min 5, max 100)", 5, 100]
+            "joinEvery": ["Join Every N Points", "Integer", 5, "Reduce render times by drawing lines between fewer data points (min 5, max 100)", 5, 100],
+            "colorMap": ["Color Map", "ColorMap", "viridis"]
         },
         "simulation": {
             "egun_mode": ["Electron Gun Mode", "Boolean", "0"]
@@ -269,7 +270,8 @@
             "title": "Particle Trace 3D",
             "advanced": [
                 "renderCount",
-                "joinEvery"
+                "joinEvery",
+                "colorMap"
             ]
         },
         "simulationGrid": {

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -135,7 +135,6 @@
         },
         "particle3d": {
             "renderCount": ["Particles to Render", "ParticleRenderCount", "10"],
-            "joinEvery": ["Join Every N Points", "Integer", 5, "Reduce render times by drawing lines between fewer data points (min 5, max 100)", 5, 100],
             "colorMap": ["Color Map", "ColorMap", "viridis"]
         },
         "simulation": {
@@ -270,7 +269,6 @@
             "title": "Particle Trace 3D",
             "advanced": [
                 "renderCount",
-                "joinEvery",
                 "colorMap"
             ]
         },

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -1,4 +1,10 @@
 {
+    "constants": {
+        "nonZeroVoltsColor": "#6992ff",
+        "zeroVoltsColor": "#f3d4c8",
+        "particleTrackColor": "#4682b4",
+        "reflectedParticleTrackColor": "#d04836"
+    },
     "dynamicFiles": {
         "externalLibs": {
             "js": [

--- a/tests/karma/plotVTK_test.js
+++ b/tests/karma/plotVTK_test.js
@@ -130,7 +130,9 @@ describe('geometry', function() {
         var p4 = geometry.point(1, 1);
 
         var r1 = geometry.rect(p1, p2);
-        var b1 = r1.boundaries();
+        var b1 = r1.sides();
+
+        var r2 = geometry.rect(p3, p4);
 
         expect(r1.containsPoint(p3)).toBeTruthy();
         expect(r1.containsPoint(p4)).toBeFalsy();
@@ -155,6 +157,27 @@ describe('geometry', function() {
         expect(lIn.length).toBe(1);
         expect(lIn[0].equals(l1)).toBeTruthy();
 
+        expect(r1.intersectsRect(r2)).toBeTruthy();
+        expect(r2.intersectsRect(r1)).toBeTruthy();
+
+        var r3 = geometry.rect(
+            geometry.point(16, 16),
+            geometry.point(726, 726)
+        );
+        var r4 = geometry.rect(
+            geometry.point(-42, 189),
+            geometry.point(599, 558)
+        );
+        expect(r3.intersectsRect(r4)).toBeTruthy();
+        expect(r4.intersectsRect(r3)).toBeTruthy();
+
+        var r5 = geometry.rect(
+            geometry.point(-0.25, -0.25),
+            geometry.point(0.25, 0.25)
+        );
+
+        // r5 is entirely within r1
+        expect(r1.intersectsRect(r5)).toBeFalsy();
     }));
 
    it('should fail [transform]: ', inject(function(geometry) {


### PR DESCRIPTION
Notes:

 - Lines now live in a single actor, which makes things much faster (idea taken from rs4pi). Consequently the ```joinEvery``` parameter has been removed as it is no longer necessary

- The color map for the field coloring of lines is now part of the particle report instead of coming from the field report

- Pinch/zoom size is limited, and the image can't be dragged out of view.  There is some jittering at the limits which we can smooth out later

- Mouseover labels on the buttons at the top
