### PR TITLE
Issue/1356 simulation href

### DIFF
--- a/sirepo/package_data/static/html/simulations.html
+++ b/sirepo/package_data/static/html/simulations.html
@@ -34,7 +34,7 @@
           </thead>
           <tbody>
             <tr data-ng-repeat="item in simulations.activeFolder.children | orderBy:['isFolder', simulations.sortField]">
-              <td><a data-ng-href="{{nav.simulationURL(item.simulationId)}}" data-ng-click="simulations.openItem(item)"><span class="glyphicon" data-ng-class="{'sr-user-item': ! simulations.fileManager.isItemExample(item), 'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder && item.isExample, 'sr-transparent-icon-user': ! item.isFolder && ! item.isExample}"></span> <span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a></td>
+              <td><a data-ng-href="{{ nav.simulationURL(item.simulationId) }}" data-ng-click="simulations.openItem(item)"><span class="glyphicon" data-ng-class="{'sr-user-item': ! simulations.fileManager.isItemExample(item), 'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder && item.isExample, 'sr-transparent-icon-user': ! item.isFolder && ! item.isExample}"></span> <span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a></td>
               <td>{{ item.lastModified }}</td>
             </tr>
             <tr data-ng-show="simulations.isWaitingForSim">
@@ -50,12 +50,12 @@
         <div data-ng-show="simulations.isIconView" style="margin-right: 65px">
           <div data-ng-repeat="item in simulations.activeFolder.children | orderBy:['isFolder', 'name']" class="sr-icon-col">
             <div class="sr-thumbnail text-center dropdown">
-              <a data-ng-href="{{nav.simulationURL(item.simulationId)}}" data-ng-dblclick="simulations.openItem(item)" class="sr-item-icon" data-toggle="dropdown">
+              <a data-ng-href="{{ nav.simulationURL(item.simulationId) }}" data-ng-dblclick="simulations.openItem(item)" class="sr-item-icon" data-toggle="dropdown">
                 <span class="caret" style="visibility: hidden"></span><span class="glyphicon" data-ng-class="{'sr-user-item': ! simulations.fileManager.isItemExample(item), 'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder && item.isExample, 'sr-transparent-icon-user': ! item.isFolder && ! item.isExample}"></span><span data-ng-if="simulations.fileManager.isItemExample(item)" class="glyphicon glyphicon-cog sr-example-item" data-ng-class="{ 'sr-example-folder': item.isFolder, 'sr-example-sim': ! item.isFolder }"></span><span class="caret"></span>
               </a>
-              <a class="sr-item-text" data-ng-href="{{nav.simulationURL(item.simulationId)}}" data-ng-click="simulations.openItem(item)"><span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a>
+              <a class="sr-item-text" data-ng-href="{{ nav.simulationURL(item.simulationId) }}" data-ng-click="simulations.openItem(item)"><span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a>
               <ul class="dropdown-menu">
-                <li><a data-ng-href="{{nav.simulationURL(item.simulationId)}}" data-ng-click="simulations.openItem(item)"><span class="glyphicon sr-nav-icon" data-ng-class="{'glyphicon-folder-open': item.isFolder, 'glyphicon-open-file': ! item.isFolder}"></span> Open</a></li>
+                <li><a data-ng-href="{{ nav.simulationURL(item.simulationId) }}" data-ng-click="simulations.openItem(item)"><span class="glyphicon sr-nav-icon" data-ng-class="{'glyphicon-folder-open': item.isFolder, 'glyphicon-open-file': ! item.isFolder}"></span> Open</a></li>
                 <li data-ng-if="! item.isFolder"><a href data-ng-click="simulations.copyItem(item)"><span class="glyphicon glyphicon-duplicate sr-nav-icon"></span> Open as a New Copy</a></li>
                 <li data-ng-if="! simulations.fileManager.isItemExample(item)"><a href data-ng-click="simulations.renameItem(item)"><span class="glyphicon glyphicon-edit sr-nav-icon"></span> Rename</a></li>
                 <li data-ng-if="! simulations.fileManager.isItemExample(item)"><a href data-ng-click="simulations.moveItem(item)"><span class="glyphicon glyphicon-arrow-right sr-nav-icon"></span> Move</a></li>

