### PR TITLE
[WIP] Container runner

### DIFF
--- a/container-runner-requirements.txt
+++ b/container-runner-requirements.txt
@@ -1,6 +1,7 @@
 trio
-redis
-hiredis
 docker
+quart-trio
+hypercorn[trio]
+yarl
 -e src/radiasoft/pykern
 -e src/radiasoft/sirepo

--- a/container-runner-requirements.txt
+++ b/container-runner-requirements.txt
@@ -1,0 +1,6 @@
+trio
+redis
+hiredis
+docker
+-e src/radiasoft/pykern
+-e src/radiasoft/sirepo

--- a/container-runner-requirements.txt
+++ b/container-runner-requirements.txt
@@ -1,7 +1,0 @@
-trio
-docker
-quart-trio
-hypercorn[trio]
-yarl
--e src/radiasoft/pykern
--e src/radiasoft/sirepo

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -74,6 +74,11 @@ def http():
         )
 
 
+def container_runner():
+    from sirepo.runner.container import serve
+    serve()
+
+
 def nginx_proxy():
     """Starts nginx in container.
 

--- a/sirepo/runner/__init__.py
+++ b/sirepo/runner/__init__.py
@@ -41,7 +41,7 @@ class State(aenum.UniqueEnum):
     RUN = 4
     STOP = 5
 
-_JOB_CLASSES = ('background', 'celery', 'docker')
+_JOB_CLASSES = ('background', 'celery', 'docker', 'container')
 
 _JOB_CLASS_DEFAULT = _JOB_CLASSES[0]
 

--- a/sirepo/runner/container.py
+++ b/sirepo/runner/container.py
@@ -5,22 +5,22 @@ u"""Run jobs in Docker.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from sirepo import runner, simulation_db
-import base64
+import collections
 import contextlib
 import docker
+import enum
 import functools
 import json
-import logging
 from pykern.pkdebug import pkdp, pkdc, pkdlog, pkdexc
-import redis
+import quart
+import quart_trio
 import requests
 import shlex
 import trio
+import yarl
 
-# The redis key we use for the request list
-_REQUEST_LIST_KEY = 'seq:job_queue'
-# The redis key we use for the job status hash
-_JOB_STATUS_HASH_KEY = 'hash:job_status'
+# XX TODO: should this be configurable somehow?
+_HTTP_API_URL = yarl.URL("http://127.0.0.1:8001")
 
 # How often threaded blocking operations should wake up and check for Trio
 # cancellation
@@ -28,21 +28,12 @@ _CANCEL_POLL_INTERVAL = 1
 
 # Global connection pools (don't worry, they don't actually make any
 # connections until we start using them)
-_REDIS = redis.from_url('redis://localhost:6379/0')
 _DOCKER = docker.from_env()
+_REQUESTS = requests.Session()
 
-
-def _encode_request(request):
-    return json.dumps(request).encode('utf-8')
-
-
-def _decode_request(request):
-    return json.loads(request.decode('utf-8'))
-
-
-def _submit_request(request):
-    pkdc('submitting request: {!r}', request)
-    _REDIS.rpush(_REQUEST_LIST_KEY, _encode_request(request))
+# The scheduler daemon's global state. _JOB_TRACKER is initialized lazily.
+_JOB_TRACKER = None
+_QUART_APP = quart_trio.QuartTrio(__name__)
 
 
 @contextlib.contextmanager
@@ -54,20 +45,7 @@ def _catch_and_log_errors(exc_type, msg, *args, **kwargs):
         pkdlog(pkdexc())
 
 
-# Helper to call redis blpop in a async/cancellation-friendly way
-async def _pop_encoded_request():
-    while True:
-        retval = await trio.run_sync_in_worker_thread(
-            functools.partial(
-                _REDIS.blpop, [_REQUEST_LIST_KEY], timeout=_CANCEL_POLL_INTERVAL
-            )
-        )
-        if retval is not None:
-            # it's a pair (key, popped value)
-            return retval[1]
-
-
-# Helper to call docker wait in a async/cancellation-friendly way
+# Helper to call container.wait in a async/cancellation-friendly way
 async def _container_wait(container):
     while True:
         try:
@@ -81,55 +59,122 @@ async def _container_wait(container):
             pass
 
 
