### PR TITLE
FIX: misspelled attribute name "py_pth"

### DIFF
--- a/sirepo/srdb.py
+++ b/sirepo/srdb.py
@@ -76,7 +76,7 @@ def _init_root(*args):
         # but should be reliable.
         if not root.join('requirements.txt').check():
             # Don't run from an install directory
-            root = pkio.py_pth.local('.')
+            root = pkio.py_path.local('.')
         v = pkio.mkdir_parent(root.join(_DEFAULT_ROOT))
     _root = v
 


### PR DESCRIPTION
When running sirepo in a fresh Docker container on the beta channel, the following problem is observed:
```py
[py2; /]$ sirepo service http
Traceback (most recent call last):
  File "/home/vagrant/.pyenv/versions/py2/bin/sirepo", line 10, in <module>
    sys.exit(main())
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/sirepo/sirepo_console.py", line 18, in main
    return pkcli.main('sirepo')
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/pykern/pkcli/__init__.py", line 98, in main
    argh.dispatch(parser, argv=argv)
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/argh/dispatching.py", line 174, in dispatch
    for line in lines:
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/argh/dispatching.py", line 277, in _execute_command
    for line in result:
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/argh/dispatching.py", line 260, in _call
    result = function(*positional, **keywords)
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/sirepo/pkcli/service.py", line 62, in http
    from sirepo import server
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/sirepo/server.py", line 1076, in <module>
    backend=('local', str, 'Select runner daemon backend (e.g. "local", "docker")'),
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/pykern/pkconfig.py", line 369, in init
    _iter_decls(decls, res)
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/pykern/pkconfig.py", line 671, in _iter_decls
    r[kp] = _resolver(d)(k, d)
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/pykern/pkconfig.py", line 750, in _resolve_value
    return decl.parser(res)
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/sirepo/server.py", line 735, in _cfg_db_dir
    return srdb.root()
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/sirepo/srdb.py", line 34, in root
    _init_root()
  File "/home/vagrant/.pyenv/versions/2.7.14/envs/py2/lib/python2.7/site-packages/sirepo/srdb.py", line 79, in _init_root
    root = pkio.py_pth.local('.')
AttributeError: 'module' object has no attribute 'py_pth'
```
The error was also observed with @awalter-bnl when running Sirepo directly from sources.

This PR fixes it.