### PR TITLE
Webcon epics plots

### DIFF
--- a/sirepo/package_data/static/html/webcon-controls.html
+++ b/sirepo/package_data/static/html/webcon-controls.html
@@ -32,12 +32,7 @@
   <div class="row">
     <div data-ng-repeat="item in controls.watches track by $index">
       <div class="col-sm-6 col-md-3">
-        <div data-basic-editor-panel="" data-view-name="{{ item.viewName }}" data-model-data="item" data-panel-title="{{ item.title }}">
-          TODO: Centroid history plot
-          <div data-ng-if="item.element.hpos != undefined">
-            X, Y: {{ item.element.hpos }}, {{ item.element.vpos }}
-          </div>
-        </div>
+        <div data-report-panel="parameter" data-view-name="WATCH" data-model-data="item" data-panel-title="{{ item.title }}"></div>
       </div>
     </div>
   </div>

--- a/sirepo/package_data/static/html/webcon-controls.html
+++ b/sirepo/package_data/static/html/webcon-controls.html
@@ -12,6 +12,11 @@
   <div class="row">
     <div data-webcon-lattice=""></div>
   </div>
+    <div class="row">
+        <div class="col-sm-6 col-md-3">
+            <button class="btn btn-default" data-ng-disabled="controls.isConnectedToEPICS()" data-ng-click="controls.reset()">Reset</button>
+        </div>
+    </div>
   <div class="row">
     <div data-ng-repeat="col in controls.editorColumns track by $index">
       <div class="col-sm-6 col-md-3">
@@ -41,10 +46,10 @@
       <div data-basic-editor-panel="" data-view-name="bunch" data-ng-show="! controls.isRemoteServer()"></div>
     </div>
     <div class="col-md-6 col-xl-4">
-      <div data-report-content="parameter" data-model-key="beamPositionAnimation"</div>
+      <div data-report-content="parameter" data-model-key="beamPositionAnimation"></div>
     </div>
     <div class="col-md-6 col-xl-4">
-      <div data-report-content="parameter" data-model-key="correctorSettingAnimation"</div>
+      <div data-control-corrector-report="" data-parent-controller="controls"></div>
     </div>
   </div>
 </div>

--- a/sirepo/package_data/static/html/webcon-controls.html
+++ b/sirepo/package_data/static/html/webcon-controls.html
@@ -32,7 +32,7 @@
   <div class="row">
     <div data-ng-repeat="item in controls.watches track by $index">
       <div class="col-sm-6 col-md-3">
-        <div data-report-panel="parameter" data-view-name="WATCH" data-model-data="item" data-panel-title="{{ item.title }}"></div>
+        <div data-report-panel="parameter" data-model-name="watchpointReport" data-model-data="item" data-panel-title="{{ item.title }}"></div>
       </div>
     </div>
   </div>

--- a/sirepo/package_data/static/html/webcon-controls.html
+++ b/sirepo/package_data/static/html/webcon-controls.html
@@ -46,7 +46,7 @@
       <div data-basic-editor-panel="" data-view-name="bunch" data-ng-show="! controls.isRemoteServer()"></div>
     </div>
     <div class="col-md-6 col-xl-4">
