### PR TITLE
Fixed bug introduced by previous fix of #1477

### DIFF
--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -2004,7 +2004,7 @@ SIREPO.app.directive('settingsMenu', function(appDataService, appState, fileMana
 
             $scope.copyItem = function() {
                 if(! $('#sr-jit-copy-confirmation')[0]) {
-                    $('body').append(copyConfModal);
+                    $('div[data-ng-view]').append(copyConfModal);
                 }
                 if(! $scope.doneLoadingSimList) {
                     loadList();
@@ -2065,10 +2065,6 @@ SIREPO.app.directive('settingsMenu', function(appDataService, appState, fileMana
                     '<filename>':  $scope.nav.simulationName() + '.' + extension,
                 }), '_blank');
             };
-
-            $scope.$on('$destroy', function() {
-                $('#sr-jit-copy-confirmation').remove();
-            });
 
             function loadList() {
                 appState.listSimulations(


### PR DESCRIPTION
Notes:

The page would intermittently stay in modal mode (forbidding interaction) after the copy from the simulation's settings menu was complete.  @moellep traced this to a probable race condition between hiding the dialog and removing it upon destruction.  We now add the dialog node to the 'ng-view' node instead of the body, so it gets wiped when the new page is loaded, obviating the need to remove it explicitly.  That should make it behave the same as copying from the simulations list