### PR TITLE
Simplify reshaping of array in remap_3d

### DIFF
--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -1755,17 +1755,8 @@ def _remap_3d(info, allrange, z_label, z_units, width_pixels, scale='linear'):
     ar2d = info['points']
 
     totLen = int(x_range[2] * y_range[2])
-    lenAr2d = len(ar2d)
-    if lenAr2d > totLen:
-        ar2d = np.array(ar2d[0:totLen])
-    elif lenAr2d < totLen:
-        auxAr = np.array([0] * lenAr2d, dtype=numpy.dtype(type(ar2d[0])))
-        for i in range(lenAr2d):
-            auxAr[i] = ar2d[i]
-        ar2d = np.array(auxAr)
-    if isinstance(ar2d, (list, np.array)):
-        ar2d = np.array(ar2d)
-    ar2d = ar2d.reshape(y_range[2], x_range[2])
+    n = len(ar2d) if totLen > len(ar2d) else totLen
+    ar2d = np.reshape(ar2d[0:n], (y_range[2], x_range[2]))
 
     if scale != 'linear':
         ar2d[np.where(ar2d <= 0.)] = 1.e-23

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -1759,7 +1759,7 @@ def _remap_3d(info, allrange, z_label, z_units, width_pixels, scale='linear'):
     if lenAr2d > totLen:
         ar2d = np.array(ar2d[0:totLen])
     elif lenAr2d < totLen:
-        auxAr = np.array([0] * lenAr2d, dtype='float64')
+        auxAr = np.array([0] * lenAr2d, dtype=numpy.dtype(type(ar2d[0])))
         for i in range(lenAr2d):
             auxAr[i] = ar2d[i]
         ar2d = np.array(auxAr)


### PR DESCRIPTION
I decided to learn a tiny bit more about numpy, and it seems that `reshape` takes an `array-like`, and returns a numpy array, so you don't actually need to be concerned about the type.