-      <div data-report-content="parameter" data-model-key="beamPositionAnimation"></div>
+      <div data-control-beam-position-report="" data-parent-controller="controls"></div>
     </div>
     <div class="col-md-6 col-xl-4">
       <div data-control-corrector-report="" data-parent-controller="controls"></div>

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -420,14 +420,14 @@ SIREPO.app.factory('plotting', function(appState, frameCache, panelState, utilit
             return fmt(v);
         },
 
-        getAspectRatio: function(modelName, json) {
+        getAspectRatio: function(modelName, json, defaultRatio) {
             if (appState.isLoaded() && appState.applicationState()[modelName]) {
                 var ratioEnum = appState.applicationState()[modelName].aspectRatio;
                 if (ratioEnum) {
                     return parseFloat(ratioEnum);
                 }
             }
-            return json.aspectRatio || 1.0;
+            return json.aspectRatio || defaultRatio || 1.0;
         },
 
         initialHeight: function(scope) {
@@ -2986,6 +2986,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                 includeForDomain.length = 0;
                 $scope.isZoomXY = json.zoom_x_y;
                 $scope.doAdjustDomain = ! json.fixed_y_range;
+                $scope.aspectRatio = plotting.getAspectRatio($scope.modelName, json, 4.0 / 7);
                 // data may contain 2 plots (y1, y2) or multiple plots (plots)
                 var plots = json.plots || [
                     {

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -2853,14 +2853,16 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                 var s = reverse ? end : start;
                 var e = reverse ? start : end;
                 if (steps <= 1) {
-                    return [end];
+                    return [e];
                 }
                 var rgbaSteps = [];
                 for (var i  = 0; i < steps; ++i) {
-                    var c = s.map(function (startComp, j) {
+                    var c = [];
+                    for (var j = 0; j < 4; ++j) {
+                        var startComp = s[j];
                         var endComp = e[j];
-                        return startComp + i * (endComp - startComp) / (steps - 1);
-                    });
+                        c.push(startComp + i * (endComp - startComp) / (steps - 1));
+                    }
                     rgbaSteps.push(c);
                 }
                 return rgbaSteps;
@@ -3035,6 +3037,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                     var pointColorMod = modulateRGBA(color, endColor, plot.points.length, reverseMod);
                     var plotColorMod = modulateRGBA(color, endColor, plots.length, reverseMod);
                     var strokeWidth = plot._parent ? 0.75 : 2.0;
+                    var sym;
                     if (plot.symbol) {
                         $scope.hasSymbols = true;
                     }
@@ -3050,7 +3053,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                             circleRadius = 4;
                         }
                         if (plot.symbol) {
-                            var sym = d3.svg.symbol().size(symbolSize).type(plot.symbol);
+                            sym = d3.svg.symbol().size(symbolSize).type(plot.symbol);
                             viewport.append('g')
                             .attr('class', 'param-plot')
                             .attr('index', ip)
@@ -3097,10 +3100,10 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                             .style('stroke-width', strokeWidth)
                             .datum(plot.points);
                         if (plot.dashes) {
-                            p.style('stroke-dasharray', (plot.dashes))
+                            p.style('stroke-dasharray', (plot.dashes));
                         }
                         if (plot.symbol) {
-                            var sym = d3.svg.symbol().size(symbolSize / 2.0).type(plot.symbol);
+                            sym = d3.svg.symbol().size(symbolSize / 2.0).type(plot.symbol);
                             viewport.append('g')
                                 .attr('index', ip)
                                 .attr('class', 'param-plot').selectAll('.data-point')

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -2838,7 +2838,9 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
             }
 
             function plotPath(pIndex) {
-                return d3.select(selectAll('.plot-viewport .param-plot')[0][pIndex]);
+                var sel = '.plot-viewport .param-plot[index=\'' + pIndex + '\']';
+                //return d3.select(selectAll('.plot-viewport .param-plot')[0][pIndex]);
+                return d3.selectAll(selectAll(sel)[0]);
             }
 
             function selectAll(selector) {
@@ -3015,6 +3017,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                             var sym = d3.svg.symbol().size(symbolSize).type(plot.symbol);
                             viewport.append('g')
                             .attr('class', 'param-plot')
+                            .attr('index', i)
                             .selectAll('.scatter-point')
                                 .data(plot.points)
                                 .enter()
@@ -3040,6 +3043,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                         else {
                             viewport.append('g')
                             .attr('class', 'param-plot')
+                            .attr('index', i)
                             .selectAll('.scatter-point')
                                 .data(plot.points)
                                 .enter()
@@ -3057,6 +3061,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                     else {
                         var p = viewport.append('path')
                             .attr('class', 'param-plot line line-color')
+                            .attr('index', i)
                             .style('stroke', plot.color)
                             .style('stroke-width', strokeWidth)
                             .datum(plot.points);
@@ -3066,6 +3071,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                         if (plot.symbol) {
                             var sym = d3.svg.symbol().size(symbolSize / 2.0).type(plot.symbol);
                             viewport.append('g')
+                                .attr('index', i)
                                 .attr('class', 'param-plot').selectAll('.data-point')
                                 .data(plot.points)
                                 .enter()
@@ -3169,7 +3175,12 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
             };
 
             $scope.refresh = function() {
-                $scope.select('.plot-viewport').selectAll('.line').attr('d', $scope.graphLine);
+                //$scope.select('.plot-viewport').selectAll('.line').attr('d', $scope.graphLine);
+                $scope.select('.plot-viewport').selectAll('.line')
+                    .each(function (d, i) {
+                        d3.select(this).attr('d', $scope.plotGraphLine(i));
+                    });
+
                 $scope.select('.plot-viewport').selectAll('g.param-plot')
                     .each(function (d, i) {
                         var sp = d3.select(this).selectAll('.scatter-point');
@@ -3186,23 +3197,10 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                                     });
                             }
                             else {
-                                p.attr('cx', $scope.plotGraphLine(i).x())
+                                pt.attr('cx', $scope.plotGraphLine(i).x())
                                     .attr('cy', $scope.plotGraphLine(i).y());
                             }
                         });
-                        /*
-                        if ($scope.axes.y.plots[i].symbol) {
-                            sp.attr('x', $scope.plotGraphLine(i).x())
-                                .attr('y', $scope.plotGraphLine(i).y())
-                                .attr('transform', function (d) {
-                                    return 'translate(' + d3.select(this).attr('x') + ',' + d3.select(this).attr('y') + ')';
-                                });
-                        }
-                        else {
-                            sp.attr('cx', $scope.plotGraphLine(i).x())
-                                .attr('cy', $scope.plotGraphLine(i).y());
-                        }
-                        */
                 });
 
                 $scope.focusPoints.forEach(function(fp) {

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -2844,7 +2844,6 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
             }
 
             function modulateRGBA(start, end, steps, reverse) {
-                var rgbaSteps = [];
                 if (! start[3]) {
                     start.push(1.0);
                 }
@@ -2853,10 +2852,14 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                 }
                 var s = reverse ? end : start;
                 var e = reverse ? start : end;
+                if (steps <= 1) {
+                    return [end];
+                }
+                var rgbaSteps = [];
                 for (var i  = 0; i < steps; ++i) {
                     var c = s.map(function (startComp, j) {
                         var endComp = e[j];
-                        return startComp + i * (endComp - startComp) / steps;
+                        return startComp + i * (endComp - startComp) / (steps - 1);
                     });
                     rgbaSteps.push(c);
                 }

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -472,8 +472,10 @@ SIREPO.app.factory('plotting', function(appState, frameCache, panelState, utilit
                 scope.resize();
             }, 250);
 
+            // also emit so scopes in either direction can see
             scope.broadcastEvent = function(args) {
                 scope.$broadcast('sr-plotEvent', args);
+                scope.$emit('sr-plotEvent', args);
             };
 
             scope.$on('$destroy', function() {
@@ -2993,6 +2995,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
 
                 $scope.hasSymbols = false;
 
+                $scope.axes.y.plots = plots;
                 var legendCount = createLegend(plots);
                 plots.forEach(function(plot, i) {
                     var color = plotting.colorsFromHexString(plot.color, 1.0);
@@ -3114,7 +3117,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                     setPlotVisible(i, true);
                 });
 
-                $scope.axes.y.plots = plots;
+                //$scope.axes.y.plots = plots;
                 for (var fpIndex = 0; fpIndex < $scope.focusPoints.length; ++fpIndex) {
                     if (fpIndex < plots.length) {
                         $scope.focusPoints[fpIndex].config.color = plots[fpIndex].color;
@@ -3168,11 +3171,11 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                         ydom[0] = 0;
                     }
                     $scope.axes.y.scale.domain([ydom[0] - $scope.domPadding.y, ydom[1] + $scope.domPadding.y]).nice();
-                    //$scope.axes.y.scale.domain(ydom).nice();
                 }
             };
 
             $scope.refresh = function() {
+                // need to wait for the screen dimensions to be set, then calculate the padding once
                 if ($scope.firstRefresh) {
                     $scope.firstRefresh = false;
                     if ($scope.hasSymbols) {
@@ -3181,11 +3184,9 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                                 $scope.axes[dim].scale.invert(0));
                         }
                     }
-                    $scope.$apply(function () {
-                        $scope.setYDomain();
-                        $scope.padXDomain();
-                        $scope.axes.x.scale.domain($scope.axes.x.domain);
-                    });
+                    $scope.setYDomain();
+                    $scope.padXDomain();
+                    $scope.axes.x.scale.domain($scope.axes.x.domain);
                 }
 
                 $scope.select('.plot-viewport').selectAll('.line')
@@ -3214,6 +3215,9 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                             }
                         });
                 });