-# The core request handler
-async def _handle_request(encoded_request):
-    with _catch_and_log_errors(Exception, 'error handling request {!r}', encoded_request):
-        request = _decode_request(encoded_request)
-        if request['type'] == 'start':
-            # Technically a blocking call, but redis is fast and local so we
-            # can get away with it
-            _REDIS.hset(_JOB_STATUS_HASH_KEY, request['jid'], b'running')
-            # Start the container
+class JobStatus(enum.Enum):
+    NOT_STARTED = "NOT_STARTED"
+    RUNNING = "RUNNING"
+    FINISHED = "FINISHED"
+
+
+class JobTracker:
+    def __init__(self, nursery):
+        # XX TODO: eventually we'll need a way to stop this growing without
+        # bound, perhaps by clarifying the split in responsibilities between
+        # the on-disk simulation_db versus the in-memory status.
+        self.jid_to_status = collections.defaultdict(
+            lambda: JobStatus.NOT_STARTED
+        )
+        self._nursery = nursery
+
+    async def start_job(self, jid, config):
+        await self._nursery.start(self._run_job, jid, config)
+
+    async def _run_job(
+            self, jid, config, *, task_status=trio.TASK_STATUS_IGNORED
+    ):
+        # XX TODO: there are all kinds of race conditions here, e.g. if the
+        # same jid gets started multiple times in parallel... we need to
+        # revisit this once jids are globally unique, and possibly add
+        # features like "if there is another job running with the same
+        # user/sim/job but a different hash, then auto-cancel that other job"
+        self.jid_to_status[jid] = JobStatus.RUNNING
+        try:
             container = await trio.run_sync_in_worker_thread(
                 functools.partial(
                     _DOCKER.containers.run,
-                    request['image'],
-                    request['command'],
-                    working_dir=request['working_dir'],
+                    config['image'],
+                    config['command'],
+                    working_dir=config['working_dir'],
                     # {host path: {'bind': container path, 'mode': 'rw'}}
-                    volumes=request['volumes'],
-                    name=request['jid'],
+                    volumes=config['volumes'],
+                    name=jid,
                     auto_remove=True,
                     detach=True,
                     init=True,
                 )
             )
+            task_status.started()
             # Returns a dict like: {'Error': None, 'StatusCode': 0}
             # XX TODO but there may be a race condition where if the container
             # finishes before our call to wait() starts, then it just errors
             # out with docker.errors.NotFound
-            pkdp(await _container_wait(container))
-            # Technically a blocking call
-            _REDIS.hset(_JOB_STATUS_HASH_KEY, request['jid'], b'finished')
-        elif request['type'] == 'cancel':
-            # This could fail, if the container doesn't exist or has already
-            # stopped, but _catch_and_log_errors catch the issue. We might
-            # want to catch and ignore expected errors like this, though,
-            # rather than letting them escape to _catch_and_log_errors?
-            container = _DOCKER.containers.get(request['jid'])
-            container.stop()
-            # Doesn't update status, because that will happen automatically
-            # when it actually stops...
-        else:
-            raise RuntimeError(f'unknown request type: {request["type"]!r}')
+            with _catch_and_log_errors(
+                    Exception, "error waiting for container {}", jid
+            ):
+                pkdp(await _container_wait(container))
+        finally:
+            self.jid_to_status[jid] = JobStatus.FINISHED
+
+
+@_QUART_APP.route('/jobs/<jid>', methods=["PUT"])
+async def start_job(jid):
+    pkdp("start_job", jid)
+    config = await quart.request.get_json()
+    await _JOB_TRACKER.start_job(jid, config)
+    return ""
+
+
+@_QUART_APP.route('/jobs/<jid>', methods=["GET"])
+async def job_status(jid):
+    pkdp("job_status: {}", jid)
+    return _JOB_TRACKER.jid_to_status[jid].value
+    return ""
+
+
+@_QUART_APP.route('/jobs/<jid>/cancel', methods=["POST"])
+async def cancel_job(jid):
+    try:
+        container = _DOCKER.containers.get(jid)
+        container.stop()
+    except docker.errors.NotFound:
+        # XX TODO: do we need to worry about a race condition where cancel
+        # arrives just before start_job?
+        # Probably a more reliable API for interactive jobs would be: the
+        # frontend polls every X seconds to say that it wants to see the
+        # results for {jid}, are they ready? And if it's not running, we start
+        # it; if it's running, we do nothing; and if it's running but we
+        # haven't seen a poll for the last X+Y seconds, then we automatically
+        # cancel it. (This assumes improved jid's that include the hash.)
+        # Of course batch jobs we only want to cancel when explicitly
+        # requested, but in that case it involves a user clicking a button so
+        # we don't really need to worried about race conditions.
+        pass
+    # Doesn't update status, because that will happen automatically
+    # when it actually stops...
+    return ""
+
+
+# This is a temporary kluge until we get app.serve(...) or similar:
+#   https://gitlab.com/pgjones/quart-trio/merge_requests/1
+async def app_serve(app, host, port):
+    import hypercorn
+    import hypercorn.trio.run
+    import quart.logging
+    config = hypercorn.Config()
+    config.host = host
+    config.port = port
+    config.access_log_format = "%(h)s %(r)s %(s)s %(b)s %(D)s"
+    config.access_logger = quart.logging.create_serving_logger()
+    config.error_logger = config.access_logger
+    config.application_path = None
+    hypercorn.trio.run.load_application = lambda *_: app
+    await hypercorn.trio.run.run_single(config)
 
 
 async def _main():
     async with trio.open_nursery() as nursery:
