### PR TITLE
Webcon fit auto-fill and security

### DIFF
--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -127,11 +127,10 @@ SIREPO.app.factory('webconService', function(appState, panelState) {
     };
 
     self.tokenizeEquation = function(eq) {
-        var reserved = ['sin', 'cos', 'tan', 'csc', 'sec', 'cot', 'exp', 'abs', 'pi'];
         return (eq || '').split(/[-+*/^|%().0-9\s]/)
             .filter(function (t) {
                 return t.length > 0 &&
-                    reserved.indexOf(t.toLowerCase()) < 0;
+                    SIREPO.APP_SCHEMA.constants.allowedEquationOps.indexOf(t) < 0;
         });
     };
 
@@ -1345,6 +1344,10 @@ SIREPO.app.directive('validVariableOrParam', function(webconService, utilities) 
                 }
                 if (! isUnique(p, webconService.tokenizeParams(ngModel.$viewValue))) {
                     scope.warningText = p + ' is duplicated';
+                    return false;
+                }
+                if (p.length > 1) {
+                    scope.warningText = p + ': use single character';
                     return false;
                 }
 

--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -1077,7 +1077,7 @@ SIREPO.app.directive('equation', function(appState, webconService, $timeout) {
         template: [
             '<div>',
                 '<input type="text" data-ng-change="validateAll()" data-ng-model="model[field]" class="form-control" required>',
-                '<input type="checkbox" data-ng-model="model[\'autoFill\']" data-ng-change="validateAll()"> Auto-fill variables',
+                '<input type="checkbox" data-ng-model="model.autoFill" data-ng-change="validateAll()"> Auto-fill variables',
             '</div>',
         ].join(''),
         controller: function ($scope) {

--- a/sirepo/package_data/static/js/webcon.js
+++ b/sirepo/package_data/static/js/webcon.js
@@ -1185,8 +1185,6 @@ SIREPO.app.directive('equation', function(appState, webconService, $timeout) {
                 return indVar;
             }
 
-            //$scope.autoFillEnabled = true;
-
             $scope.validateAll = function() {
                 if ($scope.model.autoFill) {
                     // allow time for models to be set before validating

--- a/sirepo/package_data/static/json/webcon-schema.json
+++ b/sirepo/package_data/static/json/webcon-schema.json
@@ -5,7 +5,10 @@
         }
     },
     "constants": {
-        "inProgressText": "Working"
+        "inProgressText": "Working",
+        "allowedEquationOps": [
+          "abs", "cos", "cot", "csc", "exp", "log", "pi", "sec", "sin", "tan"
+        ]
     },
     "dynamicFiles": {
         "sirepoLibs": {
@@ -74,7 +77,7 @@
             "clusterRandomSeed": ["Random Seed", "Integer", 12341234],
             "clusterKmeansInit": ["KMeans Number of Runs", "Integer", 2, "Number of time the k-means algorithm will be run with different centroid seeds. The final results will be the best output of n_init consecutive runs in terms of inertia.", 2, 20],
             "clusterDbscanEps": ["DBSCAN Max Sample Distance", "Float", 0.1, "The maximum distance between two samples for them to be considered as in the same neighborhood."],
-            "fitEquation": ["Equation to Fit", "Equation", "a * x + b"],
+            "fitEquation": ["Equation to Fit", "Equation", "a * x + b", "Functions limited to trig, exp, log, abs. Use 'pi' for π. Variable and parameter names limited to 1 letter"],
             "fitParameters": ["Fit Parameters", "EquationParameters", "a,b"],
             "fitVariable": ["Independent Variable", "EquationVariables", "x"],
             "trimField": ["Trim Field", "AnalysisParameter"],

--- a/sirepo/template/webcon.py
+++ b/sirepo/template/webcon.py
@@ -10,6 +10,7 @@ from pykern import pkio
 from pykern import pkjinja
 from pykern.pkdebug import pkdp, pkdc, pkdlog
 from sirepo import simulation_db
+from sirepo import util
 from sirepo.template import template_common
 import StringIO
 import copy
@@ -801,6 +802,18 @@ def _epics_dir(sim_id):
 
 def _fit_to_equation(x, y, equation, var, params):
     # TODO: must sanitize input - sympy uses eval
+
+    # These security measures taken so far:
+    #     Whitelist of allowed functions and other symbols as defined in the schema
+    #     Variable and parameters must be 1 alphabetic character
+
+    eq_ops = [t for t in _tokenize_equation(equation) if t != var and t not in params]
+    eq_ops_rejected = [op for op in eq_ops if op not in _SCHEMA.constants.allowedEquationOps]
+    assert len(eq_ops_rejected) == 0, util.err(eq_ops_rejected, 'operation fobidden')
+    assert _validate_eq_var(var), util.err(var, 'invalid variable name')
+    assert all([_validate_eq_var(p) for p in re.split(r'\s*,\s*', params)]),\
+        util.err(params, 'invalid parameter name(s)')
+
     sym_curve = sympy.sympify(equation)
     sym_str = var + ' ' + ' '.join(params)
 
@@ -1265,6 +1278,10 @@ def _setting_plots_by_time(data, history, start_time):
     return np.array([current_time - time_window, current_time]), plots, c
 
 
+def _tokenize_equation(eq):
+    return [t for t in re.split(r'[-+*/^|%().0-9\s]', (eq if eq is not None else '')) if len(t) > 0]
+
+
 def _update_epics_kicker(data):
     epics_settings = data.epicsServerAnimation
     # data validation is done by casting values to int() or float()
@@ -1277,6 +1294,10 @@ def _update_epics_kicker(data):
         values.append(float(data['kicker']['{}kick'.format(f)]))
     update_epics_kickers(epics_settings, _epics_dir(data.simulationId), fields, values)
     return {}
+
+
+def _validate_eq_var(val):
+    return len(val) == 1 and re.match(r'^[a-zA-Z]+$', val)
 
 
 def _watch_index(data, watch_id):


### PR DESCRIPTION
Notes:

- Allows user to have the variables and parameters get filled in as they enter the equation
- We assume that variables will be among the usual suspects (x, y, z, t)
- The schema defines a handful of allowed functions and symbols (trig stuff, exp, log, abs, pi). Other needed items can be added
- Anything not a variable or function is treated as a parameter
- Variables and params are allowed only one alphabetic character for now
- The server does similar validations before handing the equation off to sympy.  That should reduce the ```eval()``` mischief, but merits scrutiny