### PR TITLE
Fete 3d animation

### DIFF
--- a/sirepo/package_data/static/html/conductor-grid.html
+++ b/sirepo/package_data/static/html/conductor-grid.html
@@ -1,5 +1,5 @@
 
-  <ul data-ng-if="warpvndService.is3D() && ! source.usesSTL()" class="nav nav-tabs">
+  <ul data-ng-if="warpvndService.is3D()" class="nav nav-tabs">
     <li role="presentation" data-ng-class="{active: ! is3dPreview }"><a class="srw-tab" href data-ng-click="toggle3dPreview()"><strong>Layout</strong></a></li>
     <li role="presentation" data-ng-class="{active: is3dPreview }"><a class="srw-tab" href data-ng-click="toggle3dPreview()"><strong><span class="glyphicon glyphicon-option-vertical"></span> 3D Preview</strong></a></li>
   </ul>

--- a/sirepo/package_data/static/html/conductor-grid.html
+++ b/sirepo/package_data/static/html/conductor-grid.html
@@ -57,5 +57,5 @@
   </div>
 </div>
 <div data-ng-if="warpvndService.is3D() && is3dPreview">
- <div data-conductors-3d="" data-report-id="reportId" data-parent-controller="source"></div>
+ <div class="vtk-canvas-holder" data-conductors-3d="" data-report-id="reportId" data-parent-controller="source"></div>
 </div>

--- a/sirepo/package_data/static/html/warpvnd-source.html
+++ b/sirepo/package_data/static/html/warpvnd-source.html
@@ -27,7 +27,6 @@
         <div class="col-sm-12" data-ng-show="true">
           <div data-field-calculation-animation="fieldCalculationAnimation"></div>
         </div>
-        <!--<div class="col-sm-12" data-ng-if="source.hasFrames('fieldComparisonAnimation')" data-report-panel="parameter" data-request-priority="0" data-model-name="fieldComparisonAnimation"></div>-->
         <div class="col-sm-12" data-ng-if="source.hasFrames('fieldComparisonAnimation')" data-field-comparison="" data-model-name="fieldComparisonAnimation" data-parent-controller="source"></div>
         <div class="col-sm-12" data-ng-if="source.hasFrames('fieldCalcAnimation')" data-potential-report="" data-model-name="fieldCalcAnimation"></div>
       </div>
@@ -38,7 +37,6 @@
 <div data-modal-editor="" view-name="beam" data-parent-controller="source"></div>
 <div data-modal-editor="" view-name="simulationGrid" data-parent-controller="source"></div>
 <div data-modal-editor="" view-name="fieldComparisonReport" data-parent-controller="source"></div>
-<!--<div data-modal-editor="" view-name="box" data-parent-controller="source"></div>-->
 <div data-modal-editor="" view-name="conductor" data-parent-controller="source"></div>
 <div data-ng-if="source.usesSTL()" data-modal-editor="" view-name="stl" data-parent-controller="source"></div>
 <div data-modal-editor="" view-name="conductorPosition" data-parent-controller="source"></div>

--- a/sirepo/package_data/static/html/warpvnd-source.html
+++ b/sirepo/package_data/static/html/warpvnd-source.html
@@ -24,10 +24,15 @@
     </div>
     <div class="col-md-8">
       <div class="row">
-        <div class="col-sm-12" data-report-panel="parameter" data-request-priority="0" data-model-name="fieldComparisonReport"></div>
-        <div class="col-sm-12" data-potential-report="" data-model-name="fieldReport"></div>
+        <div class="col-sm-12" data-ng-show="true">
+          <div data-field-calculation-animation="fieldCalculationAnimation"></div>
+        </div>
+        <!--<div class="col-sm-12" data-ng-if="source.hasFrames('fieldComparisonAnimation')" data-report-panel="parameter" data-request-priority="0" data-model-name="fieldComparisonAnimation"></div>-->
+        <div class="col-sm-12" data-ng-if="source.hasFrames('fieldComparisonAnimation')" data-field-comparison="" data-model-name="fieldComparisonAnimation"></div>
+        <div class="col-sm-12" data-ng-if="source.hasFrames('fieldCalcAnimation')" data-potential-report="" data-model-name="fieldCalcAnimation"></div>
       </div>
     </div>
+
   </div>
 </div>
 <div data-modal-editor="" view-name="beam" data-parent-controller="source"></div>

--- a/sirepo/package_data/static/html/warpvnd-source.html
+++ b/sirepo/package_data/static/html/warpvnd-source.html
@@ -28,7 +28,7 @@
           <div data-field-calculation-animation="fieldCalculationAnimation"></div>
         </div>
         <!--<div class="col-sm-12" data-ng-if="source.hasFrames('fieldComparisonAnimation')" data-report-panel="parameter" data-request-priority="0" data-model-name="fieldComparisonAnimation"></div>-->