-        while True:
-            encoded_request = await _pop_encoded_request()
-            pkdc('handling request: {!r}', encoded_request)
-            nursery.start_soon(_handle_request, encoded_request)
+        global _JOB_TRACKER
+        _JOB_TRACKER = JobTracker(nursery)
+        await app_serve(_QUART_APP, _HTTP_API_URL.host, _HTTP_API_URL.port)
 
 
 def serve():
@@ -141,21 +186,18 @@ def serve():
 ################################################################
 
 class ContainerJob(runner.JobBase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._sent_start_request = False
-
     def _is_processing(self):
-        return (self._sent_start_request
-                and _REDIS.hget(_JOB_STATUS_HASH_KEY, self.jid) != b'finished')
+        r = _REQUESTS.get(_HTTP_API_URL / 'jobs' / self.jid)
+        r.raise_for_status()
+        return r.text == JobStatus.RUNNING.value
 
     def _kill(self):
-        _submit_request({'type': 'cancel', 'jid': self.jid})
+        r = _REQUESTS.post(_HTTP_API_URL / 'jobs' / self.jid / 'cancel')
+        r.raise_for_status()
 
     def _start(self):
-        # XX TODO I suspect this is not the right place to do this but I don't
-        # understand the status tracking flow yet.
-        simulation_db.write_status('running', self.run_dir)
+        # This doesn't seem to be needed anymore? But I'm not 100% certain.
+        #simulation_db.write_status('running', self.run_dir)
         # We can't just pass self.cmd directly to docker because we have to
         # detour through bash to set up our environment. But we do assume that
         # self.cmd is sufficiently well-behaved that shlex.quote will work.
@@ -165,23 +207,17 @@ class ContainerJob(runner.JobBase):
             '-c',
             '. ~/.bashrc && ' + ' '.join(shlex.quote(c) for c in self.cmd),
         ]
-        _submit_request({
-            'type': 'start',
-            'jid': self.jid,
+        config = {
             'image': image,
             'command': docker_command,
             'working_dir': str(self.run_dir),
             'volumes': {str(self.run_dir):
                           {'bind': str(self.run_dir), 'mode': 'rw'}},
-        })
-        # XX TODO: This is a hack to avoid a race condition where
-        # _is_processing would return False for a moment after we call this.
-        # If we could wait for the scheduler daemon to acknowledge our request
-        # before returning, this would be unnecessary.
-        self._sent_start_request = True
+        }
+        r = _REQUESTS.put(_HTTP_API_URL / 'jobs' / self.jid, json=config)
+        r.raise_for_status()
 
 
 def init_class(app, uwsgi):
-    # XX TODO: what else should we do here? check if we can connect to redis
-    # and the service is running?
+    # XX TODO: what else should we do here?
     return ContainerJob

--- a/sirepo/runner/container.py
+++ b/sirepo/runner/container.py
@@ -20,7 +20,7 @@ import trio
 import yarl
 
 # XX TODO: should this be configurable somehow?
-_HTTP_API_URL = yarl.URL("http://127.0.0.1:8001")
+_HTTP_API_URL = yarl.URL('http://127.0.0.1:8001')
 
 # How often threaded blocking operations should wake up and check for Trio
 # cancellation
@@ -60,9 +60,9 @@ async def _container_wait(container):
 
 
 class JobStatus(enum.Enum):
-    NOT_STARTED = "NOT_STARTED"
-    RUNNING = "RUNNING"
-    FINISHED = "FINISHED"
+    NOT_STARTED = 'NOT_STARTED'
+    RUNNING = 'RUNNING'
+    FINISHED = 'FINISHED'
 
 
 class JobTracker:
