### PR TITLE
Fete visualization changes

### DIFF
--- a/sirepo/package_data/static/html/particle3d.html
+++ b/sirepo/package_data/static/html/particle3d.html
@@ -15,7 +15,8 @@
               </div>
               <div>
                 <a href="" data-ng-click="toggleConductors()"><span class="glyphicon" data-ng-class="{'glyphicon-check': showConductors, 'glyphicon-unchecked': ! showConductors}"></span></a> Conductors
-                &nbsp;&nbsp;&nbsp;<span data-ng-show="enableImpactDensity"><a href=""  data-ng-click="toggleImpactDensity()"><span class="glyphicon" data-ng-class="{'glyphicon-check': showImpactDensity, 'glyphicon-unchecked': ! showImpactDensity}"></span></a> Impact Density</span>
+                &nbsp;&nbsp;&nbsp;<span data-ng-show="enableSTLPolys"><a href=""  data-ng-click="toggleSTLPolys()"><span class="glyphicon" data-ng-class="{'glyphicon-check': showSTLPolys, 'glyphicon-unchecked': ! showSTLPolys}"></span></a> Show Polygons </span>
+                   &nbsp;<span data-ng-show="enableImpactDensity"><a href=""  data-ng-click="toggleImpactDensity()"><span class="glyphicon" data-ng-class="{'glyphicon-check': showImpactDensity, 'glyphicon-unchecked': ! showImpactDensity}"></span></a> Impact Density</span>
               </div>
             </div>
             <div class="col-sm-6">

--- a/sirepo/package_data/static/html/warpvnd-visualization.html
+++ b/sirepo/package_data/static/html/warpvnd-visualization.html
@@ -53,10 +53,10 @@
       <div data-ng-if="! visualization.warpvndService.isEGunMode(true)" data-report-panel="parameter" data-model-name="currentAnimation"></div>
       <div data-ng-if="visualization.warpvndService.isEGunMode(true)" data-report-panel="parameter" data-model-name="egunCurrentAnimation"></div>
     </div>
-    <div class="col-md-6" data-ng-if="! visualization.warpvndService.is3D() && visualization.hasFrames('impactDensityAnimation')">
+    <div class="col-md-6" data-ng-if="! visualization.ranIn3d && visualization.hasFrames('impactDensityAnimation')">
       <div data-report-panel="impactDensity" data-model-name="impactDensityAnimation"></div>
     </div>
-    <div class="col-md-6" data-ng-if="visualization.warpvndService.is3D() && visualization.hasFrames('particleAnimation')">
+    <div class="col-md-6" data-ng-if="visualization.ranIn3d && visualization.hasFrames('particleAnimation')">
       <div data-report-panel="particle3d" data-model-name="particle3d"></div>
     </div>
   </div>

--- a/sirepo/package_data/static/html/warpvnd-visualization.html
+++ b/sirepo/package_data/static/html/warpvnd-visualization.html
@@ -42,7 +42,7 @@
           </div>
         </div>
         <div class="col-sm-12" data-ng-if="visualization.hasFrames('fieldAnimation')">
