### PR TITLE
Webcon fft fixup

### DIFF
--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -1256,7 +1256,7 @@ SIREPO.app.service('layoutService', function(plotting, utilities) {
                 var baseFormat = calcFormat(tickCount, unit, null, true).format;
                 var base = midPoint(formatInfo, d);
                 if (unit) {
-                    unit =  formatPrefix(d, base);
+                    unit = formatPrefix(d, base);
                 }
                 formatInfo = calcFormat(tickCount, unit, base);
                 tickCount = calcTickCount(formatInfo.format, canvasSize, unit, base, fontSize);
@@ -1269,7 +1269,7 @@ SIREPO.app.service('layoutService', function(plotting, utilities) {
                 formatInfo.base = base;
                 formatInfo.baseFormat = baseFormat;
             }
-            if ((orientation == 'left' || orientation == 'right') && ! canvasSize.isPlaying) {
+            if ((orientation === 'left' || orientation === 'right') && ! canvasSize.isPlaying) {
                 var w = Math.max(formatInfo.format(applyUnit(d[0] - (formatInfo.base || 0), unit)).length, formatInfo.format(applyUnit(d[1] - (formatInfo.base || 0), unit)).length);
                 margin[orientation] = (w + 6) * (fontSize / 2);
             }

--- a/sirepo/template/webcon.py
+++ b/sirepo/template/webcon.py
@@ -198,7 +198,7 @@ def get_fft(run_dir, data):
     # the first half of the fft data (taking abs() folds in the imaginary part)
     y = 2.0 / num_samples * np.abs(fft_out[0:half_num_samples])
 
-    # get the freuqencies found
+    # get the frequencies found
     # fftfreq just generates an array of equally-spaced values that represent the x-axis
     # of the fft of data of a given length.  It includes negative values
     freqs = scipy.fftpack.fftfreq(len(fft_out)) / sample_period
@@ -210,7 +210,7 @@ def get_fft(run_dir, data):
     sd = y.std()
     s2n = np.where(sd == 0, 0, m / sd)
 
-    # We'll say we found a frequncy peak when the size of the coefficient divided by the average is
+    # We'll say we found a frequency peak when the size of the coefficient divided by the average is
     # greather than this.  A crude indicator - one presumes better methods exist
     found_sn_thresh = 10
 
@@ -234,9 +234,11 @@ def get_fft(run_dir, data):
     yy = 2.0 / num_samples * np.abs(fft_out[min_bin:max_bin])
     ww = freqs[min_bin:max_bin]
 
+    max_y = np.max(y)
+    y_norm = y / (max_y if max_y != 0 else 1)
     plots = [
         {
-            'points': y.tolist(),
+            'points': y_norm.tolist(),
             'label': 'fft',
         },
     ]
@@ -245,7 +247,8 @@ def get_fft(run_dir, data):
     return template_common.parameter_plot(w.tolist(), plots, {}, {
         'title': '',
         'y_label': _label(col_info, 1),
-        'x_label': 'ω[s-1]',
+        'x_label': 'f[1/s]',
+        'preserve_units': True,
         #'x_label': _label(col_info, 0) + '^-1',
         'summaryData': {
             'freqs': found_freqs,


### PR DESCRIPTION
Notes:

- Changed label to frequency from angular frequency
- The x units are now "1/s".  Note that normally we re-label the x-axis of plots as we zoom in to keep the tick values between 1-10 or so, but this is confusing with things like inverse units (that's why the units were "s-1" - the label would otherwise change to e.g. "m1/s").  The solution here is to preserve the scale of the axis regardless of zoom level
- y values normalized to the largest peak