### PR TITLE
Popup report changes for #1434, #1437

### DIFF
--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -2629,6 +2629,13 @@ SIREPO.app.service('utilities', function($window, $interval) {
         return parseFloat(fsString.substring(0, fsString.indexOf('px')));
     };
 
+    this.wordSplits = function(str) {
+        var wds = str.split(/(\s+)/);
+        return wds.map(function (value, index) {
+            return wds.slice(0, index).join('') + value;
+        });
+    };
+
     // fullscreen utilities
     this.getFullScreenElement = function() {
         return document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement || document.msFullscreenElement;


### PR DESCRIPTION
Notes:

- Popup reports print the x coordinate only once, instead of repeating it for each plot
- The popup window sizes to fit in both dimensions
- Popup text wraps if the window would otherwise extend beyond the plot boundaries
- If a unit is inverse (e.g. "1/s"), it gets converted to e.g. "unit-1" in the popup window, so the "1" does not look like part of the numeric value