### PR TITLE
Minor fixes to fete 3d

### DIFF
--- a/sirepo/package_data/static/html/conductor-grid.html
+++ b/sirepo/package_data/static/html/conductor-grid.html
@@ -57,5 +57,5 @@
   </div>
 </div>
 <div data-ng-if="warpvndService.is3D() && is3dPreview">
- <div data-conductors-3d="" data-report-id="reportId" data-parent-controller="source"></div>
+ <div class="vtk-canvas-holder" data-conductors-3d="" data-report-id="reportId" data-parent-controller="source"></div>
 </div>

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -2613,7 +2613,7 @@ SIREPO.app.directive('conductors3d', function(appState, errorService, geometry, 
             // if we have stl-type conductors, we might need to rescale the grid for drawing
             // (easier and faster than scaling the data)
             var toMetersFactor = Math.min.apply(null, warpvndService.stlScaleRanges.scale);
-            var toMicronFactor = 1e-6;
+            var toMicronFactor = 1.0;
             var gridOffsets = [0, 0, 0];
             var domain = {
                 width: 1,

--- a/sirepo/package_data/template/warpvnd/base.py.jinja
+++ b/sirepo/package_data/template/warpvnd/base.py.jinja
@@ -344,7 +344,8 @@ conductors = [
 ]
 
 for c in conductors:
-    wp.installconductor(c, dfill=wp.largepos)
+    if c.voltage != 0:
+        wp.installconductor(c, dfill=wp.largepos)
 
 # Create source conductors
 source = wp.ZPlane(zcent=wp.w3d.zmmin, zsign=-1., voltage=0., condid= len(conductors) + 1)


### PR DESCRIPTION
Notes:

- #1742: was adding 0-volt conductors which the previous code did not.  Removed that
- #1743: changes to support stl files introduced a constant 1e-6 factor to conductor sizes, which should not matter except vtk balks at very small numbers.  Defaulting to 1 instead gets vtk to behave