### PR TITLE
Extend existing data with new data so we preserve fields required for…

### DIFF
--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -2120,7 +2120,9 @@ SIREPO.app.factory('persistentSimulation', function(simulationQueue, appState, f
                 appState.models.simulationStatus = {};
             }
             data.report = state.model;
-            appState.models.simulationStatus[state.model] = data;
+            appState.models.simulationStatus[state.model] = angular.extend(
+                {}, appState.models.simulationStatus[state.model], data
+            );
             if (appState.isLoaded()) {
                 // simulationStatus is not saved to server from client
                 appState.saveQuietly('simulationStatus');


### PR DESCRIPTION
… subsequent requests.

job_api.api_simulationFrame requires computeJobHash and computeJobStart. By extending
rather than overwriting we preserve these fields. Previously in a cancel scenario
simulationStatus became just {state: 'canceled', report: 'animation'}. So, we could
not request simulationFrame since computeJobHash and computeJobStart we're undefined.

Fix #2144 