@@ -108,29 +108,29 @@ class JobTracker:
             # finishes before our call to wait() starts, then it just errors
             # out with docker.errors.NotFound
             with _catch_and_log_errors(
-                    Exception, "error waiting for container {}", jid
+                    Exception, 'error waiting for container {}', jid
             ):
                 pkdp(await _container_wait(container))
         finally:
             self.jid_to_status[jid] = JobStatus.FINISHED
 
 
-@_QUART_APP.route('/jobs/<jid>', methods=["PUT"])
+@_QUART_APP.route('/jobs/<jid>', methods=['PUT'])
 async def start_job(jid):
-    pkdp("start_job", jid)
+    pkdp('start_job', jid)
     config = await quart.request.get_json()
     await _JOB_TRACKER.start_job(jid, config)
-    return ""
+    return ''
 
 
-@_QUART_APP.route('/jobs/<jid>', methods=["GET"])
+@_QUART_APP.route('/jobs/<jid>', methods=['GET'])
 async def job_status(jid):
-    pkdp("job_status: {}", jid)
+    pkdp('job_status: {}', jid)
     return _JOB_TRACKER.jid_to_status[jid].value
-    return ""
+    return ''
 
 
-@_QUART_APP.route('/jobs/<jid>/cancel', methods=["POST"])
+@_QUART_APP.route('/jobs/<jid>/cancel', methods=['POST'])
 async def cancel_job(jid):
     try:
         container = _DOCKER.containers.get(jid)
@@ -150,7 +150,7 @@ async def cancel_job(jid):
         pass
     # Doesn't update status, because that will happen automatically
     # when it actually stops...
-    return ""
+    return ''
 
 
 # This is a temporary kluge until we get app.serve(...) or similar:
@@ -162,7 +162,7 @@ async def app_serve(app, host, port):
     config = hypercorn.Config()
     config.host = host
     config.port = port
-    config.access_log_format = "%(h)s %(r)s %(s)s %(b)s %(D)s"
+    config.access_log_format = '%(h)s %(r)s %(s)s %(b)s %(D)s'
     config.access_logger = quart.logging.create_serving_logger()
     config.error_logger = config.access_logger
     config.application_path = None

