### PR TITLE
SRW: fix toroidal mirror templates

### DIFF
--- a/sirepo/package_data/template/srw/beamline_optics.py.jinja
+++ b/sirepo/package_data/template/srw/beamline_optics.py.jinja
@@ -240,7 +240,7 @@ v.op_{{ item.name }}_{{ nameMap.get(name, name) }}
                 _size_sag={{ field(item, 'sagittalSize') }},
                 _x={{ field(item, 'horizontalPosition') }},
                 _y={{ field(item, 'verticalPosition') }},
-                _ap_shape='{{ field(item, 'apertureShape') }}',
+                _ap_shape={{ field(item, 'apertureShape') }},
                 _nvx={{ field(item, 'normalVectorX') }},
                 _nvy={{ field(item, 'normalVectorY') }},
                 _nvz={{ field(item, 'normalVectorZ') }},

--- a/sirepo/package_data/template/srw/beamline_parameters.py.jinja
+++ b/sirepo/package_data/template/srw/beamline_parameters.py.jinja
@@ -52,8 +52,8 @@
     {{- fields(item, 's', ('heightProfileFile', 'orientation')) }}
     {{- fields(item, 'f', ('radius', 'tangentialSize', 'sagittalSize', 'grazingAngle', 'normalVectorX', 'normalVectorY', 'normalVectorZ', 'tangentialVectorX', 'tangentialVectorY', 'heightAmplification', 'horizontalOffset', 'verticalOffset')) }}
 {% elif item.type == 'toroidalMirror' %}
-    {{- fields(item, 's', ('heightProfileFile', 'orientation')) }}
-    {{- fields(item, 'f', ('tangentialRadius', 'sagittalRadius', 'tangentialSize', 'sagittalSize', 'horizontalPosition', 'verticalPosition', 'apertureShape', 'normalVectorX', 'normalVectorY', 'normalVectorZ', 'tangentialVectorX', 'tangentialVectorY')) }}
+    {{- fields(item, 's', ('heightProfileFile', 'orientation', 'apertureShape')) }}
+    {{- fields(item, 'f', ('tangentialRadius', 'sagittalRadius', 'tangentialSize', 'sagittalSize', 'horizontalPosition', 'verticalPosition', 'normalVectorX', 'normalVectorY', 'normalVectorZ', 'tangentialVectorX', 'tangentialVectorY')) }}
 {% elif item.type == 'zonePlate' %}
     {{- fields(item, 'f', ('outerRadius', 'thickness', 'mainRefractiveIndex', 'mainAttenuationLength', 'complementaryRefractiveIndex', 'complementaryAttenuationLength', 'horizontalOffset', 'verticalOffset')) }}
     {{- fields(item, 'i', ('numberOfZones', )) }}


### PR DESCRIPTION
The `apertureShape` parameter of the toroidal mirror was incorrectly rendered, and the assigned type was float (`f`) instead of string (`s`). This PR fixes the both issues.

This was reported at the [Sirepo tutorial in Berlin](https://indico.helmholtz-berlin.de/sessionDisplay.py?sessionId=6&confId=11#20190116). The original simulation archive is 
[ttttttt.zip](https://github.com/radiasoft/sirepo/files/2788972/ttttttt.zip), and the corresponding simulation is at https://beta.sirepo.com/srw#/beamline/AepDZ2t1. However, it can be easily reproduced by creating a new simulation and putting the toroidal mirror on the beamline page.