-        <div class="col-sm-12" data-ng-if="source.hasFrames('fieldComparisonAnimation')" data-field-comparison="" data-model-name="fieldComparisonAnimation"></div>
+        <div class="col-sm-12" data-ng-if="source.hasFrames('fieldComparisonAnimation')" data-field-comparison="" data-model-name="fieldComparisonAnimation" data-parent-controller="source"></div>
         <div class="col-sm-12" data-ng-if="source.hasFrames('fieldCalcAnimation')" data-potential-report="" data-model-name="fieldCalcAnimation"></div>
       </div>
     </div>

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -2537,6 +2537,8 @@ SIREPO.app.directive('heatmap', function(appState, layoutService, plotting, util
 
             var aspectRatio = 1.0;
             var canvas, ctx, amrLine, heatmap, mouseMovePoint, pointer, zoom;
+            var globalMin = 0.0;
+            var globalMax = 1.0;
             var cacheCanvas, imageData;
             var colorbar;
             var axes = {
@@ -2634,8 +2636,8 @@ SIREPO.app.directive('heatmap', function(appState, layoutService, plotting, util
             }
 
             function setColorScale() {
-                var plotMin = plotting.min2d(heatmap);
-                var plotMax = plotting.max2d(heatmap);
+                var plotMin = globalMin != null ? globalMin : plotting.min2d(heatmap);
+                var plotMax = globalMax != null ? globalMax : plotting.max2d(heatmap);
                 if (plotMin == plotMax) {
                     plotMax = (plotMin || 1e-6) * 10;
                 }
@@ -2698,6 +2700,8 @@ SIREPO.app.directive('heatmap', function(appState, layoutService, plotting, util
                 $scope.dataCleared = false;
                 aspectRatio = plotting.getAspectRatio($scope.modelName, json);
                 heatmap = appState.clone(json.z_matrix).reverse();
+                globalMin = json.global_min;
+                globalMax = json.global_max;
                 select('.main-title').text(json.title);
                 select('.sub-title').text(json.subtitle);
                 $.each(axes, function(dim, axis) {

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -240,7 +240,6 @@ SIREPO.app.factory('appState', function(errorService, fileManager, requestQueue,
                     successCallback: function (resp) {
                         if (resp.error && resp.error == 'invalidSerial') {
                             srlog(resp.simulationData.models.simulation.simulationId, ': update collision newSerial=', resp.simulationData.models.simulation.simulationSerial, '; refreshing');
-                            srdbg('rq refresh', resp.simulationData);
                             refreshSimulationData(resp.simulationData);
                             errorService.alertText("Another browser updated this simulation.This window's state has been refreshed. Please retry your action.");
                         }

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -240,6 +240,7 @@ SIREPO.app.factory('appState', function(errorService, fileManager, requestQueue,
                     successCallback: function (resp) {
                         if (resp.error && resp.error == 'invalidSerial') {
                             srlog(resp.simulationData.models.simulation.simulationId, ': update collision newSerial=', resp.simulationData.models.simulation.simulationSerial, '; refreshing');
+                            srdbg('rq refresh', resp.simulationData);
                             refreshSimulationData(resp.simulationData);
                             errorService.alertText("Another browser updated this simulation.This window's state has been refreshed. Please retry your action.");
                         }
@@ -902,6 +903,13 @@ SIREPO.app.factory('frameCache', function(appState, panelState, requestSender, $
         else {
             requestFunction();
         }
+    };
+
+    self.hasFrames = function(modelName) {
+        if (modelName) {
+            return self.getFrameCount(modelName) > 0;
+        }
+        return self.getFrameCount() > 0;
     };
 
     self.isLoaded = function() {

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -347,11 +347,9 @@ SIREPO.app.controller('SourceController', function (appState, frameCache, panelS
         var dims = warpvndService.is3D() ? ['x', 'y', 'z'] : ['x', 'z'];
         ['1', '2', '3'].forEach(function(i) {
             dims.forEach(function (d) {
-                //panelState.showField('fieldComparisonReport', d + 'Cell' + i, dim != d);
                 panelState.showField(rpt, d + 'Cell' + i, dim != d);
             });
             if (! warpvndService.is3D()) {
-                //panelState.showField('fieldComparisonReport', 'yCell' + i, false);
                 panelState.showField(rpt, 'yCell' + i, false);
             }
         });
@@ -500,7 +498,6 @@ SIREPO.app.controller('SourceController', function (appState, frameCache, panelS
 
     $scope.$on('cancelChanges', function(e, name) {
         if (isModelConductorType(name)) {
-        //if (name == 'box') {
             appState.removeModel(name);
             appState.cancelChanges('conductorTypes');
         }
@@ -541,7 +538,6 @@ SIREPO.app.controller('SourceController', function (appState, frameCache, panelS
         appState.watchModelFields($scope, ['simulationGrid.plate_spacing', 'simulationGrid.num_z'], updateParticleZMin);
         appState.watchModelFields($scope, ['simulationGrid.channel_width'], updateBeamRadius);
         appState.watchModelFields($scope, ['beam.currentMode'], updateBeamCurrent);
-        //appState.watchModelFields($scope, ['fieldComparisonReport.dimension'], updateFieldComparison);
         appState.watchModelFields($scope, [warpvndService.activeComparisonReport() + '.dimension'], updateFieldComparison);
         SIREPO.APP_SCHEMA.enum.ConductorType.forEach(function (i) {
             var t = i[SIREPO.INFO_INDEX_TYPE];
@@ -2217,20 +2213,14 @@ SIREPO.app.directive('potentialReport', function(appState, panelState, plotting,
                 $scope.model.units = 'µm';
             });
 
-            //appState.watchModelFields($scope, ['fieldReport.axes'], updateSliceRange);
             appState.watchModelFields($scope, ['fieldCalcAnimation.axes'], updateSliceRange);
             appState.watchModelFields($scope, ['simulationGrid.simulation_mode'], updateSliceRange);
 
             // the DOM for editors does not exist until they appear, so we must show/hide fields this way
-            //$scope.$on('fieldReport.editor.show', function () {
             $scope.$on('fieldCalcAnimation.editor.show', function () {
                 if (! slider) {
-                    //slider = $('#fieldReport-slice-range');
                     slider = $('#fieldCalcAnimation-slice-range');
                 }
-
-                //panelState.showField('fieldReport', 'axes', warpvndService.is3D());
-                //panelState.showField('fieldReport', 'slice', warpvndService.is3D());
                 panelState.showField('fieldCalcAnimation', 'axes', warpvndService.is3D());
                 panelState.showField('fieldCalcAnimation', 'slice', warpvndService.is3D());
 

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -966,7 +966,9 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
             function caratField(elev, index, dimension, range) {
                 var rpt = warpvndService.activeComparisonReport();
                 var cell = 'Cell' + index;
-                var field = (elev === ELEVATIONS.front ? (dimension == 'x' ? 'z': 'x') : (dimension == 'y' ? 'z': 'y')) + cell;
+                var field = (elev === ELEVATIONS.front ?
+                    (dimension == 'x' ? 'z': 'x') :
+                    (dimension == 'y' ? 'z': 'y')) + cell;
                 if (appState.models[rpt][field] > range.length) {
                     appState.models[rpt][field] = range.length - 1;
                 }
@@ -1150,7 +1152,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
                             : 'M0,-7L0,7 14,0Z';
                     })
                     .style('cursor', function(d) {
-                        return d.dimension === 'x' ? 'ew-resize' : 'ns-resize';
+                        return d.dimension === 'x' || d.dimension === 'y' ? 'ew-resize' : 'ns-resize';
                     })
                     .style('fill', function(d) {
                         return CELL_COLORS[d.index - 1];

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -265,8 +265,8 @@ SIREPO.app.controller('SourceController', function (appState, frameCache, panelS
                 var bounds = r.getOutputData().getBounds();
                 t.scale = initScale(bounds);
                 t.zLength = normalizeToum(Math.abs(bounds[5] - bounds[4]), t.scale);
-                t.xLength = normalizeToum(Math.abs(bounds[3] - bounds[2]), t.scale);
-                t.yLength = normalizeToum(Math.abs(bounds[1] - bounds[0]), t.scale);
+                t.xLength = normalizeToum(Math.abs(bounds[1] - bounds[0]), t.scale);
+                t.yLength = normalizeToum(Math.abs(bounds[3] - bounds[2]), t.scale);
                 appState.models.simulationGrid.plate_spacing = Math.max(appState.models.simulationGrid.plate_spacing, t.zLength);
                 appState.models.simulationGrid.channel_width = Math.max(appState.models.simulationGrid.channel_width, t.xLength);
                 appState.models.simulationGrid.channel_height = Math.max(appState.models.simulationGrid.channel_height, t.yLength);
@@ -276,8 +276,8 @@ SIREPO.app.controller('SourceController', function (appState, frameCache, panelS
                         id: appState.maxId(appState.models.conductors) + 1,
                         conductorTypeId: t.id,
                         zCenter: normalizeToum(bounds[4], t.scale) + t.zLength / 2.0,
-                        xCenter: normalizeToum(bounds[2], t.scale) + t.xLength / 2.0,
-                        yCenter: normalizeToum(bounds[0], t.scale) + t.yLength / 2.0,
+                        xCenter: normalizeToum(bounds[0], t.scale) + t.xLength / 2.0,
+                        yCenter: normalizeToum(bounds[2], t.scale) + t.yLength / 2.0,
                     };
                     appState.models.conductors.push(c);
                     appState.saveChanges('conductors');
@@ -473,7 +473,6 @@ SIREPO.app.controller('SourceController', function (appState, frameCache, panelS
 
     self.handleModalShown = function(name) {
         updateAllFields();
-        //if (name == 'fieldComparisonReport') {
         if (name == warpvndService.activeComparisonReport()) {
             updateFieldComparison();
         }
@@ -1164,9 +1163,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
                 var info = plotInfoForElevation(elev);
                 var shapes = [];
                 appState.models.conductors
-                    .filter(function (c) {
-                        return warpvndService.getConductorType(c) === 'box';
-                    }).forEach(function(conductorPosition, cpi) {
+                    .forEach(function(conductorPosition) {
                         var conductorType = typeMap[conductorPosition.conductorTypeId];
                         var w = toMicron(conductorType.zLength);
                         var h = toMicron(conductorType[info.lengthField]);
@@ -1694,9 +1691,9 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
             };
 
             $scope.toggle3dPreview = function() {
-                if(! $scope.source.usesSTL()) {
+                //if(! $scope.source.usesSTL()) {
                     $scope.is3dPreview = !$scope.is3dPreview;
-                }
+                //}
             };
 
             $scope.toggleTiledDomain = function() {
@@ -2745,7 +2742,7 @@ SIREPO.app.directive('conductors3d', function(appState, errorService, geometry, 
             // if we have stl-type conductors, we might need to rescale the grid for drawing
             // (easier and faster than scaling the data)
             var toMetersFactor = Math.min.apply(null, warpvndService.stlScaleRanges.scale);
-            var toMicronFactor = 1e-6;
+            var toMicronFactor = 1.0;
             var gridOffsets = [0, 0, 0];
             var domain = {
                 width: 1,
@@ -2929,7 +2926,13 @@ SIREPO.app.directive('conductors3d', function(appState, errorService, geometry, 
                 refresh();
             }
 
-            var labMatrix = [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1];  //stl
+            //var labMatrix = [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1];  //stl
+            var labMatrix = [
+                0, 1, 0, 0,
+                0, 0, -1, 0,
+                1, 0, 0, 0,
+                0, 0, 0, 1
+            ];  //stl
             //var labMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];  //unit
 
             function loadConductor(conductor, type) {
@@ -3373,8 +3376,8 @@ SIREPO.app.directive('particle3d', function(appState, errorService, frameCache, 
 
             function buildSTLCoordMapper(scale) {
                 var t1 = geometry.transform([
-                    [0, 0, 1],
                     [0, 1, 0],
+                    [0, 0, -1],
                     [1, 0, 0]
                 ]);
                 var t2 = geometry.transform(
@@ -3396,8 +3399,8 @@ SIREPO.app.directive('particle3d', function(appState, errorService, frameCache, 
                 var zOffset = bounds[4] + (bounds[5] - bounds[4]) / 2;
                 // the conductor centers are in microns
                 var offsetPos = [
-                    toMicronFactor * conductor.xCenter - xOffset,
                     toMicronFactor * conductor.yCenter - yOffset,
+                    toMicronFactor * conductor.xCenter - xOffset,
                     toMicronFactor * conductor.zCenter - zOffset
                 ];
                 var cColor = vtk.Common.Core.vtkMath.hex2float(type.color || SIREPO.APP_SCHEMA.constants.nonZeroVoltsColor);

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -383,9 +383,7 @@ SIREPO.app.controller('SourceController', function (appState, frameCache, panelS
         });
         panelState.showField('box', 'yLength', is3d);
         panelState.showField('conductorPosition', 'yCenter', is3d);
-        //panelState.showField('fieldReport', 'axes', is3d);
         panelState.showField('fieldCalcAnimation', 'axes', is3d);
-        //panelState.showEnum('fieldComparisonReport', 'dimension', 'y', is3d);
         panelState.showEnum(warpvndService.activeComparisonReport(), 'dimension', 'y', is3d);
     }
 
@@ -858,7 +856,6 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
                 top: 'top'
             };
 
-            var grid = appState.models.simulationGrid;
             var insetWidthPct = 0.07;
             var insetMargin = 16.0;
 
@@ -903,6 +900,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
             };
 
             function alignShapeOnGrid(shape) {
+                var grid = appState.models.simulationGrid;
                 var numX = grid.num_x;
                 var n = toMicron(grid.channel_width / (numX * 2));
                 var yCenter = shape.y - shape.height / 2;
@@ -1032,6 +1030,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
             }
 
             function d3DragLine() {
+                var grid = appState.models.simulationGrid;
                 var oldPlaneLine = planeLine;
                 planeLine = axes.z.scale.invert(d3.event.y);
                 var depth = toMicron(grid.channel_height / 2.0);
@@ -1077,6 +1076,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
                 if (shape.elev == ELEVATIONS.top) {
                     return true;
                 }
+                var grid = appState.models.simulationGrid;
                 var numX = grid.num_x;  // number of vertical cells
                 var halfChannel = toMicron(grid.channel_width/2.0);
                 var cellHeight = toMicron(grid.channel_width / numX);  // height of one cell
@@ -1107,6 +1107,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
             }
 
             function drawCathodeAndAnode(elev) {
+                var grid = appState.models.simulationGrid;
                 var info = plotInfoForElevation(elev);
                 var viewport = select(info.viewportClass);
                 viewport.selectAll('.warpvnd-plate').remove();
@@ -1163,6 +1164,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
             }
 
             function drawConductors(typeMap, elev) {
+                var grid = appState.models.simulationGrid;
                 var info = plotInfoForElevation(elev);
                 var shapes = [];
                 appState.models.conductors
@@ -1345,6 +1347,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
                     select('.z-plot-viewport .overlay').attr('class', 'overlay mouse-move-ew');
                 }
 
+                var grid = appState.models.simulationGrid;
                 var channel = toMicron(grid.channel_width);
                 axes.y.grid.tickValues(plotting.linearlySpacedArray(-channel / 2, channel / 2, grid.num_x + 1));
                 var depth = toMicron(grid.channel_height);
@@ -1367,6 +1370,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
             }
 
             function replot() {
+                var grid = appState.models.simulationGrid;
                 plateSize = toMicron(plateSpacing) / 15;
                 var newXDomain = [-plateSize, toMicron(plateSpacing) + plateSize];
                 if (! axes.x.domain || ! appState.deepEquals(axes.x.domain, newXDomain)) {
@@ -1419,7 +1423,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
             }
 
             function updateCarat(selection) {
-
+                var grid = appState.models.simulationGrid;
                 selection.attr('transform', function(d) {
                     var vertAxis = d.elev === ELEVATIONS.front ? axes.y : axes.z;
                     if (d.dimension === 'x' || d.dimension === 'y') {
@@ -1623,6 +1627,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
                     appState.whenModelsLoaded($scope, $scope.init);
                     return;
                 }
+                var grid = appState.models.simulationGrid;
                 plateSpacing = grid.plate_spacing;
                 select('svg').attr('height', plotting.initialHeight($scope));
                 $.each(axes, function(dim, axis) {
@@ -1670,6 +1675,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
             $scope.tileInsetSize = function() {
                 var w = 0;
                 var h = 0;
+                var grid = appState.models.simulationGrid;
                 if($scope.isDomainTiled) {
                     w = insetWidthPct * $scope.width;
                     h = warpvndService.is3D() ? w *  (grid.channel_width / grid.channel_height) : insetWidthPct * $scope.height;
@@ -1704,6 +1710,7 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
 
             appState.whenModelsLoaded($scope, function() {
                 $scope.is3dPreview = $scope.source.usesSTL();
+                var grid = appState.models.simulationGrid;
                 $scope.$on('cancelChanges', function(e, name) {
                     if (name == 'conductors') {
                         replot();
@@ -1714,7 +1721,6 @@ SIREPO.app.directive('conductorGrid', function(appState, layoutService, panelSta
                     plateSpacing = grid.plate_spacing;
                     replot();
                 });
-                //$scope.$on('fieldComparisonReport.changed', replot);
                 $scope.$on(warpvndService.activeComparisonReport() + '.changed', replot);
             });
         },
@@ -2994,7 +3000,7 @@ SIREPO.app.directive('conductors3d', function(appState, errorService, geometry, 
                 ];
                 a.addPosition(offsetPos);
                 a.getProperty().setColor(cColor[0], cColor[1], cColor[2]);
-                //stlActor.getProperty().setEdgeVisibility(true);
+                //a.getProperty().setEdgeVisibility(true);
                 a.getProperty().setLighting(false);
                 fsRenderer.getRenderer().addActor(a);
                 stlActors[conductor.id] = a;

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -1,4 +1,19 @@
 {
+    "animationArgs": {
+        "fieldCalcAnimation": ["axes", "slice"],
+        "fieldComparisonAnimation": [
+            "dimension'",
+            "xCell1",
+            "xCell2",
+            "xCell3",
+            "yCell1",
+            "yCell2",
+            "yCell3",
+            "zCell1",
+            "zCell2",
+            "zCell3"
+        ]
+    },
     "constants": {
         "nonZeroVoltsColor": "#6992ff",
         "particleTrackColor": "#4682b4",
@@ -140,6 +155,13 @@
             "framesPerSecond": ["Frames per Second", "FramesPerSecond", "2"],
             "colorMap": ["Color Map", "ColorMap", "viridis"],
             "notes": ["Notes", "Text", ""]
+        },
+        "fieldCalcAnimation": {
+            "_super": ["_", "model", "fieldReport"]
+        },
+        "fieldCalculationAnimation": {},
+        "fieldComparisonAnimation": {
+            "_super": ["_", "model", "fieldComparisonReport"]
         },
         "fieldComparisonReport": {
             "dimension": ["Dimension", "Dimension"],
@@ -309,6 +331,10 @@
                 "colorMap", "notes"
             ]
         },
+        "fieldCalculationAnimation": {
+            "title": "Field Calculation Status",
+            "advanced": []
+        },
         "fieldComparisonReport": {
             "title": "Field Comparison Report",
             "advanced": [
@@ -326,6 +352,31 @@
             ]
         },
         "fieldReport": {
+            "title": "Field Report",
+            "advanced": [
+                "axes",
+                "slice",
+                "colorMap",
+                "notes"
+            ]
+        },
+        "fieldComparisonAnimation": {
+            "title": "Field Comparison Report",
+            "advanced": [
+                "dimension",
+                "xCell1",
+                "xCell2",
+                "xCell3",
+                "yCell1",
+                "yCell2",
+                "yCell3",
+                "zCell1",
+                "zCell2",
+                "zCell3",
+                "notes"
+            ]
+        },
+        "fieldCalcAnimation": {
             "title": "Field Report",
             "advanced": [
                 "axes",

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -2,7 +2,7 @@
     "animationArgs": {
         "fieldCalcAnimation": ["axes", "slice"],
         "fieldComparisonAnimation": [
-            "dimension'",
+            "dimension",
             "xCell1",
             "xCell2",
             "xCell3",

--- a/sirepo/package_data/template/warpvnd/base.py.jinja
+++ b/sirepo/package_data/template/warpvnd/base.py.jinja
@@ -22,6 +22,8 @@ from scipy import constants
 from warp.data_dumping.openpmd_diag import ParticleDiagnostic
 from warp.field_solvers.generateconductors import XPlane, YPlane, ZPlane, Box, Sphere
 
+print('START BASE')
+
 {% if isOptimize %}
 def parse_opts():
     res = {}
@@ -333,6 +335,8 @@ extractor_voltage = vacuum_level
 # --- Anode Location
 zplate = Z_MAX # --- plate location
 
+print('ADD CONDS')
+
 conductors = [
 {% for c in conductors %}
 {% if c.conductor_type.type == 'stl' %}
@@ -372,3 +376,4 @@ wp.installafterstep(efield_diagnostic_0.write)
 {% endif %}
 
 #------
+print('END BASE')

--- a/sirepo/package_data/template/warpvnd/base.py.jinja
+++ b/sirepo/package_data/template/warpvnd/base.py.jinja
@@ -344,7 +344,8 @@ conductors = [
 ]
 
 for c in conductors:
-    wp.installconductor(c, dfill=wp.largepos)
+    if c.voltage != 0:
+        wp.installconductor(c, dfill=wp.largepos)
 
 # Create source conductors
 source = wp.ZPlane(zcent=wp.w3d.zmmin, zsign=-1., voltage=0., condid= len(conductors) + 1)

--- a/sirepo/package_data/template/warpvnd/base.py.jinja
+++ b/sirepo/package_data/template/warpvnd/base.py.jinja
@@ -22,8 +22,6 @@ from scipy import constants
 from warp.data_dumping.openpmd_diag import ParticleDiagnostic
 from warp.field_solvers.generateconductors import XPlane, YPlane, ZPlane, Box, Sphere
 
-print('START BASE')
-
 {% if isOptimize %}
 def parse_opts():
     res = {}
@@ -335,8 +333,6 @@ extractor_voltage = vacuum_level
 # --- Anode Location
 zplate = Z_MAX # --- plate location
 
-print('ADD CONDS')
-
 conductors = [
 {% for c in conductors %}
 {% if c.conductor_type.type == 'stl' %}
@@ -376,4 +372,4 @@ wp.installafterstep(efield_diagnostic_0.write)
 {% endif %}
 
 #------
-print('END BASE')
+

--- a/sirepo/package_data/template/warpvnd/source-field.py.jinja
+++ b/sirepo/package_data/template/warpvnd/source-field.py.jinja
@@ -87,3 +87,5 @@ e_cross = sources.compute_crossing_fraction(CATHODE_TEMP, Phi_approx, zmesh)
 field_results.tof_expected = tof_expected
 field_results.steps_expected = steps_expected
 field_results.e_cross = e_cross
+
+wp.step({{ stepSize }})

--- a/sirepo/package_data/template/warpvnd/source-field.py.jinja
+++ b/sirepo/package_data/template/warpvnd/source-field.py.jinja
@@ -1,4 +1,4 @@
-
+print('START SOURCE FIELD')
 from sirepo.template import template_common
 
 #prevent GIST from starting upon setup

--- a/sirepo/package_data/template/warpvnd/source-field.py.jinja
+++ b/sirepo/package_data/template/warpvnd/source-field.py.jinja
@@ -1,11 +1,12 @@
 
+from sirepo import simulation_db
 from sirepo.template import template_common
 
 #prevent GIST from starting upon setup
 wp.top.lprntpara = False
 wp.top.lpsplots = False
 
-field_results = pkcollections.Dict()
+field_estimates = pkcollections.Dict()
 
 wp.top.verbosity = 1 # Reduce solver verbosity
 solverE.mgverbose = 1 #further reduce output upon stepping - prevents websocket timeouts in Jupyter notebook
@@ -84,8 +85,9 @@ Phi_approx = scipy_interp1d(zmesh,flat_Phi, kind='cubic')
 
 e_cross = sources.compute_crossing_fraction(CATHODE_TEMP, Phi_approx, zmesh)
 
-field_results.tof_expected = tof_expected
-field_results.steps_expected = steps_expected
-field_results.e_cross = e_cross
+field_estimates.tof_expected = tof_expected
+field_estimates.steps_expected = steps_expected
+field_estimates.e_cross = e_cross
+simulation_db.write_json('{{ estimateFile }}', field_estimates)
 
 wp.step({{ stepSize }})

--- a/sirepo/package_data/template/warpvnd/source-field.py.jinja
+++ b/sirepo/package_data/template/warpvnd/source-field.py.jinja
@@ -1,4 +1,4 @@
-print('START SOURCE FIELD')
+
 from sirepo.template import template_common
 
 #prevent GIST from starting upon setup

--- a/sirepo/pkcli/warpvnd.py
+++ b/sirepo/pkcli/warpvnd.py
@@ -16,6 +16,7 @@ import sirepo.template.warpvnd as template
 
 
 def run(cfg_dir):
+    pkdp('!WARP RUN FG')
     with pkio.save_chdir(cfg_dir):
         exec(_script(), locals(), locals())
         data = simulation_db.read_json(template_common.INPUT_BASE_NAME)

--- a/sirepo/pkcli/warpvnd.py
+++ b/sirepo/pkcli/warpvnd.py
@@ -16,7 +16,6 @@ import sirepo.template.warpvnd as template
 
 
 def run(cfg_dir):
-    pkdp('!WARP RUN FG')
     with pkio.save_chdir(cfg_dir):
         exec(_script(), locals(), locals())
         data = simulation_db.read_json(template_common.INPUT_BASE_NAME)

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -473,6 +473,8 @@ def report_parameters_hash(data):
 def report_fields(data, report_name, style_fields):
     # if the model has "style" fields, then return the full list of non-style fields
     # otherwise returns the report name (which implies all model fields)
+    if report_name not in data.models:
+        return [report_name]
     m = data.models[report_name]
     for style_field in style_fields:
         if style_field not in m:
@@ -497,8 +499,10 @@ def resource_dir(sim_type):
     return _RESOURCE_DIR.join(sim_type)
 
 
-def update_model_defaults(model, name, schema):
+def update_model_defaults(model, name, schema, dynamic=None):
     defaults = model_defaults(name, schema)
+    if dynamic is not None:
+        defaults.update(dynamic)
     for f in defaults:
         if f not in model:
             model[f] = defaults[f]

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -26,6 +26,7 @@ SIM_TYPE = 'warpvnd'
 WANT_BROWSER_FRAME_CACHE = True
 
 _FIELD_ANIMATIONS = ['fieldCalcAnimation', 'fieldComparisonAnimation']
+_FIELD_ESTIMATE_FILE = 'estimates.json'
 _COMPARISON_FILE = 'diags/fields/electric/data00{}.h5'.format(COMPARISON_STEP_SIZE)
 _CULL_PARTICLE_SLOPE = 1e-4
 _DENSITY_FILE = 'density.h5'
@@ -212,9 +213,9 @@ def get_animation_name(data):
 
 def get_application_data(data):
     if data['method'] == 'compute_simulation_steps':
-        run_dir = simulation_db.simulation_dir(SIM_TYPE, data['simulationId']).join('fieldReport')
+        run_dir = simulation_db.simulation_dir(SIM_TYPE, data['simulationId']).join('fieldCalculationAnimation')
         if run_dir.exists():
-            res = simulation_db.read_result(run_dir)[0]
+            res = simulation_db.read_json(run_dir.join(_FIELD_ESTIMATE_FILE))
             if res and 'tof_expected' in res:
                 return {
                     'timeOfFlight': res['tof_expected'],
@@ -788,6 +789,7 @@ def _generate_parameters_file(data):
     v['stepSize'] = COMPARISON_STEP_SIZE
     v['densityFile'] = _DENSITY_FILE
     v['egunCurrentFile'] = _EGUN_CURRENT_FILE
+    v['estimateFile'] = _FIELD_ESTIMATE_FILE
     v['conductors'] = _prepare_conductors(data)
     v['usesSTL'] = any(ct['file'] is not None for ct in data.models.conductorTypes)
     v['maxConductorVoltage'] = _max_conductor_voltage(data)

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -58,10 +58,6 @@ def fixup_old_data(data):
         }
     for m in [
             'egunCurrentAnimation',
-            'fieldCalcAnimation',
-            'fieldCalculationAnimation',
-            'fieldComparisonAnimation',
-            'fieldReport',
             'impactDensityAnimation',
             'optimizer',
             'optimizerAnimation',
@@ -70,6 +66,10 @@ def fixup_old_data(data):
             'particleAnimation',
             'simulation',
             'simulationGrid',
+            'fieldCalcAnimation',
+            'fieldCalculationAnimation',
+            'fieldComparisonAnimation',
+            'fieldReport',
     ]:
         if m not in data.models:
             data.models[m] = {}

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -157,6 +157,7 @@ def generate_field_report(data, run_dir, args=None):
 
     x_max = len(values[0])
     y_max = len(values)
+    vals_equal = np.isclose(np.std(values), 0., atol=1e-9)
     if axes == 'xz':
         xr = [0, plate_spacing, x_max]
         yr = [- radius, radius, y_max]
@@ -188,8 +189,8 @@ def generate_field_report(data, run_dir, args=None):
         'y_label': y_label,
         'title': 'ϕ Across Whole Domain ({} = {}µm)'.format(other_axis, phi_slice),
         'z_matrix': values.tolist(),
-        'global_min': np.min(potential),
-        'global_max': np.max(potential),
+        'global_min': np.min(potential) if vals_equal else None,
+        'global_max': np.max(potential) if vals_equal else None,
         'frequency_title': 'Volts'
     }
 

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -103,15 +103,7 @@ def generate_field_comparison_report(data, run_dir, args=None):
         'y': [-half_height, half_height],
         'z': [0, _meters(grid['plate_spacing'])]
     }
-    x_range = [-radius, radius]
-    y_range = [-half_height, half_height]
-    z_range = [0, _meters(grid['plate_spacing'])]
-    if dimension == 'x':
-        plot_range = x_range
-    elif dimension == 'y':
-        plot_range = y_range
-    else:
-        plot_range = z_range
+    plot_range = ranges[dimension]
     plots, plot_y_range = _create_plots(dimension, params, values, ranges)
     return {
         'title': 'Comparison of E {}'.format(dimension),

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -462,14 +462,14 @@ def _create_plots(dimension, params, values, ranges):
     plots = []
     color = _SCHEMA.constants.cellColors
     label_fmts = {
-        'x':  u'{:.3f} µm',
-        'y': u'{:.3f} µm',
-        'z': '{:.0f} nm'
+        'x': u'{:.0f} nm',
+        'y': u'{:.0f} nm',
+        'z': u'{:.3f} µm'
     }
     label_factors = {
-        'x': 1e6,
-        'y': 1e6,
-        'z': 1e9
+        'x': 1e9,
+        'y': 1e9,
+        'z': 1e6
     }
     x_points = {}
     for axis_idx, axis in enumerate(all_axes):


### PR DESCRIPTION
Notes:

- This replaces the field and field comparison reports with "animations" so that the reports dip from the same simulations results (addressing #1739 ). This is for both 2d and 3d at the moment, as allowing two different report types depending on that was getting a little convoluted
- Consider this a starting point for moving from the historical report/animation duality to a unified approach (again see the discussion for #1739). I've gone with "calculation" or "calc" as a possible description distinct from "simulation"
- 3d conductor grid now has carats in the bottom plot
- Field comparison report allows selection of the y component of the field in 3d
- Heatmaps allow for optional min/max to set the range of values.  Useful for cross-sections that are uniform but vary along the other axis