--- a/sirepo/package_data/static/html/simulations.html
+++ b/sirepo/package_data/static/html/simulations.html
@@ -34,7 +34,7 @@
           </thead>
           <tbody>
             <tr data-ng-repeat="item in simulations.activeFolder.children | orderBy:['isFolder', simulations.sortField]">
-              <td><a href data-ng-click="simulations.openItem(item)"><span class="glyphicon" data-ng-class="{'sr-user-item': ! simulations.fileManager.isItemExample(item), 'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder && item.isExample, 'sr-transparent-icon-user': ! item.isFolder && ! item.isExample}"></span> <span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a></td>
+              <td><a data-ng-href="{{nav.simulationURL(item)}}" data-ng-click="simulations.openItem(item)"><span class="glyphicon" data-ng-class="{'sr-user-item': ! simulations.fileManager.isItemExample(item), 'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder && item.isExample, 'sr-transparent-icon-user': ! item.isFolder && ! item.isExample}"></span> <span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a></td>
               <td>{{ item.lastModified }}</td>
             </tr>
             <tr data-ng-show="simulations.isWaitingForSim">

--- a/sirepo/package_data/static/html/simulations.html
+++ b/sirepo/package_data/static/html/simulations.html
@@ -50,10 +50,10 @@
         <div data-ng-show="simulations.isIconView" style="margin-right: 65px">
           <div data-ng-repeat="item in simulations.activeFolder.children | orderBy:['isFolder', 'name']" class="sr-icon-col">
             <div class="sr-thumbnail text-center dropdown">
-              <a href data-ng-dblclick="simulations.openItem(item)" class="sr-item-icon" data-toggle="dropdown">
+              <a data-ng-href="{{nav.simulationURL(item)}}" data-ng-dblclick="simulations.openItem(item)" class="sr-item-icon" data-toggle="dropdown">
                 <span class="caret" style="visibility: hidden"></span><span class="glyphicon" data-ng-class="{'sr-user-item': ! simulations.fileManager.isItemExample(item), 'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder && item.isExample, 'sr-transparent-icon-user': ! item.isFolder && ! item.isExample}"></span><span data-ng-if="simulations.fileManager.isItemExample(item)" class="glyphicon glyphicon-cog sr-example-item" data-ng-class="{ 'sr-example-folder': item.isFolder, 'sr-example-sim': ! item.isFolder }"></span><span class="caret"></span>
               </a>
-              <a class="sr-item-text" href data-ng-click="simulations.openItem(item)"><span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a>
+              <a class="sr-item-text" data-ng-href="{{nav.simulationURL(item)}}" data-ng-click="simulations.openItem(item)"><span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a>
               <ul class="dropdown-menu">
                 <li><a href data-ng-click="simulations.openItem(item)"><span class="glyphicon sr-nav-icon" data-ng-class="{'glyphicon-folder-open': item.isFolder, 'glyphicon-open-file': ! item.isFolder}"></span> Open</a></li>
                 <li data-ng-if="! item.isFolder"><a href data-ng-click="simulations.copyItem(item)"><span class="glyphicon glyphicon-duplicate sr-nav-icon"></span> Open as a New Copy</a></li>

--- a/sirepo/package_data/static/html/simulations.html
+++ b/sirepo/package_data/static/html/simulations.html
@@ -55,7 +55,7 @@
               </a>
               <a class="sr-item-text" data-ng-href="{{nav.simulationURL(item)}}" data-ng-click="simulations.openItem(item)"><span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a>
               <ul class="dropdown-menu">