+                $scope.broadcastEvent({
+                    name: 'retranslate'
+                });
 
                 $scope.focusPoints.forEach(function(fp) {
                     focusPointService.refreshFocusPoint(fp, $scope);
@@ -3241,7 +3245,6 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                 else {
                     var vd = visibleDomain();
                     $scope.axes.y.scale.domain([vd[0] - $scope.domPadding.y, vd[1] + $scope.domPadding.y]).nice();
-                    //$scope.axes.y.scale.domain(visibleDomain()).nice();
                 }
             };
         },

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -2736,7 +2736,6 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
     return {
         restrict: 'A',
         scope: {
-            axisStyle: '<',
             reportId: '<',
             modelName: '@',
         },
@@ -2958,8 +2957,7 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
 
             $scope.init = function() {
                 plot2dService.init2dPlot($scope, {
-                    margin: {top: 50, right: 23, bottom: 50, left: 75},
-                    isZoomXY: true,
+                    margin: {top: 50, right: 23, bottom: 50, left: 75}
                 });
                 // override graphLine to work with multiple point sets
                 $scope.plotGraphLine = function(plotIndex) {
@@ -2986,7 +2984,6 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
                 //TODO(pjm): move first part into normalizeInput()
                 childPlots = {};
                 includeForDomain.length = 0;
-                $scope.isZoomXY = json.zoom_x_y;
                 $scope.doAdjustDomain = ! json.fixed_y_range;
                 $scope.aspectRatio = plotting.getAspectRatio($scope.modelName, json, 4.0 / 7);
                 // data may contain 2 plots (y1, y2) or multiple plots (plots)
@@ -3280,7 +3277,6 @@ SIREPO.app.directive('parameterPlot', function(appState, focusPointService, layo
         },
     };
 });
-
 
 SIREPO.app.directive('particle', function(plotting, plot2dService) {
     return {

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1134,7 +1134,8 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
     self.getStatusText = function(name) {
         if (self.isRunning(name)) {
             var count = (queueItems[name] && queueItems[name].runStatusCount) || 0;
-            return 'Simulating ' + new Array(count % 3 + 2).join('.');
+            return ((appState.models[name] || {}).inProgressText || 'Simulating') + ' ' +
+                new Array(count % 3 + 2).join('.');
         }
         return 'Waiting';
     };

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1134,8 +1134,10 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
     self.getStatusText = function(name) {
         if (self.isRunning(name)) {
             var count = (queueItems[name] && queueItems[name].runStatusCount) || 0;
-            return ((appState.models[name] || {}).inProgressText || 'Simulating') + ' ' +
-                new Array(count % 3 + 2).join('.');
+            var progressText = SIREPO.APP_SCHEMA.constants.inProgressText ||
+                (appState.models[name] || {}).inProgressText ||
+                'Simulating';
+            return progressText + ' ' + new Array(count % 3 + 2).join('.');
         }
         return 'Waiting';
     };

--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -229,7 +229,7 @@ SIREPO.app.controller('ControlsController', function (appState, frameCache, pane
             }
             self.monitorToModelFields[t].push(map);
         });
-        srdbg(self.monitorToModelFields);
+        //srdbg(self.monitorToModelFields);
     }
 
     function elementForId(id) {
@@ -567,7 +567,7 @@ SIREPO.app.controller('ControlsController', function (appState, frameCache, pane
 
     self.simState = persistentSimulation.initSimulationState($scope, 'epicsServerAnimation', handleStatus, {
         //TODO(pjm): add beamPositionAnimation and correctorSettingAnimation info here
-        'correctorSettingAnimation': [SIREPO.ANIMATION_ARGS_VERSION + '1', 'startTime']
+        //'correctorSettingAnimation': [SIREPO.ANIMATION_ARGS_VERSION + '1', 'startTime']
     });
 
     return self;
@@ -942,7 +942,8 @@ SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, pa
             var history = [];
             var spread = [40.0, 0];
 
-            $scope.modelName = 'correctorSettingAnimation';
+            //$scope.modelName = 'correctorSettingAnimation';
+            $scope.modelName = 'correctorSettingReport';
             $scope.spreadView = false;
 
             $scope.init = function() {
@@ -975,9 +976,9 @@ SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, pa
             };
 
            $scope.showSpreadButton = function() {
-                //return canToggleSpread && (appState.models.correctorSettingReport || {}).plotOrder == 'position'
+                return canToggleSpread && (appState.models.correctorSettingReport || {}).plotOrder == 'position'
                 //srdbg('spread', appState.models.correctorSettingAnimation);
-                return (appState.models.correctorSettingAnimation || {}).plotOrder == 'position'
+                //return (appState.models.correctorSettingAnimation || {}).plotOrder == 'position'
            };
 
            $scope.spreadButtonText = function () {
@@ -1000,12 +1001,14 @@ SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, pa
                 }
             });
 
+            /*
             $scope.$on('correctorSettingAnimation.summaryData', function (e, data) {
                 srdbg('correctorSettingAnimation sum data', data);
                 if (! $scope.showSpreadButton()) {
                     return;
                 }
             });
+            */
             $scope.$on('modelChanged', update);
 
 
@@ -1051,7 +1054,7 @@ SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, pa
                 if ( $scope.parentController.kickers().indexOf(name) < 0) {
                     return;
                 }
-                srdbg('update from kicker', name, appState.models[name]);
+                //srdbg('update from kicker', name, appState.models[name]);
                 var m = appState.models[name];
             }
 
@@ -1066,9 +1069,9 @@ SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, pa
             */
 
         },
-        link: function link(scope, element) {
-            plotting.linkPlot(scope, element);
-        },
+        //link: function link(scope, element) {
+        //    plotting.linkPlot(scope, element);
+        //},
     };
 });
 

--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -925,6 +925,27 @@ SIREPO.app.directive('clusterFields', function(appState, webconService) {
     };
 });
 
