### PR TITLE
Curve fitting #1555

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ pykern.pksetup.setup(
         # requests-oauthlib-1.2.0 forces oauthlib-3.0.0 but Flask-OAuthlib
         # requires oauthlib<3.0.0.
         'requests-oauthlib==1.1.0',
+        'sympy',
         'uwsgi',
         'trio >= 0.11.0; python_version >= "3"',
         'docker; python_version >= "3"',

--- a/sirepo/package_data/static/html/webcon-analysis.html
+++ b/sirepo/package_data/static/html/webcon-analysis.html
@@ -6,5 +6,8 @@
     <div class="col-md-6" data-ng-if="analysis.hasFile()">
       <div data-report-panel="parameter" data-model-name="analysisAnimation"></div>
     </div>
+    <div class="col-md-6" data-ng-if="analysis.hasFile()">
+        <div data-fit-report="" data-parent-controller="analysis"></div>
+    </div>
   </div>
 </div>

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -2730,6 +2730,8 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
         controller: function($scope) {
             var includeForDomain = [];
             var plotLabels = [];
+            var childPlots = {};
+
             $scope.focusPoints = [];
             $scope.focusStrategy = 'closest';
             $scope.wantLegend = true;
@@ -2754,6 +2756,9 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                 }
                 var itemWidth;
                 plots.forEach(function(plot, i) {
+                    if(plot._parent) {
+                        return;
+                    }
                     plotLabels.push(plot.label);
                     var item = legend.append('g').attr('class', 'sr-plot-legend-item');
                     item.append('text')
@@ -2799,7 +2804,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
             }
 
             function plotPath(pIndex) {
-                return d3.select(selectAll('.plot-viewport path')[0][pIndex]);
+                return d3.select(selectAll('.plot-viewport .param-plot')[0][pIndex]);
             }
 
             function selectAll(selector) {
@@ -2836,6 +2841,9 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
 
             function togglePlot(pIndex) {
                 setPlotVisible(pIndex, isPlotVisible(pIndex));
+                (childPlots[pIndex] || []).forEach(function (i) {
+                    setPlotVisible(i, isPlotVisible(i));
+                });
             }
 
             function vIcon(pIndex) {
@@ -2928,6 +2936,19 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                 viewport.selectAll('.line').remove();
                 createLegend(plots);
                 plots.forEach(function(plot, i) {
+                    var strokeWidth = 2.0;
+                    if(plot._parent) {
+                        strokeWidth = 1.0;
+                        var parent = plots.filter(function (p, j) {
+                            return j !== i && p.label === plot._parent;
+                        })[0];
+                        if(parent) {
+                            var pIndex = plots.indexOf(parent);
+                            var cp = childPlots[pIndex] || [];
+                            cp.push(i);
+                            childPlots[pIndex] = cp;
+                        }
+                    }
                     viewport.append('path')
                         .attr('class', 'line line-color')
                         .style('stroke', plot.color)

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -2950,7 +2950,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                         }
                     }
                     viewport.append('path')
-                        .attr('class', 'line line-color')
+                        .attr('class', 'param-plot line line-color')
                         .style('stroke', plot.color)
                         .datum(plot.points);
                     // must create extra focus points here since we don't know how many to make

--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -157,7 +157,7 @@ SIREPO.app.directive('equation', function(appState, webconService) {
         controller: function ($scope) {
             $scope.webconservice = webconService;
 
-            srdbg('eq', $scope.model[$scope.field], 'tokens', tokenizeEquation());
+            //srdbg('eq', $scope.model[$scope.field], 'tokens', tokenizeEquation());
 
             function tokenizeEquation() {
                 var reserved = ['sin', 'cos', 'tan', 'csc', 'sec', 'cot', 'exp', 'abs'];

--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -10,6 +10,16 @@ SIREPO.appFieldEditors = [
     '<div data-ng-switch-when="AnalysisOptionalParameter" class="col-sm-5">',
       '<div data-analysis-parameter="" data-model="model" data-field="field" data-is-optional="true"></div>',
     '</div>',
+    '<div data-ng-switch-when="Equation" class="col-sm-7">',
+      '<div data-equation="equation" data-model="model" data-field="field"></div>',
+      '<div class="sr-input-warning" data-ng-show="showWarning">{{warningText}}</div>',
+    '</div>',
+    '<div data-ng-switch-when="EquationVariables" class="col-sm-7">',
+      '<div data-equation-variables="" data-model="model" data-field="field" data-form="form" data-is-variable="true"></div>',
+    '</div>',
+    '<div data-ng-switch-when="EquationParameters" class="col-sm-7">',
+      '<div data-equation-variables="" data-model="model" data-field="field" data-form="form" data-is-variable="false"></div>',
+    '</div>',
 ].join('');
 
 SIREPO.app.factory('webconService', function(appState) {
@@ -37,6 +47,10 @@ SIREPO.app.controller('AnalysisController', function (appState, frameCache, pane
 
     self.hasFile = function() {
         return appState.isLoaded() && appState.applicationState().analysisData.file;
+    };
+
+    self.isFitterConfigured = function() {
+        return appState.models.fitter.equation && appState.models.fitter.variable && appState.models.fitter.parameters;
     };
 
     appState.whenModelsLoaded($scope, function() {
@@ -126,5 +140,84 @@ SIREPO.app.directive('appHeader', function(appState, panelState) {
               '</app-header-right-sim-list>',
             '</div>',
 	].join(''),
+    };
+});
+
+SIREPO.app.directive('equation', function(appState, webconService) {
+    return {
+        scope: {
+            model: '=',
+            field: '='
+        },
+        template: [
+            '<div>',
+                '<input type="text" data-ng-model="model[field]" class="form-control" required>',
+            '</div>',
+        ].join(''),
+        controller: function ($scope) {
+            $scope.webconservice = webconService;
+
+            srdbg('eq', $scope.model[$scope.field], 'tokens', tokenizeEquation());
+
+            function tokenizeEquation() {
+                var reserved = ['sin', 'cos', 'tan', 'csc', 'sec', 'cot', 'exp', 'abs'];
+                var tokens = $scope.model[$scope.field].split(/[-+*/^|%().0-9\s+]/)
+                    .filter(function (t) {
+                        return t.length > 0 && reserved.indexOf(t.toLowerCase()) < 0;
+                });
+                //tokens = tokens.filter(function (t) {
+                //    return tokens.indexOf(t) === tokens.lastIndexOf(t);
+                //});
+                return tokens;
+            }
+        },
+    };
+});
+
+SIREPO.app.directive('equationVariables', function() {
+    return {
+        restrict: 'A',
+        scope: {
+            field: '=',
+            form: '=',
+            isVariable: '<',
+            model: '=',
+        },
+        template: [
+            '<div>',
+                '<input type="text" data-ng-model="model[field]" data-valid-variable-or-param="" class="form-control" required />',
+            '</div>',
+            '<div class="sr-input-warning" data-ng-show="warningText.length > 0">{{warningText}}</div>',
+        ].join(''),
+        controller: function($scope, $element) {
+            var reserved = ['sin', 'cos', 'tan', 'abs'];
+
+            $scope.equation = $scope.model.equation;
+        },
+    };
+});
+
+SIREPO.app.directive('fitReport', function(appState, mathRendering) {
+    return {
+        scope: {
+            controller: '=parentController',
+        },
+        template: [
+            '<div data-basic-editor-panel="" data-view-name="fitter" data-parent-controller="controller"></div>',
+            '<div data-ng-if="controller.isFitterConfigured()" data-report-panel="parameter" data-request-priority="1" data-model-name="fitReport">',
+            '</div>',
+        ].join(''),
+        controller: function($scope) {
+
+            $scope.$on('fitter.changed', function() {
+                appState.saveChanges('fitReport', function () {
+                });
+            });
+            $scope.$on('fitReport.changed', function() {
+                var focusText = $('.focus-hint');
+                var str = '';
+            });
+
+        },
     };
 });

--- a/sirepo/package_data/static/json/webcon-schema.json
+++ b/sirepo/package_data/static/json/webcon-schema.json
@@ -29,6 +29,17 @@
             "y2": ["Y2 Value", "AnalysisOptionalParameter", "2"],
             "y3": ["Y3 Value", "AnalysisOptionalParameter", "none"],
             "notes": ["Notes", "Text", ""]
+        },
+         "fitter": {
+            "equation": ["Equation to Fit", "Equation"],
+            "parameters": ["Fit Parameters", "EquationParameters", ""],
+            "variable": ["Independent Variable", "EquationVariables", ""]
+        },
+        "fitReport": {
+            "parameterSigmas": ["_", "String", ""],
+            "parameterValues": ["_", "String", ""],
+            "x": ["X", "AnalysisParameter", "0"],
+            "y": ["Y", "AnalysisParameter", "1"]
         }
     },
     "view": {
@@ -47,6 +58,22 @@
                 "y2",
                 "y3",
                 "notes"
+            ]
+        },
+        "fitter": {
+            "title": "Fitter",
+            "basic": [
+                "equation",
+                "variable",
+                "parameters"
+            ],
+            "advanced": []
+        },
+        "fitReport": {
+            "title": "Best Fit",
+            "advanced": [
+                "x",
+                "y"
             ]
         }
     }

--- a/sirepo/pkcli/webcon.py
+++ b/sirepo/pkcli/webcon.py
@@ -14,6 +14,13 @@ import sirepo.template.webcon as template
 
 _SCHEMA = simulation_db.get_schema(template.SIM_TYPE)
 
+def run(cfg_dir):
+    with pkio.save_chdir(cfg_dir):
+        data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
+        if data['report'] == 'fitReport':
+            res = template.get_fit(data)
+        simulation_db.write_result(res)
+
 def run_background(cfg_dir):
     with pkio.save_chdir(cfg_dir):
         simulation_db.write_result({})

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -77,7 +77,7 @@ def compute_plot_color_and_range(plots):
     y_range = None
     for i in range(len(plots)):
         plot = plots[i]
-        plot['color'] = _PLOT_LINE_COLOR[i]
+        plot['color'] = _PLOT_LINE_COLOR[i % len(_PLOT_LINE_COLOR)]
         vmin = min(plot['points'])
         vmax = max(plot['points'])
         if y_range:
@@ -87,6 +87,13 @@ def compute_plot_color_and_range(plots):
                 y_range[1] = vmax
         else:
             y_range = [vmin, vmax]
+    # color child plots the same as parent
+    for c in [p for p in plots if '_parent' in p]:
+        p_label = plot['_parent']
+        for p in plots:
+            if p['label'] == p_label:
+                c['color'] = p['color']
+                break
     return y_range
 
 

--- a/sirepo/template/webcon.py
+++ b/sirepo/template/webcon.py
@@ -12,7 +12,6 @@ from pykern.pkdebug import pkdc, pkdp
 from sirepo import simulation_db
 from sirepo.template import template_common
 
-import scipy
 import sympy
 import csv
 import math
@@ -224,6 +223,8 @@ def _column_info(path):
 
 
 def _fit_to_equation(x, y, equation, var, params):
+
+    import scipy.optimize
 
     # TODO: must sanitize input - sympy uses eval
     sym_curve = sympy.sympify(equation)

--- a/sirepo/template/webcon.py
+++ b/sirepo/template/webcon.py
@@ -10,7 +10,7 @@ from pykern import pkio
 from pykern import pkjinja
 from pykern.pkdebug import pkdc, pkdp
 from scipy.optimize import curve_fit
-import sympy as sp
+import sympy
 from sirepo import simulation_db
 from sirepo.template import template_common
 import csv
@@ -171,7 +171,7 @@ def validate_file(file_type, path):
 
 def validate_sympy(str):
     try:
-        sp.sympify(str)
+        sympy.sympify(str)
         return True
     except:
         return False
@@ -225,11 +225,11 @@ def _column_info(path):
 def _fit_to_equation(x, y, equation, var, params):
 
     # TODO: must sanitize input - sympy uses eval
-    sym_curve = sp.sympify(equation)
+    sym_curve = sympy.sympify(equation)
     sym_str = var + ' ' + ' '.join(params)
 
-    syms = sp.symbols(sym_str)
-    sym_curve_l = sp.lambdify(syms, sym_curve, 'numpy')
+    syms = sympy.symbols(sym_str)
+    sym_curve_l = sympy.lambdify(syms, sym_curve, 'numpy')
 
     # feed a uniform x distribution to the function?  or sort?
     #x_uniform = np.linspace(np.min(x), np.max(x), 100)
@@ -259,11 +259,11 @@ def _fit_to_equation(x, y, equation, var, params):
     # used for the laTeX label - rounding should take size of uncertainty into account
     y_fit_rounded = sym_curve.subs(p_rounded)
 
-    y_fit_l = sp.lambdify(var, y_fit, 'numpy')
-    y_fit_min_l = sp.lambdify(var, y_fit_min, 'numpy')
-    y_fit_max_l = sp.lambdify(var, y_fit_max, 'numpy')
+    y_fit_l = sympy.lambdify(var, y_fit, 'numpy')
+    y_fit_min_l = sympy.lambdify(var, y_fit_min, 'numpy')
+    y_fit_max_l = sympy.lambdify(var, y_fit_max, 'numpy')
 
-    return y_fit_l(x), y_fit_min_l(x), y_fit_max_l(x), p_vals, sp.latex(y_fit_rounded)
+    return y_fit_l(x), y_fit_min_l(x), y_fit_max_l(x), p_vals, sympy.latex(y_fit_rounded)
 
 
 def _generate_parameters_file(data):

--- a/sirepo/template/webcon.py
+++ b/sirepo/template/webcon.py
@@ -9,10 +9,11 @@ from pykern import pkcollections
 from pykern import pkio
 from pykern import pkjinja
 from pykern.pkdebug import pkdc, pkdp
-from scipy.optimize import curve_fit
-import sympy
 from sirepo import simulation_db
 from sirepo.template import template_common
+
+import scipy
+import sympy
 import csv
 import math
 import numpy as np
@@ -234,7 +235,7 @@ def _fit_to_equation(x, y, equation, var, params):
     # feed a uniform x distribution to the function?  or sort?
     #x_uniform = np.linspace(np.min(x), np.max(x), 100)
 
-    p_vals, pcov = curve_fit(sym_curve_l, x, y, maxfev=500000)
+    p_vals, pcov = scipy.optimize.curve_fit(sym_curve_l, x, y, maxfev=500000)
     sigma = np.sqrt(np.diagonal(pcov))
 
     p_subs = []


### PR DESCRIPTION
This adds fitting data to a user-specified curve parsed by the ```sympy``` package.

Notes:
- Currently assumes the data to be fit is in order along the "x" axis
- Displays 2-standard-deviation (95%) confidence bands
- As part of the above, introduces the concept of "parent/child" plots.  Children have an attribute ```_parent``` whose value is the label of another plot, though we can use a name or id or whatever.  Child plots share the color and visibility of their parents