-                <li><a href data-ng-click="simulations.openItem(item)"><span class="glyphicon sr-nav-icon" data-ng-class="{'glyphicon-folder-open': item.isFolder, 'glyphicon-open-file': ! item.isFolder}"></span> Open</a></li>
+                <li><a data-ng-href="{{nav.simulationURL(item)}}" data-ng-click="simulations.openItem(item)"><span class="glyphicon sr-nav-icon" data-ng-class="{'glyphicon-folder-open': item.isFolder, 'glyphicon-open-file': ! item.isFolder}"></span> Open</a></li>
                 <li data-ng-if="! item.isFolder"><a href data-ng-click="simulations.copyItem(item)"><span class="glyphicon glyphicon-duplicate sr-nav-icon"></span> Open as a New Copy</a></li>
                 <li data-ng-if="! simulations.fileManager.isItemExample(item)"><a href data-ng-click="simulations.renameItem(item)"><span class="glyphicon glyphicon-edit sr-nav-icon"></span> Rename</a></li>
                 <li data-ng-if="! simulations.fileManager.isItemExample(item)"><a href data-ng-click="simulations.moveItem(item)"><span class="glyphicon glyphicon-arrow-right sr-nav-icon"></span> Move</a></li>

--- a/sirepo/package_data/static/html/simulations.html
+++ b/sirepo/package_data/static/html/simulations.html
@@ -34,7 +34,7 @@
           </thead>
           <tbody>
             <tr data-ng-repeat="item in simulations.activeFolder.children | orderBy:['isFolder', simulations.sortField]">
-              <td><a data-ng-href="{{nav.simulationURL(item)}}" data-ng-click="simulations.openItem(item)"><span class="glyphicon" data-ng-class="{'sr-user-item': ! simulations.fileManager.isItemExample(item), 'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder && item.isExample, 'sr-transparent-icon-user': ! item.isFolder && ! item.isExample}"></span> <span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a></td>
+              <td><a data-ng-href="{{nav.simulationURL(item.simulationId)}}" data-ng-click="simulations.openItem(item)"><span class="glyphicon" data-ng-class="{'sr-user-item': ! simulations.fileManager.isItemExample(item), 'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder && item.isExample, 'sr-transparent-icon-user': ! item.isFolder && ! item.isExample}"></span> <span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a></td>
               <td>{{ item.lastModified }}</td>
             </tr>
             <tr data-ng-show="simulations.isWaitingForSim">
@@ -50,12 +50,12 @@
         <div data-ng-show="simulations.isIconView" style="margin-right: 65px">
           <div data-ng-repeat="item in simulations.activeFolder.children | orderBy:['isFolder', 'name']" class="sr-icon-col">
             <div class="sr-thumbnail text-center dropdown">
-              <a data-ng-href="{{nav.simulationURL(item)}}" data-ng-dblclick="simulations.openItem(item)" class="sr-item-icon" data-toggle="dropdown">
+              <a data-ng-href="{{nav.simulationURL(item.simulationId)}}" data-ng-dblclick="simulations.openItem(item)" class="sr-item-icon" data-toggle="dropdown">
                 <span class="caret" style="visibility: hidden"></span><span class="glyphicon" data-ng-class="{'sr-user-item': ! simulations.fileManager.isItemExample(item), 'glyphicon-folder-close': item.isFolder, 'glyphicon-file': ! item.isFolder, 'sr-transparent-icon': ! item.isFolder && item.isExample, 'sr-transparent-icon-user': ! item.isFolder && ! item.isExample}"></span><span data-ng-if="simulations.fileManager.isItemExample(item)" class="glyphicon glyphicon-cog sr-example-item" data-ng-class="{ 'sr-example-folder': item.isFolder, 'sr-example-sim': ! item.isFolder }"></span><span class="caret"></span>
               </a>
-              <a class="sr-item-text" data-ng-href="{{nav.simulationURL(item)}}" data-ng-click="simulations.openItem(item)"><span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a>
+              <a class="sr-item-text" data-ng-href="{{nav.simulationURL(item.simulationId)}}" data-ng-click="simulations.openItem(item)"><span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName }}</span></a>
               <ul class="dropdown-menu">