--- a/sirepo/runner/container.py
+++ b/sirepo/runner/container.py
@@ -1,0 +1,208 @@
+from sirepo import runner, simulation_db
+from base64 import b64encode
+from contextlib import contextmanager
+from functools import partial
+import logging
+import json
+import trio
+import docker
+import redis
+import requests
+
+__all__ = ["serve", "ContainerJob"]
+
+# XX TODO: what's the right way to do logging in pykern/sirepo?
+log = logging.getLogger(__name__)
+
+# The redis key we use for the request list
+REQUEST_LIST_KEY = "seq:job_queue"
+# The redis key we use for the job status hash
+JOB_STATUS_HASH_KEY = "hash:job_status"
+
+# How often threaded blocking operations should wake up and check for Trio
+# cancellation
+CANCEL_POLL_INTERVAL = 1
+
+# Global connection pools (don't worry, they don't actually make any
+# connections until we start using them)
+REDIS = redis.from_url("redis://localhost:6379/0")
+DOCKER = docker.from_env()
+
+
+def encode_request(request):
+    return json.dumps(request).encode("utf-8")
+
+
+def decode_request(request):
+    return json.loads(request.decode("utf-8"))
+
+
+def submit_request(request):
+    print("submitting:", request)
+    REDIS.rpush(REQUEST_LIST_KEY, encode_request(request))
+
+
+# XX TODO: how to integrate this properly into pykern/sirepo's logging system?
+@contextmanager
+def catch_and_log_errors(exc_type, msg, *args, **kwargs):
+    try:
+        yield
+    except exc_type as exc:
+        log.exception(msg, *args, **kwargs)
+
+
+# Helper to call redis blpop in a async/cancellation-friendly way
+async def pop_encoded_request():
+    while True:
+        retval = await trio.run_sync_in_worker_thread(
+            partial(
+                REDIS.blpop, [REQUEST_LIST_KEY], timeout=CANCEL_POLL_INTERVAL
+            )
+        )
+        if retval is not None:
+            _, encoded_request = retval
+            return encoded_request
+
+
+# Helper to call docker wait in a async/cancellation-friendly way
+async def container_wait(container):
+    while True:
+        try:
+            return await trio.run_sync_in_worker_thread(
+                partial(container.wait, timeout=CANCEL_POLL_INTERVAL)
+            )
+        # ReadTimeout is what the documentation says this raises.
+        # ConnectionError is what it actually raises.
+        # We'll catch both just to be safe.
+        except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError):
+            pass
+
+
+# The core request handler
+async def handle_request(encoded_request):
+    with catch_and_log_errors(Exception, "error handling request %r", encoded_request):
+        request = decode_request(encoded_request)
+        if request["type"] == "start":
+            jid = request["jid"]
+            # XX TODO should we do any sanitization here? e.g. specifying
+            # arbitrary volumes allows arbitrary access to the host. Maybe
+            # that's fine though.
+            image = request["image"]
+            command = request["command"]
+            working_dir = request["working_dir"]
+            # format: {host path: {"bind": container path, "mode": "rw"}}
+            volumes = request["volumes"]
+            # Technically a blocking call, but redis is fast and local so we
+            # can get away with it
+            REDIS.hset(JOB_STATUS_HASH_KEY, jid, b"running")
+            # Start the container
+            container = await trio.run_sync_in_worker_thread(
+                partial(
+                    DOCKER.containers.run,
+                    image,
+                    command,
+                    working_dir=working_dir,
+                    volumes=volumes,
+                    name=jid,
+                    auto_remove=True,
+                    detach=True,
+                )
+            )
+            # Returns a dict like: {"Error": None, "StatusCode": 0}
+            print(await container_wait(container))
+            # Technically a blocking call
+            REDIS.hset(JOB_STATUS_HASH_KEY, jid, b"finished")
+        elif request["type"] == "cancel":
+            jid = request["jid"]
+            container = DOCKER.containers.get(jid)
+            container.stop()
+            # Doesn't update status, because that will happen automatically
+            # when it actually stops...
+        else:
+            raise RuntimeError(f"unknown request type: {request['type']!r}")
+
+
+async def main():
+    async with trio.open_nursery() as nursery:
+        while True:
+            encoded_request = await pop_encoded_request()
+            print("handling request:", encoded_request)
+            nursery.start_soon(handle_request, encoded_request)
+
+
+def serve():
+    trio.run(main)
+
+
+################################################################
+# Sirepo integration bits
+################################################################
+
+class ContainerJob(runner.JobBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._sent_start_request = False
+
+    def _is_processing(self):
+        if (self._sent_start_request
+            and REDIS.hget(JOB_STATUS_HASH_KEY, self.jid) != b"finished"):
+            return True
+        return False
+
+    def _kill(self):
+        submit_request({"type": "cancel", "jid": self.jid})
+
+    def _start(self):
+        # XX TODO I suspect this is not the right place to do this but I don't
+        # understand the status tracking flow yet.
+        simulation_db.write_status('running', self.run_dir)
+        # XX TODO: this is a temporary hack, to work around sirepo's habit of
+        # hard-coding the host run_dir into the command line. Longer-term we
+        # need to untangle this.
+        cmd = list(self.cmd)
+        for i in range(len(cmd)):
+            if cmd[i] == self.run_dir:
+                cmd[i] = "/job-dir"
+        # XX TODO: this encoding thing is also a gnarly hack
+        # (1) for prototyping we want to work with the existing docker image,
+        # which requires we detour through bash to set up our environment,
+        # (2) self.cmd is already in the structured form we want to ultimately
+        # pass straight through to exec,
+        # (3) this means we need some hack to smuggle the real command
+        # through all the quoting layers.
+        #
+        # base64 is a blunt hammer, but it's easier than figuring out the
+        # details of all the different quoting systems.
+        encoded_cmd = b64encode(json.dumps(cmd).encode("utf-8"))
+        encoded_cmd = encoded_cmd.replace(b"\n", b"").replace(b" ", b"")
+        encoded_cmd = encoded_cmd.decode("ascii")
+        image = "radiasoft/sirepo"
+        docker_command = [
+            "/home/vagrant/.radia-run/tini",
+            "--",
+            "/bin/bash",
+            "-c",
+            """
+            . ~/.bashrc
+            exec python3 -c 'import json, base64, os; cmd = json.loads(base64.b64decode("%s")); os.execvp(cmd[0], cmd)'
+            """ % encoded_cmd,
+        ]
+        submit_request({
+            "type": "start",
+            "jid": self.jid,
+            "image": image,
+            "command": docker_command,
+            "working_dir": "/job-dir",
+            "volumes": {str(self.run_dir): {"bind": "/job-dir", "mode": "rw"}},
+        })
+        # XX TODO: This is a hack to avoid a race condition where
+        # _is_processing would return False for a moment after we call this.
+        # If we could wait for the scheduler daemon to acknowledge our request
+        # before returning, this would be unnecessary.
+        self._sent_start_request = True
+
+
+def init_class(app, uwsgi):
+    # XX TODO: what else should we do here? check if we can connect to redis
+    # and the service is running?
+    return ContainerJob

--- a/sirepo/runner/container.py
+++ b/sirepo/runner/container.py
@@ -1,75 +1,78 @@
+# -*- coding: utf-8 -*-
+u"""Run jobs in Docker.
+
+:copyright: Copyright (c) 2018-2019 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
 from sirepo import runner, simulation_db
-from base64 import b64encode
-from contextlib import contextmanager
-from functools import partial
-import logging
-import json
-import trio
+import base64
+import contextlib
 import docker
+import functools
+import json
+import logging
+from pykern.pkdebug import pkdp, pkdc, pkdlog, pkdexc
 import redis
 import requests
-
-__all__ = ["serve", "ContainerJob"]
-
-# XX TODO: what's the right way to do logging in pykern/sirepo?
-log = logging.getLogger(__name__)
+import shlex
+import trio
 
 # The redis key we use for the request list
-REQUEST_LIST_KEY = "seq:job_queue"
+_REQUEST_LIST_KEY = 'seq:job_queue'
 # The redis key we use for the job status hash
-JOB_STATUS_HASH_KEY = "hash:job_status"
+_JOB_STATUS_HASH_KEY = 'hash:job_status'
 
 # How often threaded blocking operations should wake up and check for Trio
 # cancellation
-CANCEL_POLL_INTERVAL = 1
+_CANCEL_POLL_INTERVAL = 1
 
 # Global connection pools (don't worry, they don't actually make any
 # connections until we start using them)
-REDIS = redis.from_url("redis://localhost:6379/0")
-DOCKER = docker.from_env()
+_REDIS = redis.from_url('redis://localhost:6379/0')
+_DOCKER = docker.from_env()
 
 
-def encode_request(request):
-    return json.dumps(request).encode("utf-8")
+def _encode_request(request):
+    return json.dumps(request).encode('utf-8')
 
 
-def decode_request(request):
-    return json.loads(request.decode("utf-8"))
+def _decode_request(request):
+    return json.loads(request.decode('utf-8'))
 
 
-def submit_request(request):
-    print("submitting:", request)
-    REDIS.rpush(REQUEST_LIST_KEY, encode_request(request))
+def _submit_request(request):
+    pkdc('submitting request: {!r}', request)
+    _REDIS.rpush(_REQUEST_LIST_KEY, _encode_request(request))
 
 
-# XX TODO: how to integrate this properly into pykern/sirepo's logging system?
-@contextmanager
-def catch_and_log_errors(exc_type, msg, *args, **kwargs):
+@contextlib.contextmanager
+def _catch_and_log_errors(exc_type, msg, *args, **kwargs):
     try:
         yield
-    except exc_type as exc:
-        log.exception(msg, *args, **kwargs)
+    except exc_type:
+        pkdlog(msg, *args, **kwargs)
+        pkdlog(pkdexc())
 
 
 # Helper to call redis blpop in a async/cancellation-friendly way
-async def pop_encoded_request():
+async def _pop_encoded_request():
     while True:
         retval = await trio.run_sync_in_worker_thread(
-            partial(
-                REDIS.blpop, [REQUEST_LIST_KEY], timeout=CANCEL_POLL_INTERVAL
+            functools.partial(
+                _REDIS.blpop, [_REQUEST_LIST_KEY], timeout=_CANCEL_POLL_INTERVAL
             )
         )
         if retval is not None:
-            _, encoded_request = retval
-            return encoded_request
+            # it's a pair (key, popped value)
+            return retval[1]
 
 
 # Helper to call docker wait in a async/cancellation-friendly way
-async def container_wait(container):
+async def _container_wait(container):
     while True:
         try:
             return await trio.run_sync_in_worker_thread(
-                partial(container.wait, timeout=CANCEL_POLL_INTERVAL)
+                functools.partial(container.wait, timeout=_CANCEL_POLL_INTERVAL)
             )
         # ReadTimeout is what the documentation says this raises.
         # ConnectionError is what it actually raises.
@@ -79,59 +82,58 @@ async def container_wait(container):
 
 
 # The core request handler
-async def handle_request(encoded_request):
-    with catch_and_log_errors(Exception, "error handling request %r", encoded_request):
-        request = decode_request(encoded_request)
-        if request["type"] == "start":
-            jid = request["jid"]
-            # XX TODO should we do any sanitization here? e.g. specifying
-            # arbitrary volumes allows arbitrary access to the host. Maybe
-            # that's fine though.
-            image = request["image"]
-            command = request["command"]
-            working_dir = request["working_dir"]
-            # format: {host path: {"bind": container path, "mode": "rw"}}
-            volumes = request["volumes"]
+async def _handle_request(encoded_request):
+    with _catch_and_log_errors(Exception, 'error handling request {!r}', encoded_request):
+        request = _decode_request(encoded_request)
+        if request['type'] == 'start':
             # Technically a blocking call, but redis is fast and local so we
             # can get away with it
-            REDIS.hset(JOB_STATUS_HASH_KEY, jid, b"running")
+            _REDIS.hset(_JOB_STATUS_HASH_KEY, request['jid'], b'running')
             # Start the container
             container = await trio.run_sync_in_worker_thread(
-                partial(
-                    DOCKER.containers.run,
-                    image,
-                    command,
-                    working_dir=working_dir,
-                    volumes=volumes,
-                    name=jid,
+                functools.partial(
+                    _DOCKER.containers.run,
+                    request['image'],
+                    request['command'],
+                    working_dir=request['working_dir'],
+                    # {host path: {'bind': container path, 'mode': 'rw'}}
+                    volumes=request['volumes'],
+                    name=request['jid'],
                     auto_remove=True,
                     detach=True,
+                    init=True,
                 )
             )
-            # Returns a dict like: {"Error": None, "StatusCode": 0}
-            print(await container_wait(container))
+            # Returns a dict like: {'Error': None, 'StatusCode': 0}
+            # XX TODO but there may be a race condition where if the container
+            # finishes before our call to wait() starts, then it just errors
+            # out with docker.errors.NotFound
+            pkdp(await _container_wait(container))
             # Technically a blocking call
-            REDIS.hset(JOB_STATUS_HASH_KEY, jid, b"finished")
-        elif request["type"] == "cancel":
-            jid = request["jid"]
-            container = DOCKER.containers.get(jid)
+            _REDIS.hset(_JOB_STATUS_HASH_KEY, request['jid'], b'finished')
+        elif request['type'] == 'cancel':
+            # This could fail, if the container doesn't exist or has already
+            # stopped, but _catch_and_log_errors catch the issue. We might
+            # want to catch and ignore expected errors like this, though,
+            # rather than letting them escape to _catch_and_log_errors?
+            container = _DOCKER.containers.get(request['jid'])
             container.stop()
             # Doesn't update status, because that will happen automatically
             # when it actually stops...
         else:
-            raise RuntimeError(f"unknown request type: {request['type']!r}")
+            raise RuntimeError(f'unknown request type: {request["type"]!r}')
 
 
-async def main():
+async def _main():
     async with trio.open_nursery() as nursery:
         while True:
-            encoded_request = await pop_encoded_request()
-            print("handling request:", encoded_request)
-            nursery.start_soon(handle_request, encoded_request)
+            encoded_request = await _pop_encoded_request()
+            pkdc('handling request: {!r}', encoded_request)
+            nursery.start_soon(_handle_request, encoded_request)
 
 
 def serve():
-    trio.run(main)
+    trio.run(_main)
 
 
 ################################################################
@@ -144,56 +146,33 @@ class ContainerJob(runner.JobBase):
         self._sent_start_request = False
 
     def _is_processing(self):
-        if (self._sent_start_request
-            and REDIS.hget(JOB_STATUS_HASH_KEY, self.jid) != b"finished"):
-            return True
-        return False
+        return (self._sent_start_request
+                and _REDIS.hget(_JOB_STATUS_HASH_KEY, self.jid) != b'finished')
 
     def _kill(self):
-        submit_request({"type": "cancel", "jid": self.jid})
+        _submit_request({'type': 'cancel', 'jid': self.jid})
 
     def _start(self):
         # XX TODO I suspect this is not the right place to do this but I don't
         # understand the status tracking flow yet.
         simulation_db.write_status('running', self.run_dir)
-        # XX TODO: this is a temporary hack, to work around sirepo's habit of
-        # hard-coding the host run_dir into the command line. Longer-term we
-        # need to untangle this.
-        cmd = list(self.cmd)
-        for i in range(len(cmd)):
-            if cmd[i] == self.run_dir:
-                cmd[i] = "/job-dir"
-        # XX TODO: this encoding thing is also a gnarly hack
-        # (1) for prototyping we want to work with the existing docker image,
-        # which requires we detour through bash to set up our environment,
-        # (2) self.cmd is already in the structured form we want to ultimately
-        # pass straight through to exec,
-        # (3) this means we need some hack to smuggle the real command
-        # through all the quoting layers.
-        #
-        # base64 is a blunt hammer, but it's easier than figuring out the
-        # details of all the different quoting systems.
-        encoded_cmd = b64encode(json.dumps(cmd).encode("utf-8"))
-        encoded_cmd = encoded_cmd.replace(b"\n", b"").replace(b" ", b"")
-        encoded_cmd = encoded_cmd.decode("ascii")
-        image = "radiasoft/sirepo"
+        # We can't just pass self.cmd directly to docker because we have to
+        # detour through bash to set up our environment. But we do assume that
+        # self.cmd is sufficiently well-behaved that shlex.quote will work.
+        image = 'radiasoft/sirepo'
         docker_command = [
-            "/home/vagrant/.radia-run/tini",
-            "--",
-            "/bin/bash",
-            "-c",
-            """
-            . ~/.bashrc
-            exec python3 -c 'import json, base64, os; cmd = json.loads(base64.b64decode("%s")); os.execvp(cmd[0], cmd)'
-            """ % encoded_cmd,
+            '/bin/bash',
+            '-c',
+            '. ~/.bashrc && ' + ' '.join(shlex.quote(c) for c in self.cmd),
         ]
-        submit_request({
-            "type": "start",
-            "jid": self.jid,
-            "image": image,
-            "command": docker_command,
-            "working_dir": "/job-dir",
-            "volumes": {str(self.run_dir): {"bind": "/job-dir", "mode": "rw"}},
+        _submit_request({
+            'type': 'start',
+            'jid': self.jid,
+            'image': image,
+            'command': docker_command,
+            'working_dir': str(self.run_dir),
+            'volumes': {str(self.run_dir):
+                          {'bind': str(self.run_dir), 'mode': 'rw'}},
         })
         # XX TODO: This is a hack to avoid a race condition where
         # _is_processing would return False for a moment after we call this.


### PR DESCRIPTION
**(Messy prototype, posting for discussion only, do not merge.)**

Here's a first draft of container runner functionality. It can
successfully run 'myapp', while routing everything through docker,
including cancellation.

In terms of scope, I think it currently covers everything in the SOW1
milestone, except that it doesn't use TLS to connect to docker,
doesn't do multi-host slot management, and has no automated tests.
There's definitely enough to start discussing though :-).

In order to get something working quickly, this uses a hybrid model,
with threads and classic blocking libraries (redis-py, docker-py) on
one hand, plus Trio to manage the threads, and a bit of glue to
integrate the threads into Trio's cancellation system (so e.g.
control-C works cleanly). This involves a small amount of polling. The
core functionality is actually very straightforward; the only really
messy part is the kluges in the `ContainerJob` class.

To test it out:

* Create vagrant system; install redhat-dev, sirepo-dev, redhat-docker
* Check out this branch of sirepo
* Inside vagrant system:
  * ~~sudo dnf install redis python3-devel~~
  * ~~sudo systemctl enable redis docker~~
  * ~~sudo systemctl start redis docker~~
  * ~~virtualenv -p python3 py3env~~
  * ~~py3env/bin/pip install h5py~~
  * ~~py3env/bin/pip install -r src/radiasoft/sirepo/container-runner-requirements.txt~~
  * `sudo systemctl enable docker`
  * `sudo systemctl start docker`
  * `sudo dnf install libffi-devel`  # needed by pyenv install
  * `_bivio_pyenv_version 3.7.1 py37`  # maybe this should become the default for `bivio_pyenv_3`?
  * `pip install -e src/radiasoft/pykern`  # has to be installed before installing sirepo
  * `pip install -r src/radiasoft/sirepo/container-runner-requirements.txt`
  * `pip install h5py pytz==2015.7`  # workaround some dependency weirdness... not sure why h5py is missing, but pytz is related to celery stuff so should go away when celery does
  * In window 1: `sirepo service container-runner`
  * In window 2: `SIREPO_RUNNER_JOB_CLASS=container sirepo service http`