-          <div data-report-panel="heatmap" data-model-name="fieldAnimation"></div>
+            <div class="col-sm-12" data-ng-if="visualization.hasFrames('fieldAnimation')" data-field-animation="" data-model-name="fieldAnimation"></div>
         </div>
         <div class="col-sm-12" data-ng-if="visualization.hasFrames('particleAnimation')">
           <div data-report-panel="particle" data-model-name="particleAnimation"></div>

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -487,6 +487,9 @@ SIREPO.app.directive('fieldEditor', function(appState, keypressService, panelSta
               '<div data-ng-switch-when="OptFloat" data-ng-class="fieldClass">',
                 '<div data-optimize-float="" data-model="model" data-model-name="modelName" data-field="field" data-min="info[4]" data-max="info[5]" ></div>',
               '</div>',
+               '<div data-ng-switch-when="Range" data-ng-class="fieldClass">',
+                  '<div data-range-slider="" data-model="model" data-model-name="modelName" data-field="field" data-field-delegate="fieldDelegate"></div>',
+               '</div>',
               SIREPO.appFieldEditors || '',
               // assume it is an enum
               '<div data-ng-switch-default data-ng-class="fieldClass">',
@@ -2692,15 +2695,50 @@ SIREPO.app.directive('rangeSlider', function(appState, panelState) {
         restrict: 'A',
         scope: {
             field: '=',
+            fieldDelegate: '<',
             model: '=',
             modelName: '=',
-            update: '&',
         },
         template: [
-            '<input id="{{ modelName }}-{{ field }}-range" type="range" data-ng-model="model[field]" data-ng-change="update()()">',
+            '<input id="{{ modelName }}-{{ field }}-range" type="range" data-ng-model="model[field]" data-ng-change="fieldDelegate.update()">',
             '<span class="valueLabel">{{ model[field] }}{{ model.units }}</span>',
         ].join(''),
         controller: function($scope) {
+            var slider;
+            
+            var delegate = $scope.fieldDelegate;
+            if (! delegate|| $.isEmptyObject(delegate)) {
+                delegate = panelState.getFieldDelegate($scope.modelName, $scope.field);
+            }
+
+            function update() {
+                updateReadout();
+                updateSlider();
+            }
+
+            function updateSlider() {
+                var r = delegate.range();
+                slider.attr('min', r.min);
+                slider.attr('step', r.step);
+                slider.attr('max', r.max);
+            }
+
+            function updateReadout() {
+                panelState.setFieldLabel($scope.modelName, $scope.field, delegate.readout());
+            }
+
+            appState.watchModelFields($scope, (delegate.watchFields || []), update);
+
+            appState.whenModelsLoaded($scope, function () {
+                slider = $('#' + $scope.modelName + '-' + $scope.field + '-range');
+                update();
+                // on load, the slider will coerce model values to fit the basic input model of range 0-100,
+                // step 1.  This resets to the saved value
+                var val = delegate.storedVal;
+                if ((val || val === 0) && $scope.model[$scope.field] != val) {
+                    $scope.model[$scope.field] = val;
+                }
+            });
         },
     };
 });

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -2707,7 +2707,7 @@ SIREPO.app.directive('rangeSlider', function(appState, panelState) {
             var slider;
             
             var delegate = $scope.fieldDelegate;
-            if (! delegate|| $.isEmptyObject(delegate)) {
+            if (! delegate || $.isEmptyObject(delegate)) {
                 delegate = panelState.getFieldDelegate($scope.modelName, $scope.field);
             }
 

--- a/sirepo/package_data/static/js/sirepo-plotting.js
+++ b/sirepo/package_data/static/js/sirepo-plotting.js
@@ -572,9 +572,25 @@ SIREPO.app.factory('plotting', function(appState, frameCache, panelState, utilit
             });
         },
 
+        min3d: function(data) {
+            return d3.min(data, function(row) {
+                return d3.min(row, function(col) {
+                    return d3.min(col);
+                });
+            });
+        },
+
         max2d: function(data) {
             return d3.max(data, function(row) {
                 return d3.max(row);
+            });
+        },
+
+        max3d: function(data) {
+            return d3.max(data, function(row) {
+                return d3.max(row, function(col) {
+                    return d3.max(col);
+                });
             });
         },
 

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -891,6 +891,14 @@ SIREPO.app.factory('frameCache', function(appState, panelState, requestSender, $
         return args.join('_');
     }
 
+    self.buildArgs = function(modelName, version) {
+        var args = [SIREPO.ANIMATION_ARGS_VERSION + version];
+        if (! SIREPO.APP_SCHEMA.animationArgs[modelName]) {
+            return  args;
+        }
+        return args.concat(SIREPO.APP_SCHEMA.animationArgs[modelName]);
+    };
+
     self.getCurrentFrame = function(modelName) {
         var v = self.animationInfo[modelName];
         if (v) {

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1186,6 +1186,20 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
         $(fc).find('.sr-enum-button').prop('disabled', ! isEnabled);
     };
 
+    // lazy creation/storage of field delegates
+    self.fieldDelegates = {};
+    self.getFieldDelegate = function(modelName, field) {
+        if (! self.fieldDelegates[modelName]) {
+            self.fieldDelegates[modelName] = {};
+        }
+        if (! self.fieldDelegates[modelName][field]) {
+            self.fieldDelegates[modelName][field] = {
+                storedVal: appState.models[modelName][field],
+            };
+        }
+        return self.fieldDelegates[modelName][field];
+    };
+
     self.fileNameFromText = function(text, extension) {
         return text.replace(/(\_|\W|\s)+/g, '-') + '.' + extension;
     };

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -796,8 +796,6 @@ SIREPO.app.controller('VisualizationController', function (appState, errorServic
     var self = this;
     self.warpvndService = warpvndService;
 
-    var axesRanges = {};
-
     function computeSimulationSteps() {
         panelState.showField('simulation', 'egun_mode', ! warpvndService.is3D());
         if (warpvndService.is3D()) {
@@ -4427,15 +4425,11 @@ SIREPO.app.directive('particle3d', function(appState, errorService, frameCache, 
                             k = j + 1;
                             p1 = points[i][j];
                             p2 = points[i][k];
-                            if (color) {
-                                pushLineData(p1, p2, color);
-                                continue;
-                            }
                             cp1 = cellOfPt(p1);
                             cp2 = cellOfPt(p2);
 
                             var meanVal = 0.5 * (heatmap[cp1[0]][cp1[1]][cp1[2]] + heatmap[cp2[0]][cp2[1]][cp2[2]]);
-                            c = plotting.colorsFromHexString(fieldColorScale(meanVal), 255.0);
+                            c = color || plotting.colorsFromHexString(fieldColorScale(meanVal), 255.0);
                             pushLineData(p1, p2, c);
                         }
                     }
@@ -4486,32 +4480,6 @@ SIREPO.app.directive('particle3d', function(appState, errorService, frameCache, 
                         dataColors.push(Math.floor(255*comp));
                     });
                 }
-            }
-
-            function colorIndexValPriorTo(map, startIndex, spacing) {
-                var k = startIndex - spacing;
-                var prevVal = map[k];
-                while(k >= 0 && (prevVal == null || prevVal === 'undefined')) {
-                    k -= spacing;
-                    prevVal = map[k];
-                }
-                return Math.max(0, prevVal);
-            }
-
-            function colorAtIndex(index) {
-                if (index !== 0 && ! index) {
-                    return plotting.colorsFromHexString('#000000', 255.0);
-                }
-                //var fieldxIndex = Math.min(heatmap[0].length-1, Math.floor(fieldXFactor * index));
-                //var fieldzIndex = Math.min(heatmap.length-1, Math.floor(fieldZFactor * index));
-                //var fieldyIndex = Math.min(heatmap[0][0].length-1, Math.floor(fieldYFactor * index));  //Math.floor(fieldYFactor * index);
-                var fieldxIndex = Math.min(heatmap.length-1, Math.floor(fieldXFactor * index));
-                var fieldyIndex = Math.min(heatmap[0].length-1, Math.floor(fieldYFactor * index));
-                var fieldzIndex = Math.min(heatmap[0][0].length-1, Math.floor(fieldZFactor * index));  //Math.floor(fieldYFactor * index);
-                var v = heatmap[fieldxIndex][fieldyIndex][fieldzIndex];
-                //srdbg(index, 'val at', 'x', fieldxIndex, 'y', fieldyIndex, 'z', fieldzIndex, ':', v);
-                //return plotting.colorsFromHexString(fieldColorScale(heatmap[fieldzIndex][fieldxIndex]), 255.0);
-                return plotting.colorsFromHexString(fieldColorScale(v), 255.0);
             }
 
             $scope.vtkCanvasGeometry = function() {

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -4532,31 +4532,50 @@ SIREPO.app.directive('particle3d', function(appState, errorService, frameCache, 
                 var dataPoints = [];
                 var dataLines = [];
                 var dataColors = [];
+                var p1 = [];
+                var p2 = [];
+                var cp1 = [];
+                var cp2 = [];
                 var lastP = [];
                 var newP = [];
                 var lastCell = [];
                 var newCell = [];
+
+                // lines
                 for (var i = 0; i < points.length; ++i) {
                     var l = points[i].length;
                     var multiCell = 0;
+
+                    // points making up the line
                     for (var j = 0; j < l; ++j) {
                         if (j < l - 1) {
                             k = j + 1;
-                            var p1 = points[i][j];
-                            var p2 = points[i][k];
-                            if (color) {
-                                pushLineData(p1, p2, color);
-                                continue;
+                            p1 = points[i][j];
+                            p2 = points[i][k];
+                            //if (color) {
+                            //    pushLineData(p1, p2, color);
+                            //    continue;
+                            //}
+                            cp1 = cellOfPt(p1);
+                            if (cp1[0] < 0 || cp1[0] > grid.num_x ||
+                                cp1[1] < 0 || cp1[1] > grid.num_y ||
+                                cp1[2] < 0 || cp1[2] > grid.num_z) {
+                                srdbg('line', i,  'BAD CELL', cp1, p1);
                             }
-                            var cp1 = cellOfPt(p1);
-                            var cp2 = cellOfPt(p2);
-                            var cpd = cp1.map(function (c, cx) {
-                                return cp2[cx] - c;
-                            });
-                            if (Math.abs(cpd[0] > 0) || Math.abs(cpd[1] > 0) || Math.abs(cpd[2] > 0)) {
+                            //srdbg('line', i, 'seg', j, ':', p1, '->', p1, 'of', l, 'color from', cp1);
+                            //srdbg('line', i, 'seg', j, 'color from', cp1);
+                            var c = color || plotting.colorsFromHexString(fieldColorScale(heatmap[cp1[0]][cp1[1]][cp1[2]]), 255.0);
+                            pushLineData(p1, p2, c);
+                            //cp2 = cellOfPt(p2);
+                            //var cpDiff = cp1.map(function (c, cx) {
+                            //    return cp2[cx] - c;
+                            //});
+                            /*
+                            // endpoints of line segment are in different grid cells
+                            if (Math.abs(cpDiff[0] > 0) || Math.abs(cpDiff[1] > 0) || Math.abs(cpDiff[2] > 0)) {
                                 //srdbg('line', i, 'point', j, 'point1', cp1, 'point2', k, cp2, cpd);
                                 for (var m = 0; m < 3; ++m) {
-                                    var dir = Math.sign(cpd[m]);
+                                    var dir = Math.sign(cpDiff[m]);
                                     if (! dir) {
                                         continue;
                                     }
@@ -4591,11 +4610,13 @@ SIREPO.app.directive('particle3d', function(appState, errorService, frameCache, 
                             else {
                                 pushLineData(p1, p2, plotting.colorsFromHexString(fieldColorScale(heatmap[cp1[0]][cp1[1]][cp1[2]]), 255.0));
                             }
+
+                             */
                             //pushLineData(points[i][j], points[i][k], color || colorAtIndex(pointToColorIndexMaps[i][j]));
                         }
                     }
+                    /*
                     if (l > j) {
-                        srdbg('leftover');
                         k = j - 1;
                         p1 = points[i][k];
                         p2 = points[i][l - 1];
@@ -4608,6 +4629,7 @@ SIREPO.app.directive('particle3d', function(appState, errorService, frameCache, 
                         pushLineData(p1, p2, plotting.colorsFromHexString(fieldColorScale(heatmap[cp1[0]][cp1[1]][cp1[2]]), 255.0));
                         //pushLineData(points[i][k], points[i][l - 1], color || colorAtIndex(pointToColorIndexMaps[i][k]));
                     }
+                    */
                     if (includeImpact) {
                         k = points[i].length - 1;
                         //impactSphereActors.push(coordMapper.buildSphere(points[i][k], impactSphereSize, color || colorAtIndex(pointToColorIndexMaps[i][k])).actor);

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -1,5 +1,6 @@
 {
     "animationArgs": {
+        "fieldAnimation": ["field", "axes", "displayMode", "startTime"],
         "fieldCalcAnimation": ["axes", "displayMode", "slice"],
         "fieldComparisonAnimation": [
             "dimension",
@@ -13,7 +14,9 @@
             "zCell1",
             "zCell2",
             "zCell3"
-        ]
+        ],
+        "particleAnimation": ["renderCount", "startTime"],
+        "particle3d": ["renderCount", "displayMode", "startTime"]
     },
     "constants": {
         "nonZeroVoltsColor": "#6992ff",

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -1,6 +1,6 @@
 {
     "animationArgs": {
-        "fieldAnimation": ["field", "axes", "displayMode", "startTime"],
+        "fieldAnimation": ["field", "axes", "slice", "displayMode", "startTime"],
         "fieldCalcAnimation": ["axes", "displayMode", "slice"],
         "fieldComparisonAnimation": [
             "dimension",
@@ -359,6 +359,7 @@
                 "field",
                 "framesPerSecond",
                 "axes",
+                "slice",
                 "colorMap",
                 "notes"
             ]

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -52,8 +52,7 @@ def background_percent_complete(report, run_dir, is_running):
 
 
 def fixup_old_data(data):
-    if 'optimizer' not in data['models'] or \
-            'enabledFields' not in data['models']['optimizer']:
+    if 'optimizer' not in data['models'] or 'enabledFields' not in data['models']['optimizer']:
         data['models']['optimizer'] = {
             'constraints': [],
             'enabledFields': {},
@@ -78,9 +77,7 @@ def fixup_old_data(data):
     ]:
         if m not in data.models:
             data.models[m] = {}
-        template_common.update_model_defaults(
-            data.models[m], m, _SCHEMA, dynamic=_dynamic_defaults(data, m)
-        )
+        template_common.update_model_defaults(data.models[m], m, _SCHEMA, dynamic=_dynamic_defaults(data, m))
     if 'joinEvery' in data.models.particle3d:
         del data.models.particle3d['joinEvery']
     types = data.models.conductorTypes if 'conductorTypes' in data.models else []
@@ -90,11 +87,8 @@ def fixup_old_data(data):
         if 'isConductor' not in c:
             c.isConductor = '1' if c.voltage > 0 else '0'
         if 'color' not in c:
-            c.color = _SCHEMA.constants.zeroVoltsColor if c.isConductor == '0' \
-                else _SCHEMA.constants.nonZeroVoltsColor
-        template_common.update_model_defaults(
-            c, c.type if 'type' in c else 'box', _SCHEMA
-        )
+            c.color = _SCHEMA.constants.zeroVoltsColor if c.isConductor == '0' else _SCHEMA.constants.nonZeroVoltsColor
+        template_common.update_model_defaults(c, c.type if 'type' in c else 'box', _SCHEMA)
     for c in data.models.conductors:
         template_common.update_model_defaults(c, 'conductorPosition', _SCHEMA)
     template_common.organize_example(data)
@@ -193,14 +187,8 @@ def get_application_data(data):
 
 
 def get_data_file(run_dir, model, frame, **kwargs):
-    if model == 'particleAnimation' or model == 'egunCurrentAnimation' or \
-            model == 'particle3d':
-        filename = str(
-            run_dir.join(
-                _PARTICLE_FILE if model == 'particleAnimation' or
-                                  model == 'particle3d' else _EGUN_CURRENT_FILE
-            )
-        )
+    if model == 'particleAnimation' or model == 'egunCurrentAnimation' or model == 'particle3d':
+        filename = str(run_dir.join(_PARTICLE_FILE if model == 'particleAnimation' or model == 'particle3d' else _EGUN_CURRENT_FILE))
         with open(filename) as f:
             return os.path.basename(filename), f.read(), 'application/octet-stream'
     #TODO(pjm): consolidate with template/warp.py
@@ -224,9 +212,7 @@ def get_zcurrent_new(particle_array, momenta, mesh, particle_weight, dz):
     dz: Cell Size
     """
     current = np.zeros_like(mesh)
-    velocity = constants.c * momenta / np.sqrt(
-        momenta**2 + (constants.electron_mass * constants.c)**2
-    ) * particle_weight
+    velocity = constants.c * momenta / np.sqrt(momenta**2 + (constants.electron_mass * constants.c)**2) * particle_weight
 
     for index, zval in enumerate(particle_array):
         bucket = np.round(zval/dz) #value of the bucket/index in the current array
@@ -239,8 +225,7 @@ def get_simulation_frame(run_dir, data, model_data):
     md = pkcollections.Dict(model_data)
     frame_index = int(data['frameIndex'])
     model_name = data['modelName']
-    anim_args = _SCHEMA.animationArgs[model_name] if model_name in _SCHEMA.animationArgs \
-        else []
+    anim_args = _SCHEMA.animationArgs[model_name] if model_name in _SCHEMA.animationArgs else []
     args = template_common.parse_animation_args(data, {'': anim_args})
     if model_name == 'currentAnimation':
         data_file = open_data_file(run_dir, model_name, frame_index)
@@ -251,9 +236,7 @@ def get_simulation_frame(run_dir, data, model_data):
     if model_name == 'particleAnimation' or model_name == 'particle3d':
         return _extract_particle(run_dir, model_name, model_data, args)
     if model_name == 'egunCurrentAnimation':
-        return _extract_egun_current(
-            model_data, run_dir.join(_EGUN_CURRENT_FILE), frame_index
-        )
+        return _extract_egun_current(model_data, run_dir.join(_EGUN_CURRENT_FILE), frame_index)
     if model_name == 'impactDensityAnimation':
         return _extract_impact_density(run_dir, model_data)
     if model_name == 'optimizerAnimation':
@@ -327,13 +310,9 @@ def prepare_output_file(run_dir, data):
         if fn.exists():
             fn.remove()
             if data.report == 'fieldComparisonReport':
-                simulation_db.write_result(
-                    generate_field_comparison_report(data, run_dir), run_dir=run_dir
-                )
+                simulation_db.write_result(generate_field_comparison_report(data, run_dir), run_dir=run_dir)
             else:
-                simulation_db.write_result(
-                    generate_field_report(data, run_dir), run_dir=run_dir
-                )
+                simulation_db.write_result(generate_field_report(data, run_dir), run_dir=run_dir)
 
 
 def python_source_for_model(data, model):
@@ -413,8 +392,7 @@ def _add_particle_paths(electrons, x_points, y_points, z_points, half_height, li
         x_points.append(res['x'])
         y_points.append(res['y'])
         z_points.append(res['z'])
-    pkdc('particles: {} paths, {} points {} points culled',
-         len(x_points), count, cull_count)
+    pkdc('particles: {} paths, {} points {} points culled', len(x_points), count, cull_count)
 
 
 def _compute_delta_for_field(data, bounds, field):
@@ -534,42 +512,28 @@ def _extract_current(data, data_file):
     grid = data['models']['simulationGrid']
     plate_spacing = _meters(grid['plate_spacing'])
     dz = plate_spacing / grid['num_z']
-
-    # holds the z-axis grid points in an array
-    zmesh = np.linspace(0, plate_spacing, grid['num_z'] + 1)
+    zmesh = np.linspace(0, plate_spacing, grid['num_z'] + 1) #holds the z-axis grid points in an array
     report_data = readparticles(data_file.filename)
     data_time = report_data['time']
     with h5py.File(data_file.filename, 'r') as f:
-        weights = np.array(
-            f['data/{}/particles/beam/weighting'.format(data_file.iteration)]
-        )
-    curr = get_zcurrent_new(
-        report_data['beam'][:,4], report_data['beam'][:,5], zmesh, weights, dz
-    )
+        weights = np.array(f['data/{}/particles/beam/weighting'.format(data_file.iteration)])
+    curr = get_zcurrent_new(report_data['beam'][:,4], report_data['beam'][:,5], zmesh, weights, dz)
     return _extract_current_results(data, curr, data_time)
 
 
 def _extract_current_results(data, curr, data_time):
     grid = data['models']['simulationGrid']
     plate_spacing = _meters(grid['plate_spacing'])
-
-    # holds the z-axis grid points in an array
-    zmesh = np.linspace(0, plate_spacing, grid['num_z'] + 1)
+    zmesh = np.linspace(0, plate_spacing, grid['num_z'] + 1) #holds the z-axis grid points in an array
     beam = data['models']['beam']
     if _is_3D(data):
         cathode_area = _meters(grid['channel_width']) * _meters(grid['channel_height'])
     else:
         cathode_area = _meters(grid['channel_width'])
-    RD_ideal = sources.j_rd(
-        beam['cathode_temperature'], beam['cathode_work_function']
-    ) * cathode_area
-    JCL_ideal = sources.cl_limit(
-        beam['cathode_work_function'], beam['anode_work_function'],
-        beam['anode_voltage'], plate_spacing
-    ) * cathode_area
+    RD_ideal = sources.j_rd(beam['cathode_temperature'], beam['cathode_work_function']) * cathode_area
+    JCL_ideal = sources.cl_limit(beam['cathode_work_function'], beam['anode_work_function'], beam['anode_voltage'], plate_spacing) * cathode_area
 
-    if beam['currentMode'] == '2' or \
-            (beam['currentMode'] == '1' and beam['beam_current'] >= JCL_ideal):
+    if beam['currentMode'] == '2' or (beam['currentMode'] == '1' and beam['beam_current'] >= JCL_ideal):
         curr2 = np.full_like(zmesh, JCL_ideal)
         y2_title = 'Child-Langmuir cold limit'
     else:
@@ -920,8 +884,7 @@ def _generate_parameters_file(data):
 
 def _h5_file_list(run_dir, model_name):
     return pkio.walk_tree(
-        run_dir.join('diags/xzsolver/hdf5' if model_name == 'currentAnimation' \
-                         else 'diags/fields/electric'),
+        run_dir.join('diags/xzsolver/hdf5' if model_name == 'currentAnimation' else 'diags/fields/electric'),
         r'\.h5$',
     )
 
@@ -1039,8 +1002,7 @@ def _parse_optimize_field(text):
 
 def _particle_line_has_slope(curr, next, prev, i1, i2):
     return abs(
-        _slope(curr[i1], curr[i2], next[i1], next[i2]) -
-        _slope(prev[i1], prev[i2], curr[i1], curr[i2])
+        _slope(curr[i1], curr[i2], next[i1], next[i2]) - _slope(prev[i1], prev[i2], curr[i1], curr[i2])
     ) >= _CULL_PARTICLE_SLOPE
 
 
@@ -1181,8 +1143,7 @@ def _simulation_percent_complete(report, run_dir, is_running):
             v = np.load(str(egun_current_file), allow_pickle=True)
             res['egunCurrentFrameCount'] = len(v)
     else:
-        percent_complete = (file_index + 1.0) * \
-                           _PARTICLE_PERIOD / data.models.simulationGrid.num_steps
+        percent_complete = (file_index + 1.0) * _PARTICLE_PERIOD / data.models.simulationGrid.num_steps
 
     if percent_complete < 0:
         percent_complete = 0

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -747,24 +747,6 @@ def _field_input(args):
     return axes, slice_axis, field_slice, show3d
 
 
-def _field_values(values, axes, field_slice, grid):
-    dx = grid.channel_width / grid.num_x
-    dy = grid.channel_height / grid.num_y
-    dz = grid.plate_spacing / grid.num_z
-    if axes == 'xz':
-        return values[
-               :, _get_slice_index(
-                    field_slice, -grid.channel_height / 2., dy, grid.num_y - 1
-                ), :]
-    elif axes == 'xy':
-        return values[:, :, _get_slice_index(field_slice, 0., dz, grid.num_z - 1)]
-    else:
-        return values[
-               _get_slice_index(
-                   field_slice, -grid.channel_width / 2., dx, grid.num_x - 1
-               ), :, :]
-
-
 def _field_plot(values, axes, grid, is3d):
     plate_spacing = _meters(grid.plate_spacing)
     radius = _meters(grid.channel_width / 2.)
@@ -803,6 +785,24 @@ def _field_plot(values, axes, grid, is3d):
             'runMode3d': is3d
         }
     })
+
+
+def _field_values(values, axes, field_slice, grid):
+    dx = grid.channel_width / grid.num_x
+    dy = grid.channel_height / grid.num_y
+    dz = grid.plate_spacing / grid.num_z
+    if axes == 'xz':
+        return values[
+               :, _get_slice_index(
+                    field_slice, -grid.channel_height / 2., dy, grid.num_y - 1
+                ), :]
+    elif axes == 'xy':
+        return values[:, :, _get_slice_index(field_slice, 0., dz, grid.num_z - 1)]
+    else:
+        return values[
+               _get_slice_index(
+                   field_slice, -grid.channel_width / 2., dx, grid.num_x - 1
+               ), :, :]
 
 
 def _find_by_id(container, id):

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -6,7 +6,6 @@ u"""Warp VND/WARP execution template.
 """
 
 from __future__ import absolute_import, division, print_function
-from numpy import linalg
 from pykern import pkcollections
 from pykern import pkio
 from pykern.pkdebug import pkdc, pkdp, pkdlog
@@ -429,7 +428,7 @@ def _add_particle_paths(electrons, x_points, y_points, z_points, half_height, li
                 electrons[0][i][j],
                 electrons[2][i][j],
             ]
-            if j > 0 and j < num_points - 1:
+            if 0 < j < num_points - 1:
                 next = [
                     electrons[1][i][j+1],
                     electrons[0][i][j+1],
@@ -628,11 +627,11 @@ def _extract_field(field, data, data_file, args=None):
     dz = grid.plate_spacing / grid.num_z
 
     axes = args.axes if args is not None else 'xz'
-    show3d = args.displayMode == '3d' if args is not None else False
+    show3d = args.displayMode == '3d' if args is not None and 'displayMode' in args else False
 
     axes = axes if show3d else 'xz'
     axes = axes if axes is not None and axes != '' else 'xz'
-    slice_axis = re.sub('[' + axes + ']', '', 'xyz' if _is_3D(data) else 'xz')
+    slice_axis = re.sub('[' + axes + ']', '', 'xyz')
 
     selector = field
     if not field == 'phi':
@@ -650,9 +649,12 @@ def _extract_field(field, data, data_file, args=None):
         phi_slice = 0.
         title = 'ϕ'
         if axes == 'xz':
-            values = values[:, _get_slice_index(phi_slice, -grid.channel_height / 2., dy, grid.num_y - 1), :]
+            if _is_3D(data):
+                values = values[:, _get_slice_index(phi_slice, -grid.channel_height / 2., dy, grid.num_y - 1), :]
+            else:
+                values = values[0, :, :]
         elif axes == 'xy':
-            phi_slice = grid.plate_spacing / 5.  # tmp slice
+            phi_slice = grid.plate_spacing / 2.  # tmp slice
             values = values[:, :, _get_slice_index(phi_slice, 0., dz, grid.num_z - 1)]
         else:
             values = values[_get_slice_index(phi_slice, -grid.channel_width / 2., dx, grid.num_x - 1), :, :]
@@ -686,14 +688,13 @@ def _extract_field(field, data, data_file, args=None):
         'y_range': yr,
         'x_label': x_label,
         'y_label': y_label,
-        'title': '{}{}for Time: {:.4e}s, Step {}'.format(title, slice_text, data_time, data_file.iteration),
+        'title': '{}{} for Time: {:.4e}s, Step {}'.format(title, slice_text, data_time, data_file.iteration),
         'aspectRatio': ar,
         'z_matrix': values.tolist(),
         'summaryData': {
             'runMode3d': _is_3D(data)
         },
     }
-
 
 
 def _extract_impact_density(run_dir, data):
@@ -806,10 +807,6 @@ def _extract_particle(run_dir, model_name, data, args):
     y_points = []
     z_points = []
     _add_particle_paths(kept_electrons, x_points, y_points, z_points, half_height, limit)
-
-    xx, yy, zz = _grid_interpolation(x_points, y_points, z_points, grid)
-    #pkdp('old arr {} modified arr {}', np.array(x_points).shape, xx.shape)
-
     lost_x = []
     lost_y = []
     lost_z = []
@@ -823,9 +820,9 @@ def _extract_particle(run_dir, model_name, data, args):
         'y_label': 'x [m]',
         'x_label': 'z [m]',
         'z_label': 'y [m]',
-        'points': yy,
-        'x_points': xx,
-        'z_points': zz,
+        'points': y_points,
+        'x_points': x_points,
+        'z_points': z_points,
         'y_range': [-radius, radius],
         'z_range': [-half_height, half_height],
         'lost_x': lost_x,
@@ -850,135 +847,6 @@ def _grid_delta(data, length_field, count_field):
     grid = data.models.simulationGrid
     #TODO(pjm): already converted to meters
     return grid[length_field] / grid[count_field]
-
-
-def _cell_of_point(p, grid):
-    return np.array([
-        np.floor(p[0] / _meters(grid.plate_spacing) * grid.num_z),
-        np.floor((p[1] + 0.5 * _meters(grid.channel_width)) / _meters(grid.channel_width) * grid.num_x),
-        np.floor((p[2] + 0.5 * _meters(grid.channel_height)) / _meters(grid.channel_height) * grid.num_y)
-    ])
-
-
-#least corner in x y z
-def point_of_cell(c, grid):
-    return np.array([
-        c[0] * _meters(grid.plate_spacing) / grid.num_z,
-        -0.5 * _meters(grid.channel_width) + c[1] * _meters(grid.channel_width) / grid.num_x,
-        -0.5 * _meters(grid.channel_height) + c[2] * _meters(grid.channel_height) / grid.num_y
-    ])
-
-
-# Adds points at grid planes that intersect line segments
-def _grid_interpolation(x_arr, y_arr, z_arr, grid):
-
-    # lines
-    new_x = []
-    new_y = []
-    new_z = []
-    test_line = 0
-    test_pt = 0
-    for i in range(len(x_arr)):
-        points = np.column_stack((x_arr[i], y_arr[i], z_arr[i])).tolist()
-        new_points = points[:]
-        num_new = 0
-        # points making up the line
-        for j in range(len(points) - 1):
-            added_points = []
-            #if i == test_line:
-            #    pkdp('!line {} pt {}/{} start', i, j, len(points))
-            p1 = points[j]
-            p2 = points[j + 1]
-            p_bounds = {
-                'min': [
-                    min(p1[0], p2[0]),
-                    min(p1[1], p2[1]),
-                    min(p1[2], p2[2])
-                ],
-                'max': [
-                    max(p1[0], p2[0]),
-                    max(p1[1], p2[1]),
-                    max(p1[2], p2[2])
-                ],
-            }
-            #if i == test_line and j == test_pt:
-            #    pkdp('!line {} PT {} BOUNDS {}', i, j, p_bounds)
-            c1 = _cell_of_point(p1, grid)
-            c2 = _cell_of_point(p2, grid)
-            c_diff = c2 - c1
-
-            if not np.any(np.abs(c_diff) > 0):
-                continue
-
-            # endpoints of line segment are in different grid cells
-            s = np.sign(c_diff)
-
-            # get the intersections of the line with each intervening grid plane, in each direction
-            for m, cell_idx in enumerate(c1):
-                if s[m] == 0:
-                    continue
-                d_m = p2[m] - p1[m]
-                done = False
-                c = cell_idx
-                axis = m
-                #if i == test_line:
-                #    pkdp('!line {} PT {} AXIS {} C1 {} C2 {} D {} START AT CIDX {}', i, j, m, c1, c2, c_diff[m], c)
-                while not done:
-                    done = c == c2[m]
-                    cc = np.empty(3)
-                    for n in [0, 1, 2]:
-                        if n == m:
-                            cc[n] = c
-                        else:
-                            cc[n] = c2[n]
-                    if i == test_line and j == test_pt:
-                        pkdp('!line {} PT {} AXIS {} START AT CEL {}', i, j, m, cc)
-                    next_p = point_of_cell(cc, grid)
-                    for n in [0, 1, 2]:
-                        if n != m:
-                            next_p[n] = (p1[n] + (next_p[m] - p1[m]) * (p2[n] - p1[n]) / d_m) if d_m != 0 else p1[n]
-                    next_cell = _cell_of_point(next_p, grid)
-                    if p_bounds['min'][0] <= next_p[0] <= p_bounds['max'][0] and\
-                        p_bounds['min'][1] <= next_p[1] <= p_bounds['max'][1] and\
-                        p_bounds['min'][2] <= next_p[2] <= p_bounds['max'][2]:
-                        #if i == test_line and j == test_pt:
-                            #pkdp('!line {} PT {} AXIS {} NEW POINT {} OK X LO? {} X HI? {}', i, j, axis, next_p, next_p[0] >= p_bounds['min'][0], next_p[0] <= p_bounds['max'][0])
-                            #pkdp('!line {} PT {} AXIS {} NEW POINT {} OK Y LO? {} Y HI? {}', i, j, axis, next_p, next_p[1] >= p_bounds['min'][1], next_p[1] <= p_bounds['max'][1])
-                            #pkdp('!line {} PT {} AXIS {} NEW POINT {} OK Z LO? {} Z HI? {}', i, j, axis, next_p, next_p[2] >= p_bounds['min'][2], next_p[2] <= p_bounds['max'][2])
-                            #pkdp('!line {} PT {} AXIS {} NEW POINT {} IN CELL {}', i, j, axis, next_p, next_cell)
-                        new_points.insert(j + num_new, next_p)
-                        added_points.append(next_p)
-                        num_new += 1
-                    #else:
-                        #if i == test_line:
-                        #    pkdp('!line {} PT {} AXIS {} POINT {} CELL {} OUTSIDE ENDPOINTS', i, j, axis, next_p, next_cell)
-                    #next_cell = _cell_of_point(next_p, grid)
-                    #if next_cell[0] < 0 or next_cell[0] > grid.num_z or\
-                    #    next_cell[1] < 0 or next_cell[1] > grid.num_x or\
-                    #    next_cell[2] < 0 or next_cell[2] > grid.num_y:
-                    #    if i == 3:
-                    #        pkdp('!line {} PT {} AXIS {} BAD CELL {} FROM POINT {}', i, j, axis, next_cell, next_p)
-                    ##        pkdp('!line {} PT {} AXIS {} TRY ADD CELL {} BETWEEN {} and {}', i, j, axis, cc, c1, c2)
-                    #        pkdp('!line {} PT {} AXIS {} TRY ADD POINT BETWEEN {} and {}: INITIAL POINT {}', i, j, axis, p1, p2, init_p)
-                    #new_points.insert(j + num_new, next_p)
-                    #num_new += 1
-                    c += s[m]
-            if i == test_line:
-                ap = np.array(added_points)
-                np1 = np.array(p1)
-                ndf = np1 - ap
-                #nd = np.linalg.norm(ndf)
-                nds = np.square(ndf)
-                ndss = np.sum(nds, axis=1)
-                nd = np.sqrt(ndss)
-                pkdp('!line {} pt {} done pts {} diff from p1 {} dists {}', i, j, added_points, ndf, nd)
-        if i == test_line:
-            pkdp('!line {} num pts {} -> {}', i, len(points), len(new_points))
-        new_line = np.array(new_points).T
-        new_x.append(new_line[0].tolist())
-        new_y.append(new_line[1].tolist())
-        new_z.append(new_line[2].tolist())
-    return new_x, new_y, new_z
 
 
 def _generate_optimizer_file(data, v):

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -648,14 +648,13 @@ def _extract_field(field, data, data_file, args=None):
     if field == 'phi':
         phi_slice = 0.
         title = 'ϕ'
-        # Values are arranged as y x z
         if axes == 'xz':
-            values = values[_get_slice_index(phi_slice, -grid.channel_height / 2., dy, grid.num_y - 1), :, :]
+            values = values[:, _get_slice_index(phi_slice, -grid.channel_height / 2., dy, grid.num_y - 1), :]
         elif axes == 'xy':
-            phi_slice = grid.plate_spacing / 5.
+            phi_slice = grid.plate_spacing / 5.  # tmp slice
             values = values[:, :, _get_slice_index(phi_slice, 0., dz, grid.num_z - 1)]
         else:
-            values = values[:, _get_slice_index(phi_slice, -grid.channel_width / 2., dx, grid.num_x - 1), :]
+            values = values[_get_slice_index(phi_slice, -grid.channel_width / 2., dx, grid.num_x - 1), :, :]
 
         x_max = len(values[0])
         y_max = len(values)
@@ -813,7 +812,7 @@ def _extract_particle(run_dir, model_name, data, args):
     data_file = open_data_file(run_dir, model_name, None)
     with h5py.File(data_file.filename, 'r') as f:
         field = np.array(f['data/{}/meshes/{}'.format(data_file.iteration, 'phi')])
-
+    pkdp('p field {}', field.shape)
     return {
         'title': 'Particle Trace',
         'x_range': [0, plate_spacing],

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -200,7 +200,7 @@ def generate_field_report(data, run_dir, args=None):
         'y_range': yr,
         'x_label': x_label,
         'y_label': y_label,
-        'title': 'ϕ Across Whole Domain' + (' ({} = {}µm)'.format(slice_axis, phi_slice) if _is_3D(data) else ''),
+        'title': 'ϕ Across Whole Domain' + (' ({} = {}µm)'.format(slice_axis, round(phi_slice, 3)) if _is_3D(data) else ''),
         'z_matrix': values.tolist(),
         'global_min': np.min(potential) if vals_equal else None,
         'global_max': np.max(potential) if vals_equal else None,
@@ -646,7 +646,7 @@ def _extract_field(field, data, data_file, args=None):
     y_label = 'x [m]'
     slice_text = ''
     if field == 'phi':
-        phi_slice = 0.
+        phi_slice = float(args.slice) if args and 'slice' in args else 0.
         title = 'ϕ'
         if axes == 'xz':
             if _is_3D(data):
@@ -654,7 +654,6 @@ def _extract_field(field, data, data_file, args=None):
             else:
                 values = values[0, :, :]
         elif axes == 'xy':
-            phi_slice = grid.plate_spacing / 2.  # tmp slice
             values = values[:, :, _get_slice_index(phi_slice, 0., dz, grid.num_z - 1)]
         else:
             values = values[_get_slice_index(phi_slice, -grid.channel_width / 2., dx, grid.num_x - 1), :, :]
@@ -675,7 +674,7 @@ def _extract_field(field, data, data_file, args=None):
             yr = [- height, height, y_max]
             x_label = 'z [m]'
             y_label = 'y [m]'
-        slice_text = ' (' + slice_axis + ' = ' + str(phi_slice) + 'µm) '
+        slice_text = ' (' + slice_axis + ' = ' + str(round(phi_slice, 3)) + 'µm) '
     else:
         values = values[:, 0, :]
         x_max = len(values[0])


### PR DESCRIPTION
The main thrust of this PR is to copy the axis and slice features of the field report to the field animation and use a full 3d field to color particle traces

Notes:
- Added axes and slice to electric field views (was just potential (phi))
- Unlike the field report, the field animation has the slice slider in the editor. This to have a fixed set of parameters while the animation runs
- The particle data now includes the full 3d field rather than borrowing the 2d from the field animation
- After experimentation around interpolating the field, it seems replacing all that with a simple average at the points in a particle trace is good enough.  I opted against implementing Bresenham's line algorithm plus an average weighted by the fraction of the line in each cell so derived

Other misc items:
- Added a toggle to the particle trace for stl conductors to view the outlines of the vtk polygons
- The range slider directive now contains the code for updating etc. that had been living in ```potentialReport```
- Expanded the field delegate concept for the slider, using ```panelState``` as a manager, because piping functions through multiple directives was becoming labyrinthine
