### PR TITLE
Sbatch cores hours

### DIFF
--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -537,7 +537,6 @@ SIREPO.app.directive('fieldEditor', function(appState, keypressService, panelSta
                 }
                 return true;
             }
-
             $scope.enum = SIREPO.APP_SCHEMA.enum;
             // field def: [label, type]
             $scope.info = appState.modelInfo($scope.modelName)[$scope.field];
@@ -2788,6 +2787,27 @@ SIREPO.app.directive('3dSliceWidget', function(appState, panelState) {
     };
 });
 
+SIREPO.app.directive('sbatchCoresAndHours', function(appState) {
+    return {
+        restrict: 'A',
+        scope: {
+            simState: '=sbatchCoresAndHours',
+        },
+        template: [
+            '<div data-ng-show="showCoresAndHours()">',
+                '<div data-model-field="\'sbatchHours\'" data-model-name="simState.model"></div>',
+                '<div data-model-field="\'sbatchCores\'" data-model-name="simState.model"></div>',
+            '</div>',
+        ].join(''),
+        controller: function($scope) {
+
+            $scope.showCoresAndHours = function() {
+                return appState.models[$scope.simState.model].jobRunMode === 'sbatch';
+            }
+        }
+    }
+});
+
 SIREPO.app.directive('simSections', function(utilities) {
 
     return {
@@ -2837,6 +2857,7 @@ SIREPO.app.directive('simStatusPanel', function(appState) {
               '<div data-ng-show="simState.showJobSettings()">',
                 '<div class="form-group form-group-sm">',
                   '<div data-model-field="\'jobRunMode\'" data-model-name="simState.model"></div>',
+                  '<div data-sbatch-cores-and-hours="simState"></div>',
                 '</div>',
               '</div>',
               '<div class="col-sm-6 pull-right">',

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -2802,7 +2802,8 @@ SIREPO.app.directive('sbatchCoresAndHours', function(appState) {
         controller: function($scope) {
 
             $scope.showCoresAndHours = function() {
-                return appState.models[$scope.simState.model].jobRunMode === 'sbatch';
+                var m = appState.models[$scope.simState.model];
+                return m && m.jobRunMode === 'sbatch';
             }
         }
     }

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -1873,6 +1873,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
                 '<div data-ng-show="simState.showJobSettings()">',
                   '<div class="form-group form-group-sm">',
                     '<div data-model-field="\'jobRunMode\'" data-model-name="simState.model"></div>',
+                    '<div data-sbatch-cores-and-hours="simState"></div>',
                   '</div>',
                 '</div>',
                 '<div class="col-sm-6 pull-right">',

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -426,7 +426,7 @@ class _SbatchRun(_SbatchCmd):
 #TODO(robnagler) provide via sbatch driver
             o = f'''#SBATCH --image={i}
 #SBATCH --constraint=haswell
-#SBATCH --partition={"debug" if self.msg.sbatchHours < 0.5 else "regular"}
+#SBATCH --qos={"debug" if self.msg.sbatchHours < 0.5 else "regular"}
 #SBATCH --tasks-per-node=32'''
             s = '--cpu-bind=cores shifter'
         f = self.run_dir.join(self.jid + '.sbatch')

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -420,17 +420,20 @@ class _SbatchRun(_SbatchCmd):
         await c._await_exit()
 
     def _sbatch_script(self):
+        pkdp('eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
         i = self.msg.shifterImage
         s = o = ''
         if i:
 #TODO(robnagler) provide via sbatch driver
+# TODO(e-carlin): is self.msg.sbatchHours a string or a float? Need float for > comparison
+# TODO(e-carlin): move qos back below --contraint
             o = f'''#SBATCH --image={i}
 #SBATCH --constraint=haswell
-#SBATCH --qos=debug
 #SBATCH --tasks-per-node=32'''
             s = '--cpu-bind=cores shifter'
         f = self.run_dir.join(self.jid + '.sbatch')
         f.write(f'''#!/bin/bash
+#SBATCH --qos={"debug" if self.msg.sbatchHours < 0.5 else "regular"}
 #SBATCH --error={template_common.RUN_LOG}
 #SBATCH --ntasks={self.msg.sbatchCores}
 #SBATCH --output={template_common.RUN_LOG}


### PR DESCRIPTION
Fix #2098. The user can now configure the cores and hours for an sbatch job in srw and warppba. If the hours selected is < 0.5 it uses the debug queue otherwise uses the regular queue.

<img width="564" alt="Screen Shot 2019-12-12 at 11 19 53 AM" src="https://user-images.githubusercontent.com/10264515/70738170-6d8e3400-1cd1-11ea-8724-22e9c3bb2709.png">