+SIREPO.app.directive('controlBeamPositionReport', function(appState, frameCache, panelState, plotting, requestSender, simulationQueue, webconService) {
+    return {
+        scope: {
+            parentController: '<',
+        },
+        template: [
+            //'<div data-webcon-lattice=""></div>',
+            '<div data-report-panel="parameter" data-model-name="beamPositionReport"></div>',
+        ].join(''),
+        controller: function($scope) {
+            $scope.$on('settingsLoaded', function (e, data) {
+                //requestSender.getApplicationData(
+                //    {
+                //        method: '_get_settings_report',
+                //    },
+                //);
+            });
+        },
+    };
+});
+
 SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, panelState, plotting, requestSender, simulationQueue, webconService) {
     return {
         scope: {

--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -937,7 +937,7 @@ SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, pa
         ].join(''),
         controller: function($scope, $element) {
 
-            var canToggleSpread = false;
+            var canToggleSpread = true;
             var d3self = d3.selectAll($element);
             var history = [];
             var spread = [40.0, 0];
@@ -975,25 +975,24 @@ SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, pa
                 */
             };
 
-           $scope.showSpreadButton = function() {
-                return canToggleSpread && (appState.models.correctorSettingReport || {}).plotOrder == 'position'
-                //srdbg('spread', appState.models.correctorSettingAnimation);
-                //return (appState.models.correctorSettingAnimation || {}).plotOrder == 'position'
-           };
-
-           $scope.spreadButtonText = function () {
-                return $scope.spreadView ? 'Collapse' : 'Expand';
-           };
-
-            $scope.toggleSpreadView = function () {
-                $scope.spreadView = ! $scope.spreadView;
-                doSpread(true);
+            $scope.showSpreadButton = function() {
+                return canToggleSpread && (appState.models.correctorSettingReport || {}).plotOrder == 'position';
             };
 
-           // changing plot visibility triggers a refresh, which undoes the spread.
+            $scope.spreadButtonText = function () {
+                return $scope.spreadView ? 'Collapse' : 'Expand';
+            };
+
+            $scope.toggleSpreadView = function () {
+                 $scope.spreadView = ! $scope.spreadView;
+                 doSpread(true);
+            };
+
+            // changing plot visibility triggers a refresh, which undoes the spread.
             // put it back if active but don't animate it
+            var spreadEvents = ['setInfoVisible' ,'retranslate'];
             $scope.$on('sr-plotEvent', function (e, data) {
-                if (data.name !== 'setInfoVisible') {
+                if (spreadEvents.indexOf(data.name) < 0) {
                     return;
                 }
                 if ($scope.spreadView) {

--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -218,7 +218,6 @@ SIREPO.app.controller('ControlsController', function (appState, frameCache, pane
                 ['hpos', 'vpos'].forEach(function(pos) {
                     map[pos] = 'bpm' + watchCount + '_' + pos;
                 });
-
             }
             else if (t === 'KICKER') {
                 kickerCount += 1;
@@ -371,34 +370,14 @@ SIREPO.app.controller('ControlsController', function (appState, frameCache, pane
     }
 
     function updateFromMonitorValues(monitorValues) {
-        srdbg('updateFromMonitorValues', monitorValues);
+        //srdbg('updateFromMonitorValues', monitorValues);
         var watchCount = 0;
         var kickerCount = 0;
         var count = 0;
         var isSteering = isSteeringBeam() || wantFinalKickerUpdate;
         wantFinalKickerUpdate = false;
-        /*
+
         appState.models.elements.forEach(function(el) {
-            if (el.type == 'WATCH') {
-                watchCount += 1;
-                ['hpos', 'vpos'].forEach(function(pos) {
-                    var field = 'bpm' + watchCount + '_' + pos;
-                    el[pos] = monitorValues[field];
-                });
-            }
-            else if (isSteering && el.type == 'KICKER') {
-                kickerCount += 1;
-                ['hkick', 'vkick'].forEach(function(pos) {
-                    var field = 'corrector' + kickerCount
-                        + (pos == 'hkick' ? '_HCurrent' : '_VCurrent');
-                    el[pos] = monitorValues[field];
-                    appState.models[el.type + el._id] = el;
-                });
-                appState.saveQuietly(el.type + el._id);
-            }
-        });
-        */
-         appState.models.elements.forEach(function(el) {
             if (Object.keys(self.monitorToModelFields).indexOf(el.type) < 0) {
                 return;
             }
@@ -506,6 +485,7 @@ SIREPO.app.controller('ControlsController', function (appState, frameCache, pane
     };
 
     self.reset = function () {
+        /*
         var toSave = [];
         monitoredModels().forEach(function(m) {
             var e = elementForId(m.id);
@@ -515,6 +495,7 @@ SIREPO.app.controller('ControlsController', function (appState, frameCache, pane
         });
         appState.saveChanges(toSave, function () {
         });
+        */
     };
 
     self.showEditor = function(item) {
@@ -527,17 +508,21 @@ SIREPO.app.controller('ControlsController', function (appState, frameCache, pane
     appState.whenModelsLoaded($scope, function() {
         self.watches = [];
         self.editorColumns = [];
+        self.monitoredModels = [];
         var quadCount = 0;
         appState.models.beamlines[0].items.forEach(function(id) {
             var element = elementForId(id);
+            var m = modelForElement(element);
             if (element.type == 'WATCH') {
-                self.watches.push(modelForElement(element));
+                self.watches.push(m);
             }
             else if (element.type == 'KICKER') {
-                self.editorColumns.push([modelForElement(element)]);
+                self.editorColumns.push([m]);
+                self.monitoredModels.push(m);
             }
             else if (element.type == 'QUAD') {
-                self.editorColumns[quadCount].push(modelForElement(element));
+                self.editorColumns[quadCount].push(m);
+                self.monitoredModels.push(m);
                 quadCount += 1;
             }
         });
@@ -1030,9 +1015,12 @@ SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, pa
             });
             */
             $scope.$on('modelChanged', update);
-            $scope.$on('beamSteering.changed', function (data) {
-                srdbg('check state', data);
-            });
+            //$scope.$on('epicsServerAnimation.changed', function (e, data) {
+            //    srdbg('check state', appState.models.epicsServerAnimation.connectToServer);
+            //});
+            //$scope.$on('beamSteering.changed', function (data) {
+            //    srdbg('check state', data);
+            //});
 
 
             function doSpread(doAnimate) {

--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -931,7 +931,6 @@ SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, pa
             parentController: '<',
         },
         template: [
-            //'<div data-webcon-lattice=""></div>',
             '<div data-report-panel="parameter" data-model-name="correctorSettingReport">',
             '<button class="btn btn-default" data-ng-show="showSpreadButton()" data-ng-click="toggleSpreadView()">{{ spreadButtonText() }}</button>',
             '</div>',
@@ -947,11 +946,11 @@ SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, pa
             $scope.spreadView = false;
 
             $scope.init = function() {
-                srdbg('INIT');
+                //srdbg('INIT');
             };
 
             $scope.load = function() {
-                srdbg('hist', history, $scope.parentController.monitorToModelFields);
+                //srdbg('hist', history, $scope.parentController.monitorToModelFields);
             };
 
             $scope.requestData = function() {

--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -1030,6 +1030,9 @@ SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, pa
             });
             */
             $scope.$on('modelChanged', update);
+            $scope.$on('beamSteering.changed', function (data) {
+                srdbg('check state', data);
+            });
 
 
             function doSpread(doAnimate) {

--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -936,7 +936,7 @@ SIREPO.app.directive('controlBeamPositionReport', function(appState, frameCache,
     };
 });
 
-SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache, panelState, plotting, requestSender, simulationQueue, webconService) {
+SIREPO.app.directive('controlCorrectorReport', function(appState, frameCache) {
     return {
         scope: {
             parentController: '<',

--- a/sirepo/package_data/static/json/webcon-schema.json
+++ b/sirepo/package_data/static/json/webcon-schema.json
@@ -102,6 +102,7 @@
         },
         "correctorSettingReport": {
             "numHistory": ["Time Window (sec)", "Float", 0.0, "enter 0 to view entire history", 0.0],
+            "samplePeriod": ["Sample Period (sec)", "Integer", 1, "", 1],
             "plotOrder": ["Arrange Plot", "SettingsPlotOrder", "time"]
         },
         "epicsServerAnimation": {
@@ -226,6 +227,7 @@
             "basic": [],
             "advanced": [
                 "numHistory",
+                "samplePeriod",
                 "plotOrder"
             ]
         },

--- a/sirepo/package_data/static/json/webcon-schema.json
+++ b/sirepo/package_data/static/json/webcon-schema.json
@@ -121,6 +121,8 @@
             "k1": ["Strength [1/m²]", "MiniFloat", 0]
         },
         "WATCH": {
+        },
+        "watchpointReport": {
         }
     },
     "view": {
@@ -250,6 +252,8 @@
             "advanced": []
         },
         "WATCH": {
+        },
+        "watchpointReport": {
         }
     }
 }

--- a/sirepo/package_data/static/json/webcon-schema.json
+++ b/sirepo/package_data/static/json/webcon-schema.json
@@ -84,8 +84,8 @@
         },
          "beamPositionReport": {
             "inProgressText": ["_", "String", "Working"],
-            "numHistory": ["Time Window (s)", "Float", 0.0, "enter 0 to view entire history", 0.0],
-            "samplePeriod": ["Sample Period (s)", "Integer", 1, "", 1]
+            "numHistory": ["Time Window (sec)", "Float", 0.0, "enter 0 to view entire history", 0.0],
+            "samplePeriod": ["Sample Period (sec)", "Integer", 1, "", 1]
         },
         "beamSteering": {
             "useSteering": ["Use Steering", "Boolean", "0"],
@@ -100,7 +100,7 @@
         },
         "correctorSettingReport": {
             "inProgressText": ["_", "String", "Working"],
-            "numHistory": ["Time Window (s)", "Float", 0.0, "enter 0 to view entire history", 0.0],
+            "numHistory": ["Time Window (sec)", "Float", 0.0, "enter 0 to view entire history", 0.0],
             "plotOrder": ["Arrange Plot", "SettingsPlotOrder", "time"]
         },
         "epicsServerAnimation": {

--- a/sirepo/package_data/static/json/webcon-schema.json
+++ b/sirepo/package_data/static/json/webcon-schema.json
@@ -83,7 +83,9 @@
             "notes": ["Notes", "Text", ""]
         },
          "beamPositionReport": {
-            "numHistory": ["Centroid History to Keep", "Integer", 3, "", 1, 10]
+            "inProgressText": ["_", "String", "Working"],
+            "numHistory": ["Time Window (s)", "Float", 0.0, "enter 0 to view entire history", 0.0],
+            "samplePeriod": ["Sample Period (s)", "Integer", 1, "", 1]
         },
         "beamSteering": {
             "useSteering": ["Use Steering", "Boolean", "0"],
@@ -97,9 +99,9 @@
             "centroid_yp": ["Y' [rad]", "Float", 0]
         },
         "correctorSettingReport": {
-            "numHistory": ["Settings History to Keep", "Integer", 3, "", 1, 10],
-            "plotOrder": ["Arrange Plot", "SettingsPlotOrder", "time"],
-            "inProgressText": ["_", "String", "Working"]
+            "inProgressText": ["_", "String", "Working"],
+            "numHistory": ["Time Window (s)", "Float", 0.0, "enter 0 to view entire history", 0.0],
+            "plotOrder": ["Arrange Plot", "SettingsPlotOrder", "time"]
         },
         "epicsServerAnimation": {
             "serverType": ["EPICS Server Type", "ServerType", "local"],
@@ -107,6 +109,7 @@
             "connectToServer": ["Connect to EPICS", "Boolean", "0"]
         },
         "fftReport": {
+            "inProgressText": ["_", "String", "Working"]
         },
         "hiddenReport": {
         },
@@ -193,7 +196,8 @@
             "title": "Beam Position",
             "basic": [],
             "advanced": [
-                "numHistory"
+                "numHistory",
+                "samplePeriod"
             ]
         },
         "beamSteering": {

--- a/sirepo/package_data/static/json/webcon-schema.json
+++ b/sirepo/package_data/static/json/webcon-schema.json
@@ -45,6 +45,10 @@
             ["local", "Local"],
             ["remote", "Remote"]
         ],
+        "SettingsPlotOrder": [
+            ["time", "By Time"],
+            ["position", "By Position"]
+        ],
         "SteeringMethod": [
             ["nmead", "Nelder-Mead"],
             ["polyfit", "Linear Response Matrix"]
@@ -91,7 +95,9 @@
             "centroid_y": ["Y [m]", "Float", 0.001],
             "centroid_yp": ["Y' [rad]", "Float", 0]
         },
-        "correctorSettingAnimation": {
+        "correctorSettingReport": {
+            "numHistory": ["Settings History to Keep", "Integer", 3, "", 1, 10],
+            "plotOrder": ["Arrange Plot", "SettingsPlotOrder", "time"]
         },
         "epicsServerAnimation": {
             "serverType": ["EPICS Server Type", "ServerType", "local"],
@@ -204,9 +210,13 @@
             ],
             "advanced": []
         },
-        "correctorSettingAnimation": {
+        "correctorSettingReport": {
             "title": "Corrector Settings",
-            "advanced": []
+            "basic": [],
+            "advanced": [
+                "numHistory",
+                "plotOrder"
+            ]
         },
         "epicsServerAnimation": {
             "title": "EPICS Server",

--- a/sirepo/package_data/static/json/webcon-schema.json
+++ b/sirepo/package_data/static/json/webcon-schema.json
@@ -74,6 +74,7 @@
             "fitEquation": ["Equation to Fit", "Equation", "a * x + b"],
             "fitParameters": ["Fit Parameters", "EquationParameters", "a,b"],
             "fitVariable": ["Independent Variable", "EquationVariables", "x"],
+            "inProgressText": ["_", "String", "Working"],
             "trimField": ["Trim Field", "AnalysisParameter"],
             "trimMin": ["Minimum", "Float"],
             "trimMax": ["Maximum", "Float"],

--- a/sirepo/package_data/static/json/webcon-schema.json
+++ b/sirepo/package_data/static/json/webcon-schema.json
@@ -82,7 +82,8 @@
             "y3": ["Y3 Value", "AnalysisOptionalParameter", "none"],
             "notes": ["Notes", "Text", ""]
         },
-        "beamPositionAnimation": {
+         "beamPositionReport": {
+            "numHistory": ["Centroid History to Keep", "Integer", 3, "", 1, 10]
         },
         "beamSteering": {
             "useSteering": ["Use Steering", "Boolean", "0"],
@@ -97,7 +98,8 @@
         },
         "correctorSettingReport": {
             "numHistory": ["Settings History to Keep", "Integer", 3, "", 1, 10],
-            "plotOrder": ["Arrange Plot", "SettingsPlotOrder", "time"]
+            "plotOrder": ["Arrange Plot", "SettingsPlotOrder", "time"],
+            "inProgressText": ["_", "String", "Working"]
         },
         "epicsServerAnimation": {
             "serverType": ["EPICS Server Type", "ServerType", "local"],
@@ -187,9 +189,12 @@
             ],
             "advanced": []
         },
-        "beamPositionAnimation": {
+        "beamPositionReport": {
             "title": "Beam Position",
-            "advanced": []
+            "basic": [],
+            "advanced": [
+                "numHistory"
+            ]
         },
         "beamSteering": {
             "title": "Beam Steering",

--- a/sirepo/package_data/static/json/webcon-schema.json
+++ b/sirepo/package_data/static/json/webcon-schema.json
@@ -4,6 +4,9 @@
             "localRoute": "analysis"
         }
     },
+    "constants": {
+        "inProgressText": "Working"
+    },
     "dynamicFiles": {
         "sirepoLibs": {
             "js": [
@@ -74,7 +77,6 @@
             "fitEquation": ["Equation to Fit", "Equation", "a * x + b"],
             "fitParameters": ["Fit Parameters", "EquationParameters", "a,b"],
             "fitVariable": ["Independent Variable", "EquationVariables", "x"],
-            "inProgressText": ["_", "String", "Working"],
             "trimField": ["Trim Field", "AnalysisParameter"],
             "trimMin": ["Minimum", "Float"],
             "trimMax": ["Maximum", "Float"],
@@ -84,7 +86,6 @@
             "notes": ["Notes", "Text", ""]
         },
          "beamPositionReport": {
-            "inProgressText": ["_", "String", "Working"],
             "numHistory": ["Time Window (sec)", "Float", 0.0, "enter 0 to view entire history", 0.0],
             "samplePeriod": ["Sample Period (sec)", "Integer", 1, "", 1]
         },
@@ -100,7 +101,6 @@
             "centroid_yp": ["Y' [rad]", "Float", 0]
         },
         "correctorSettingReport": {
-            "inProgressText": ["_", "String", "Working"],
             "numHistory": ["Time Window (sec)", "Float", 0.0, "enter 0 to view entire history", 0.0],
             "plotOrder": ["Arrange Plot", "SettingsPlotOrder", "time"]
         },
@@ -110,7 +110,6 @@
             "connectToServer": ["Connect to EPICS", "Boolean", "0"]
         },
         "fftReport": {
-            "inProgressText": ["_", "String", "Working"]
         },
         "hiddenReport": {
         },
@@ -251,8 +250,6 @@
             "advanced": []
         },
         "WATCH": {
-            "basic": [],
-            "advanced": []
         }
     }
 }

--- a/sirepo/pkcli/webcon.py
+++ b/sirepo/pkcli/webcon.py
@@ -40,6 +40,8 @@ def run(cfg_dir):
             res = template.get_settings_report(py.path.local(cfg_dir), data)
         elif 'beamPositionReport' in data.report:
             res = template.get_beam_pos_report(py.path.local(cfg_dir), data)
+        elif 'WATCH' in data.report:
+            res = template.get_centroid_report(py.path.local(cfg_dir), data)
         else:
             assert False, 'unknown report: {}'.format(data.report)
         simulation_db.write_result(res)

--- a/sirepo/pkcli/webcon.py
+++ b/sirepo/pkcli/webcon.py
@@ -36,6 +36,8 @@ def run(cfg_dir):
             res = template.get_analysis_report(py.path.local(cfg_dir), data)
         elif 'fftReport' in data.report:
             res = template.get_fft(py.path.local(cfg_dir), data)
+        elif 'correctorSettingReport' in data.report:
+            res = template.get_settings_report(py.path.local(cfg_dir), data)
         else:
             assert False, 'unknown report: {}'.format(data.report)
         simulation_db.write_result(res)

--- a/sirepo/pkcli/webcon.py
+++ b/sirepo/pkcli/webcon.py
@@ -40,7 +40,7 @@ def run(cfg_dir):
             res = template.get_settings_report(py.path.local(cfg_dir), data)
         elif 'beamPositionReport' in data.report:
             res = template.get_beam_pos_report(py.path.local(cfg_dir), data)
-        elif 'WATCH' in data.report:
+        elif 'watchpointReport' in data.report:
             res = template.get_centroid_report(py.path.local(cfg_dir), data)
         else:
             assert False, 'unknown report: {}'.format(data.report)

--- a/sirepo/pkcli/webcon.py
+++ b/sirepo/pkcli/webcon.py
@@ -38,6 +38,8 @@ def run(cfg_dir):
             res = template.get_fft(py.path.local(cfg_dir), data)
         elif 'correctorSettingReport' in data.report:
             res = template.get_settings_report(py.path.local(cfg_dir), data)
+        elif 'beamPositionReport' in data.report:
+            res = template.get_beam_pos_report(py.path.local(cfg_dir), data)
         else:
             assert False, 'unknown report: {}'.format(data.report)
         simulation_db.write_result(res)

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -73,21 +73,25 @@ def compute_field_range(args, compute_range):
     }
 
 
-def compute_plot_color_and_range(plots):
-    """ For parameter plots, assign each plot a color and compute the full y_range. """
-    y_range = None
+def compute_plot_color_and_range(plots, plot_colors, fixed_y_range):
+    """ For parameter plots, assign each plot a color and compute the full y_range.
+    If a fixed range is provided, use that instead
+    """
+    y_range = fixed_y_range
+    colors = plot_colors if plot_colors is not None else _PLOT_LINE_COLOR
     for i in range(len(plots)):
         plot = plots[i]
-        plot['color'] = _PLOT_LINE_COLOR[i % len(_PLOT_LINE_COLOR)]
-        vmin = min(plot['points'])
-        vmax = max(plot['points'])
-        if y_range:
-            if vmin < y_range[0]:
-                y_range[0] = vmin
-            if vmax > y_range[1]:
-                y_range[1] = vmax
-        else:
-            y_range = [vmin, vmax]
+        plot['color'] = colors[i % len(colors)]
+        if fixed_y_range is None:
+            vmin = min(plot['points'])
+            vmax = max(plot['points'])
+            if y_range:
+                if vmin < y_range[0]:
+                    y_range[0] = vmin
+                if vmax > y_range[1]:
+                    y_range[1] = vmax
+            else:
+                y_range = [vmin, vmax]
     # color child plots the same as parent
     for c in [p for p in plots if '_parent' in p]:
         p_label = plot['_parent']
@@ -228,12 +232,12 @@ def model_defaults(name, schema):
     return res
 
 
-def parameter_plot(x, plots, model, plot_fields=None):
+def parameter_plot(x, plots, model, plot_fields=None, plot_colors=None, x_range=None, y_range=None):
     res = {
         'x_points': x,
-        'x_range': [min(x), max(x)],
+        'x_range': x_range if x_range is not None else [min(x), max(x)],
         'plots': plots,
-        'y_range': compute_plot_color_and_range(plots),
+        'y_range': compute_plot_color_and_range(plots, plot_colors, y_range),
     }
     if 'plotRangeType' in model:
         if model.plotRangeType == 'fixed':

--- a/sirepo/template/webcon.py
+++ b/sirepo/template/webcon.py
@@ -336,15 +336,15 @@ def get_settings_report(run_dir, data):
     history, num_records, start_time = _read_monitor_file(monitor_file, True)
     o = data.models.correctorSettingReport.plotOrder
     plot_order = o if o is not None else 'time'
-    x_label = 't [s]'
     if plot_order == 'time':
         x, plots, colors = _setting_plots_by_time(data, history, start_time)
+        x_label = 't [s]'
     else:
         x, plots, colors = _setting_plots_by_position(data, history, start_time)
         x_label = 'z [m]'
     return template_common.parameter_plot(x.tolist(), plots, {}, {
         'title': '',
-        'y_label': 'A',
+        'y_label': 'rad',
         'x_label': x_label,
         'summaryData': {},
     }, colors)

--- a/sirepo/template/webcon.py
+++ b/sirepo/template/webcon.py
@@ -282,7 +282,6 @@ def get_centroid_report(run_dir, data):
         'y_label': '',
         'x_label': 'x [m]',
         'fixed_y_range': True,
-        'zoom_x_y': False,
         'aspectRatio': 1.0,
         'summaryData': {
             'times': ct
@@ -747,10 +746,6 @@ def _compute_clusters(report, plot_data, col_info):
     }
 
 
-def _element_by_id(data, e_id):
-    return [el for el in data.models.elements if el['_id'] == e_id][0]
-
-
 def _element_by_name(data, e_name):
     return [el for el in data.models.elements if el['name'] == e_name][0]
 
@@ -1055,28 +1050,6 @@ def _load_file_with_history(report, path, col_info):
     return res
 
 
-def _model_for_element_name(data, e_name):
-    e = _element_by_name(data, e_name)
-    if e is None:
-        return None
-    e_id =e['_id']
-    for m_name in data.models:
-        m = data.models[m_name]
-        id_key = _model_id_key(m)
-        if id_key is None:
-            continue
-        if data.models[m_name][id_key] == e_id:
-            return data.models[m_name]
-    return None
-
-
-def _model_id_key(model):
-    for k in ['id', '_id']:
-        if k in model:
-            return k
-    return None
-
-
 def _monitor_data_for_plots(data, history, start_time, type):
     m_data = {}
     _build_monitor_to_model_fields(data)
@@ -1128,7 +1101,6 @@ def _read_monitor_file(monitor_path, history=False):
     min_time = datetime.max
     #TODO(pjm): currently reading entire file to get list of current values (most recent at bottom)
     for line in pkio.read_text(str(monitor_path)).split("\n"):
-        #m = re.match(r'(\S+).*?\s([\d\.\e\-\+]+)\s*$', line)
         m = re.match(r'(\S+)(.*?)\s([\d\.\e\-\+]+)\s*$', line)
         if not m:
             continue

--- a/sirepo/template/webcon.py
+++ b/sirepo/template/webcon.py
@@ -474,9 +474,9 @@ def _beam_pos_plots(data, history, start_time):
     for t_idx, t in enumerate(bpms['t']):
         for d_idx, dim in enumerate(['x', 'y']):
             c.append(_DIM_PLOT_COLORS[d_idx % len(_DIM_PLOT_COLORS)])
-            # same color, fade to alpha 0.1
+            # same color, fade to alpha 0.2
             c_mod = _hex_color_to_rgb(c[-1])
-            c_mod[3] = 0.1
+            c_mod[3] = 0.2
             plots.append({
                 'points': bpms[dim][t_idx],
                 'x_points': bpms['z'],
@@ -1019,7 +1019,6 @@ def _monitor_data_for_plots(data, history, start_time, type):
             [t - start_time for t in h.times]
         ]
         pos = np.full(len(t_deltas), _position_of_element(data, el['_id']))
-        #m_data[el_name][el_setting] = (h.vals, t_deltas, pos.tolist())
         m_data[el_name][el_setting] = {
             'vals': h.vals,
             'times': t_deltas,
@@ -1115,19 +1114,25 @@ def _setting_plots_by_position(data, history, start_time):
                 {
                     'setting': s,
                     'vals': k_s[s]['vals'],
-                    'position': k_s[s]['position']
+                    'position': k_s[s]['position'],
+                    'times': k_s[s]['times']
                 }
             )
+
+    time_window = data.models.correctorSettingReport.numHistory
     for k_idx, k in enumerate(k_sorted):
         for s in k[1]:
             all_z = np.append(all_z, s['position'])
+            current_time = s['times'][-1]
+            times = [t for t in s['times'] if current_time - t < time_window] if time_window > 0 else s['times']
+            t_idx = s['times'].index(times[0])
             c.append(_SETTINGS_PLOT_COLORS[k_idx % len(_SETTINGS_PLOT_COLORS)])
-            # same color, fade to alpha 0.1
+            # same color, fade to alpha 0.2
             c_mod = _hex_color_to_rgb(c[-1])
-            c_mod[3] = 0.1
+            c_mod[3] = 0.2
             plots.append({
-                'points': s['vals'],
-                'x_points': s['position'],
+                'points': s['vals'][t_idx:],
+                'x_points': s['position'][t_idx:],
                 'label': '{} {}'.format(k[0], s['setting']),
                 'style': 'scatter',
                 'symbol': _SETTINGS_KICKER_SYMBOLS[s['setting']],

--- a/sirepo/template/webcon.py
+++ b/sirepo/template/webcon.py
@@ -471,17 +471,20 @@ def _beam_pos_plots(data, history, start_time):
     c = []
 
     bpms = _bpm_readings_for_plots(data, history, start_time)
-    pkdp('bpms {}', bpms)
     for t_idx, t in enumerate(bpms['t']):
         for d_idx, dim in enumerate(['x', 'y']):
             c.append(_DIM_PLOT_COLORS[d_idx % len(_DIM_PLOT_COLORS)])
+            # same color, fade to alpha 0.1
+            c_mod = _hex_color_to_rgb(c[-1])
+            c_mod[3] = 0.1
             plots.append({
                 'points': bpms[dim][t_idx],
                 'x_points': bpms['z'],
                 'label': '{} ({}s)'.format(dim, t),
                 'style': 'line',
                 'symbol': _SETTINGS_KICKER_SYMBOLS[dim],
-                'colorModulation': [0, 0, 0, 0.90]
+                'colorModulation': c_mod,
+                'modDirection': -1
             })
     return np.array(bpms['z']), plots, c
 
@@ -538,12 +541,9 @@ def _bpm_readings_for_plots(data, history, start_time):
     period = data.models.beamPositionReport.samplePeriod
     current_time = all_times[-1]
 
-    tmp_t_idx = np.where(all_times > current_time - time_window) if time_window > 0 else [np.arange(len(all_times))]
-    pkdp('indexed {}', tmp_t_idx)
-    for t_idx in tmp_t_idx[0]:
+    t_indexes = np.where(all_times > current_time - time_window) if time_window > 0 else [np.arange(len(all_times))]
+    for t_idx in t_indexes[0]:
         time = all_times[t_idx]
-        #if current_time - time > time_window > 0:
-        #    continue
         if int(time) % period != 0:
             continue
         t.append(time)
@@ -839,6 +839,11 @@ def _get_fit_report(report, plot_data, col_info):
     })
 
 
+def _hex_color_to_rgb(color):
+    rgb = [float(int(color.lstrip('#')[i:i + 2], 16)) for i in [0, 2, 4]]
+    rgb.append(1.0)
+    return rgb
+
 def _init_default_beamline(data):
     #TODO(pjm): hard-coded beamline for now, using elegant format
     data.models.elements = [
@@ -1106,7 +1111,6 @@ def _setting_plots_by_position(data, history, start_time):
             k_sorted.append((k_name, []))
         k_s = kickers[k_name]
         for s in sorted([s for s in k_s]):
-            #k_sorted[-1][1].append((s,  k_s[s]['vals'], k_s[s]['position']))
             k_sorted[-1][1].append(
                 {
                     'setting': s,
@@ -1116,16 +1120,19 @@ def _setting_plots_by_position(data, history, start_time):
             )
     for k_idx, k in enumerate(k_sorted):
         for s in k[1]:
-            #all_z = np.append(all_z, s[2])
             all_z = np.append(all_z, s['position'])
             c.append(_SETTINGS_PLOT_COLORS[k_idx % len(_SETTINGS_PLOT_COLORS)])
+            # same color, fade to alpha 0.1
+            c_mod = _hex_color_to_rgb(c[-1])
+            c_mod[3] = 0.1
             plots.append({
-                'points': s['vals'],  #s[1],
-                'x_points': s['position'],  #s[2],
+                'points': s['vals'],
+                'x_points': s['position'],
                 'label': '{} {}'.format(k[0], s['setting']),
                 'style': 'scatter',
                 'symbol': _SETTINGS_KICKER_SYMBOLS[s['setting']],
-                'colorModulation': [0, 0, 0, 0.90]
+                'colorModulation': c_mod,
+                'modDirection': -1
             })
     np.append(all_z, _element_positions(data)[-1])
     return np.unique(np.array(all_z)), plots, c
@@ -1153,7 +1160,6 @@ def _setting_plots_by_time(data, history, start_time):
 
     all_times = np.sort(np.unique(all_times))
     time_window = data.models.correctorSettingReport.numHistory
-    period = data.models.correctorSettingReport.samplePeriod
     current_time = all_times[-1]
 
     for k_idx, k in enumerate(k_sorted):
@@ -1168,8 +1174,7 @@ def _setting_plots_by_time(data, history, start_time):
                 'x_points': times,
                 'label': '{} {}'.format(k[0], s['setting']),
                 'style': 'line',
-                'symbol': _SETTINGS_KICKER_SYMBOLS[s['setting']],
-                'colorModulation': [0, 0, 0, 0.90]
+                'symbol': _SETTINGS_KICKER_SYMBOLS[s['setting']]
             })
     return all_times, plots, c
 

--- a/sirepo/template/webcon.py
+++ b/sirepo/template/webcon.py
@@ -60,14 +60,14 @@ OPTIMIZER_RESULT_FILE = 'opt.json'
 
 STEERING_FILE = 'steering.json'
 
-_MONITOR_TO_MODEL_FIELDS = pkcollections.Dict({})
-
-_SCHEMA = simulation_db.get_schema(SIM_TYPE)
-
 _DIM_PLOT_COLORS = [
     '#d0c383',
     '#9400d3'
 ]
+
+_MONITOR_TO_MODEL_FIELDS = pkcollections.Dict({})
+
+_SCHEMA = simulation_db.get_schema(SIM_TYPE)
 
 _SETTINGS_PLOT_COLORS = [
     '#ff0000',
@@ -915,6 +915,7 @@ def _hex_color_to_rgb(color):
     rgb.append(1.0)
     return rgb
 
+
 def _init_default_beamline(data):
     #TODO(pjm): hard-coded beamline for now, using elegant format
     data.models.elements = [
@@ -1020,6 +1021,7 @@ def _init_default_beamline(data):
         },
     ]
 
+
 # arrange historical data for ease of plotting
 def _kicker_settings_for_plots(data, history, start_time):
     return _monitor_data_for_plots(data, history, start_time, 'KICKER')
@@ -1094,6 +1096,13 @@ def _position_of_element(data, id):
     return p[i]
 
 
+def _read_epics_kickers(data):
+    epics_settings = data.epicsServerAnimation
+    return {
+        'kickers': read_epics_values(epics_settings.serverAddress, CURRENT_FIELDS),
+    }
+
+
 def _read_monitor_file(monitor_path, history=False):
     from datetime import datetime
     monitor_values = {}
@@ -1123,13 +1132,6 @@ def _read_monitor_file(monitor_path, history=False):
             monitor_values[var_name].times.append(t)
         count += 1
     return monitor_values, count, min_time
-
-
-def _read_epics_kickers(data):
-    epics_settings = data.epicsServerAnimation
-    return {
-        'kickers': read_epics_values(epics_settings.serverAddress, CURRENT_FIELDS),
-    }
 
 
 def _report_info(run_dir, data):


### PR DESCRIPTION
Notes:

- The corrector setting, beam position, and BPM plots are reports rather than animations, for now. They don't update quite right yet so refreshing the page or making a change to model data is sometimes required
- In general, position is indicated by color, x/horizontal values with a square, y/vertical values with a triangle, and data further back in time with decreasing alpha. The beam position plot is a little different since there is no way yet to individually color the segments of a single path
- Parameter plotting now allows each sub-plot to have its own x values, rather than using the same x for every set of y values
- The beam position and corrector plots allow the user to select a time range and sample period to reduce clutter.  Time is relative to when the user connects to epics rather than a raw timestamp
- When plotting the corrector values by position, the user can "expand" the data points as they all get stacked up at one x position
- BPM plots have a 1:1 aspect ratio and all use the same (maximal) range so they can be compared by eye.  The data are from the beam position plot including time window and sample period
- Much of the plotting code in ```sirepo/template/webcon.py``` is duplicated and could stand consolidation and pythonicizing when there is time