-                <li><a data-ng-href="{{nav.simulationURL(item)}}" data-ng-click="simulations.openItem(item)"><span class="glyphicon sr-nav-icon" data-ng-class="{'glyphicon-folder-open': item.isFolder, 'glyphicon-open-file': ! item.isFolder}"></span> Open</a></li>
+                <li><a data-ng-href="{{nav.simulationURL(item.simulationId)}}" data-ng-click="simulations.openItem(item)"><span class="glyphicon sr-nav-icon" data-ng-class="{'glyphicon-folder-open': item.isFolder, 'glyphicon-open-file': ! item.isFolder}"></span> Open</a></li>
                 <li data-ng-if="! item.isFolder"><a href data-ng-click="simulations.copyItem(item)"><span class="glyphicon glyphicon-duplicate sr-nav-icon"></span> Open as a New Copy</a></li>
                 <li data-ng-if="! simulations.fileManager.isItemExample(item)"><a href data-ng-click="simulations.renameItem(item)"><span class="glyphicon glyphicon-edit sr-nav-icon"></span> Rename</a></li>
                 <li data-ng-if="! simulations.fileManager.isItemExample(item)"><a href data-ng-click="simulations.moveItem(item)"><span class="glyphicon glyphicon-arrow-right sr-nav-icon"></span> Move</a></li>

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -2302,7 +2302,6 @@ SIREPO.app.controller('NavController', function (activeSection, appState, fileMa
         return {};
     }
 
-
     self.isActive = function(name) {
         return activeSection.getActiveSection() == name;
     };

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -2363,7 +2363,7 @@ SIREPO.app.controller('NavController', function (activeSection, appState, fileMa
     };
 
     self.simulationURL = function(item) {
-        return '#' + requestSender.formatUrlLocal(SIREPO.appHomeTab, {':simulationId': item.simulationId})
+        return '#' + requestSender.formatUrlLocal(SIREPO.appHomeTab, {':simulationId': item.simulationId});
     };
 
     self.getLocation = function() {

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -2362,8 +2362,8 @@ SIREPO.app.controller('NavController', function (activeSection, appState, fileMa
         return '#' + requestSender.formatUrlLocal(name, sectionParams(name));
     };
 
-    self.simulationURL = function(item) {
-        return '#' + requestSender.formatUrlLocal(SIREPO.appHomeTab, {':simulationId': item.simulationId});
+    self.simulationURL = function(simulationId) {
+        return '#' + requestSender.formatUrlLocal(SIREPO.appHomeTab, {':simulationId': simulationId});
     };
 
     self.getLocation = function() {

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -2302,6 +2302,7 @@ SIREPO.app.controller('NavController', function (activeSection, appState, fileMa
         return {};
     }
 
+
     self.isActive = function(name) {
         return activeSection.getActiveSection() == name;
     };
@@ -2361,6 +2362,11 @@ SIREPO.app.controller('NavController', function (activeSection, appState, fileMa
         }
         return '#' + requestSender.formatUrlLocal(name, sectionParams(name));
     };
+
+    self.simulationURL = function(item) {
+        return '#' + requestSender.formatUrlLocal(SIREPO.appHomeTab, {':simulationId': item.simulationId})
+    };
+
     self.getLocation = function() {
         return $window.location.href;
     };


### PR DESCRIPTION
Resolves #1356 

This wasn't mentioned in the issue but the href's in the simulation dropdown menu are also broken ("open as new copy", "export as zip", etc.). I fixed the href for "open" because it shared code with the other work for this issue. Any preference on how to proceed with the other options in the dropdown? I can think of how to get a URL for all options except for "open as new copy". That opens in a modal which I believe I can't create a URL for. Let me know how to proceed.  

For testing, I ran test.sh. Is that all I need to run for tests? Should I write any tests for my work? It seemed to me that the relevant tests to my change would live in tests/karma is that correct? 