### PR TITLE
Fix #2350 removed save_chdir and factored out exec()

### DIFF
--- a/sirepo/mpi.py
+++ b/sirepo/mpi.py
@@ -64,7 +64,7 @@ if MPI.COMM_WORLD.Get_rank():
     fn = 'mpi_run.py'
     pkio.write_text(fn, script)
     p = None
-    return run_program([sys.executable or 'python', fn])
+    run_program([sys.executable or 'python', fn])
 
 
 cfg = pkconfig.init(

--- a/sirepo/pkcli/flash.py
+++ b/sirepo/pkcli/flash.py
@@ -21,6 +21,5 @@ _EXE_PATH = {
 
 def run_background(cfg_dir):
     data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
-    with pkio.save_chdir(cfg_dir):
-        mpi.run_program([_EXE_PATH[data.models.simulation.flashType]])
+    mpi.run_program([_EXE_PATH[data.models.simulation.flashType]])
     simulation_db.write_result({})

--- a/sirepo/pkcli/hellweg.py
+++ b/sirepo/pkcli/hellweg.py
@@ -10,9 +10,9 @@ from pykern.pkdebug import pkdp, pkdc
 from rslinac import solver
 from sirepo import simulation_db
 from sirepo.template import template_common
+import copy
 import py.path
 import sirepo.template.hellweg as template
-import copy
 
 def run(cfg_dir):
     """Run Hellweg in ``cfg_dir``
@@ -40,11 +40,10 @@ def run_background(cfg_dir):
 
 
 def _run_hellweg(cfg_dir):
-    with pkio.save_chdir(cfg_dir):
-        exec(pkio.read_text(template_common.PARAMETERS_PYTHON_FILE), locals(), locals())
-        pkio.write_text(template.HELLWEG_INPUT_FILE, input_file)
-        pkio.write_text(template.HELLWEG_INI_FILE, ini_file)
-        s = solver.BeamSolver(template.HELLWEG_INI_FILE, template.HELLWEG_INPUT_FILE)
-        s.solve()
-        s.save_output(template.HELLWEG_SUMMARY_FILE)
-        s.dump_bin(template.HELLWEG_DUMP_FILE)
+    r = template_common.exec_parameters()
+    pkio.write_text(template.HELLWEG_INPUT_FILE, r.input_file)
+    pkio.write_text(template.HELLWEG_INI_FILE, r.ini_file)
+    s = solver.BeamSolver(template.HELLWEG_INI_FILE, template.HELLWEG_INPUT_FILE)
+    s.solve()
+    s.save_output(template.HELLWEG_SUMMARY_FILE)
+    s.dump_bin(template.HELLWEG_DUMP_FILE)

--- a/sirepo/pkcli/myapp.py
+++ b/sirepo/pkcli/myapp.py
@@ -19,26 +19,25 @@ _SCHEMA = simulation_db.get_schema(template.SIM_TYPE)
 
 
 def run(cfg_dir):
-    with pkio.save_chdir(cfg_dir):
-        try:
-            pksubprocess.check_call_with_signals(
-                [sys.executable, template_common.PARAMETERS_PYTHON_FILE],
-            )
-        except Exception as e:
-            pkdlog('script failed: dir={} err={}', cfg_dir, e)
-            simulation_db.write_result({
-                'error': 'program error occured',
-            })
-            return
-        data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
-        if data.report == 'heightWeightReport':
-            res = _report(
-                'Dog Height and Weight Over Time',
-                ('height', 'weight'),
-                data,
-            )
-        else:
-            raise AssertionError('unknown report: {}'.format(data.report))
+    try:
+        pksubprocess.check_call_with_signals(
+            [sys.executable, template_common.PARAMETERS_PYTHON_FILE],
+        )
+    except Exception as e:
+        pkdlog('script failed: dir={} err={}', cfg_dir, e)
+        simulation_db.write_result({
+            'error': 'program error occured',
+        })
+        return
+    data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
+    if data.report == 'heightWeightReport':
+        res = _report(
+            'Dog Height and Weight Over Time',
+            ('height', 'weight'),
+            data,
+        )
+    else:
+        raise AssertionError('unknown report: {}'.format(data.report))
     simulation_db.write_result(res)
 
 

--- a/sirepo/pkcli/opal.py
+++ b/sirepo/pkcli/opal.py
@@ -18,25 +18,23 @@ import sirepo.template.opal as template
 
 
 def run(cfg_dir):
-    with pkio.save_chdir(cfg_dir):
-        if _run_opal():
-            data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
-            if 'bunchReport' in data.report or data.report == 'twissReport':
-                template.save_report_data(data, py.path.local(cfg_dir))
-        else:
-            err = _parse_opal_errors()
-            if re.search(r'Singular matrix', err):
-                err = 'Twiss values could not be computed: Singular matrix'
-            simulation_db.write_result(PKDict(
-                error=err,
-            ))
+    if _run_opal():
+        data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
+        if 'bunchReport' in data.report or data.report == 'twissReport':
+            template.save_report_data(data, py.path.local(cfg_dir))
+    else:
+        err = _parse_opal_errors()
+        if re.search(r'Singular matrix', err):
+            err = 'Twiss values could not be computed: Singular matrix'
+        simulation_db.write_result(PKDict(
+            error=err,
+        ))
 
 
 def run_background(cfg_dir):
     res = PKDict()
-    with pkio.save_chdir(cfg_dir):
-        if not _run_opal(with_mpi=True):
-            res.error = _parse_opal_errors()
+    if not _run_opal(with_mpi=True):
+        res.error = _parse_opal_errors()
     simulation_db.write_result(res)
 
 

--- a/sirepo/pkcli/rcscon.py
+++ b/sirepo/pkcli/rcscon.py
@@ -12,27 +12,23 @@ from sirepo import simulation_db
 from sirepo.template import template_common
 import pykern.pkio
 import sirepo.template.rcscon as template
-import pykern.pkrunpy
 
 
 def run(cfg_dir):
-    with pkio.save_chdir(cfg_dir) as d:
-        _run_simulation()
-        template.extract_report_data(
-            d,
-            simulation_db.read_json(template_common.INPUT_BASE_NAME),
-        )
+    template_common.exec_parameters()
+    template.extract_report_data(
+        d,
+        simulation_db.read_json(template_common.INPUT_BASE_NAME),
+    )
 
 
 def run_background(cfg_dir):
     res = PKDict()
-    with pkio.save_chdir(cfg_dir):
-        try:
-            _run_simulation()
-        except Exception as e:
-            res.error = str(e)
-        simulation_db.write_result(res)
+    try:
+        template_common.exec_parameters()
+    except Exception as e:
+        res.error = str(e)
+    simulation_db.write_result(res)
 
 
 def _run_simulation():
-    pykern.pkrunpy.run_path_as_module(template_common.PARAMETERS_PYTHON_FILE)

--- a/sirepo/pkcli/rs4pi.py
+++ b/sirepo/pkcli/rs4pi.py
@@ -31,8 +31,7 @@ def run(cfg_dir):
 
 
 def run_background(cfg_dir):
-    with pkio.save_chdir(cfg_dir):
-        simulation_db.write_result({})
+    simulation_db.write_result({})
 
 
 def _parent_file(cfg_dir, filename):
@@ -43,9 +42,8 @@ def _run_dose_calculation(data, cfg_dir):
     if not feature_config.cfg().rs4pi_dose_calc:
         dicom_dose = _run_dose_calculation_fake(data, cfg_dir)
     else:
-        with pkio.save_chdir(cfg_dir):
-            pksubprocess.check_call_with_signals(['bash', str(cfg_dir.join(template.DOSE_CALC_SH))])
-            dicom_dose = template.generate_rtdose_file(data, cfg_dir)
+        pksubprocess.check_call_with_signals(['bash', str(cfg_dir.join(template.DOSE_CALC_SH))])
+        dicom_dose = template.generate_rtdose_file(data, cfg_dir)
     data['models']['dicomDose'] = dicom_dose
     # save results into simulation input data file, this is needed for further calls to get_simulation_frame()
     simulation_db.write_json(template_common.INPUT_BASE_NAME, data)

--- a/sirepo/pkcli/shadow.py
+++ b/sirepo/pkcli/shadow.py
@@ -7,12 +7,10 @@
 from __future__ import absolute_import, division, print_function
 from pykern import pkio
 from pykern.pkdebug import pkdp, pkdlog, pkdexc
-from sirepo import mpi
 from sirepo import simulation_db
 from sirepo.template import template_common
 import numpy
 import py.path
-import pykern.pkrunpy
 import re
 import sirepo.template.shadow as template
 
@@ -56,66 +54,65 @@ def run(cfg_dir):
     Args:
         cfg_dir (str): directory to run shadow in
     """
-    with pkio.save_chdir(cfg_dir):
-        beam = _run_shadow()
-        data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
-        model = data['models'][data['report']]
-        column_values = _SCHEMA['enum']['ColumnValue']
+    beam = template_common.exec_parameters().beam
+    data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
+    model = data['models'][data['report']]
+    column_values = _SCHEMA['enum']['ColumnValue']
 
-        if 'y' in model:
-            x_range = None
-            y_range = None
-            if model['overrideSize'] == '1':
-                x_range = (numpy.array([
-                    model['horizontalOffset'] - model['horizontalSize'] / 2,
-                    model['horizontalOffset'] + model['horizontalSize'] / 2,
-                ]) * _MM_TO_CM).tolist()
-                y_range = (numpy.array([
-                    model['verticalOffset'] - model['verticalSize'] / 2,
-                    model['verticalOffset'] + model['verticalSize'] / 2,
-                ]) * _MM_TO_CM).tolist()
-            ticket = beam.histo2(int(model['x']), int(model['y']), nbins=template_common.histogram_bins(model['histogramBins']), ref=int(model['weight']), nolost=1, calculate_widths=0, xrange=x_range, yrange=y_range)
-            _scale_ticket(ticket)
-            values = ticket['histogram'].T
-            if numpy.isnan(values).any():
-                # something failed, look for errors in log
-                simulation_db.write_result({
-                    'error': _parse_shadow_error(cfg_dir)
-                })
-                return
-            res = {
-                'x_range': [ticket['xrange'][0], ticket['xrange'][1], ticket['nbins_h']],
-                'y_range': [ticket['yrange'][0], ticket['yrange'][1], ticket['nbins_v']],
-                'x_label': _label_with_units(model['x'], column_values),
-                'y_label': _label_with_units(model['y'], column_values),
-                'z_label': 'Frequency',
-                'title': u'{}, {}'.format(_label(model['x'], column_values), _label(model['y'], column_values)),
-                'z_matrix': values.tolist(),
-                'frameCount': 1,
-            }
-        else:
-            weight = int(model['weight'])
-            ticket = beam.histo1(int(model['column']), nbins=template_common.histogram_bins(model['histogramBins']), ref=weight, nolost=1, calculate_widths=0)
-            _scale_ticket(ticket)
-            res = {
-                'title': _label(model['column'], column_values),
-                'x_range': [ticket['xrange'][0], ticket['xrange'][1], ticket['nbins']],
-                'y_label': u'{}{}'.format(
-                    'Number of Rays',
-                    u' weighted by {}'.format(_label_for_weight(model['weight'], column_values)) if weight else ''),
-                'x_label': _label_with_units(model['column'], column_values),
-                'points': ticket['histogram'].T.tolist(),
-                'frameCount': 1,
-            }
-            #pkdlog('range amount: {}', res['x_range'][1] - res['x_range'][0])
-            #1.55431223448e-15
-            dist = res['x_range'][1] - res['x_range'][0]
-            #TODO(pjm): only rebalance range if outside of 0
-            if dist < 1e-14:
-                #TODO(pjm): include offset range for client
-                res['x_range'][0] = 0
-                res['x_range'][1] = dist
-        simulation_db.write_result(res)
+    if 'y' in model:
+        x_range = None
+        y_range = None
+        if model['overrideSize'] == '1':
+            x_range = (numpy.array([
+                model['horizontalOffset'] - model['horizontalSize'] / 2,
+                model['horizontalOffset'] + model['horizontalSize'] / 2,
+            ]) * _MM_TO_CM).tolist()
+            y_range = (numpy.array([
+                model['verticalOffset'] - model['verticalSize'] / 2,
+                model['verticalOffset'] + model['verticalSize'] / 2,
+            ]) * _MM_TO_CM).tolist()
+        ticket = beam.histo2(int(model['x']), int(model['y']), nbins=template_common.histogram_bins(model['histogramBins']), ref=int(model['weight']), nolost=1, calculate_widths=0, xrange=x_range, yrange=y_range)
+        _scale_ticket(ticket)
+        values = ticket['histogram'].T
+        if numpy.isnan(values).any():
+            # something failed, look for errors in log
+            simulation_db.write_result({
+                'error': _parse_shadow_error(cfg_dir)
+            })
+            return
+        res = {
+            'x_range': [ticket['xrange'][0], ticket['xrange'][1], ticket['nbins_h']],
+            'y_range': [ticket['yrange'][0], ticket['yrange'][1], ticket['nbins_v']],
+            'x_label': _label_with_units(model['x'], column_values),
+            'y_label': _label_with_units(model['y'], column_values),
+            'z_label': 'Frequency',
+            'title': u'{}, {}'.format(_label(model['x'], column_values), _label(model['y'], column_values)),
+            'z_matrix': values.tolist(),
+            'frameCount': 1,
+        }
+    else:
+        weight = int(model['weight'])
+        ticket = beam.histo1(int(model['column']), nbins=template_common.histogram_bins(model['histogramBins']), ref=weight, nolost=1, calculate_widths=0)
+        _scale_ticket(ticket)
+        res = {
+            'title': _label(model['column'], column_values),
+            'x_range': [ticket['xrange'][0], ticket['xrange'][1], ticket['nbins']],
+            'y_label': u'{}{}'.format(
+                'Number of Rays',
+                u' weighted by {}'.format(_label_for_weight(model['weight'], column_values)) if weight else ''),
+            'x_label': _label_with_units(model['column'], column_values),
+            'points': ticket['histogram'].T.tolist(),
+            'frameCount': 1,
+        }
+        #pkdlog('range amount: {}', res['x_range'][1] - res['x_range'][0])
+        #1.55431223448e-15
+        dist = res['x_range'][1] - res['x_range'][0]
+        #TODO(pjm): only rebalance range if outside of 0
+        if dist < 1e-14:
+            #TODO(pjm): include offset range for client
+            res['x_range'][0] = 0
+            res['x_range'][1] = dist
+    simulation_db.write_result(res)
 
 
 def run_background(cfg_dir):
@@ -151,14 +148,6 @@ def _parse_shadow_error(run_dir):
             if re.search(r'invalid chemical formula', line):
                 return 'A mirror contains an invalid reflectivity material'
     return 'an unknown error occurred'
-
-
-def _run_shadow():
-    """Run shadow program with isolated locals()
-    """
-    return pykern.pkrunpy.run_path_as_module(
-        template_common.PARAMETERS_PYTHON_FILE,
-    ).beam
 
 
 def _scale_ticket(ticket):

--- a/sirepo/pkcli/srw.py
+++ b/sirepo/pkcli/srw.py
@@ -110,8 +110,21 @@ def run(cfg_dir):
     Args:
         cfg_dir (str): directory to run srw in
     """
-    with pkio.save_chdir(cfg_dir):
-        _run_srw()
+    sim_in = simulation_db.read_json(template_common.INPUT_BASE_NAME)
+    r = template_common.exec_parameters()
+    # special case for importing python code
+    m = sim_in.report
+    if m == 'backgroundImport':
+        simulation_db.write_result({
+            sirepo.template.srw.PARSED_DATA_ATTR: r.parsed_data,
+        })
+    else:
+        simulation_db.write_result(
+            sirepo.template.srw.extract_report_data(
+                sirepo.template.srw.get_filename_for_model(m),
+                sim_in,
+            ),
+        )
 
 
 def run_background(cfg_dir):
@@ -120,27 +133,8 @@ def run_background(cfg_dir):
     Args:
         cfg_dir (str): directory to run srw in
     """
-    with pkio.save_chdir(cfg_dir):
-        mpi.run_script(pkio.read_text(template_common.PARAMETERS_PYTHON_FILE))
-        simulation_db.write_result({})
-
-def _run_srw():
-    #TODO(pjm): need to properly escape data values, untrusted from client
-    sim_in = simulation_db.read_json(template_common.INPUT_BASE_NAME)
-    exec(pkio.read_text(template_common.PARAMETERS_PYTHON_FILE), locals(), locals())
-    # special case for importing python code
-    r = sim_in.report
-    if r == 'backgroundImport':
-        simulation_db.write_result({
-            sirepo.template.srw.PARSED_DATA_ATTR: parsed_data,
-        })
-    else:
-        simulation_db.write_result(
-            sirepo.template.srw.extract_report_data(
-                sirepo.template.srw.get_filename_for_model(r),
-                sim_in,
-            ),
-        )
+    template_common.exec_parameters_with_mpi()
+    simulation_db.write_result({})
 
 
 def _cfg_int(lower, upper):

--- a/sirepo/pkcli/synergia.py
+++ b/sirepo/pkcli/synergia.py
@@ -22,8 +22,7 @@ def run(cfg_dir):
     report = data['report']
     if 'bunchReport' in report or report == 'twissReport' or report == 'twissReport2':
         try:
-            with pkio.save_chdir(cfg_dir):
-                exec(pkio.read_text(template_common.PARAMETERS_PYTHON_FILE), locals(), locals())
+            template_common.exec_parameters()
             template.save_report_data(data, py.path.local(cfg_dir))
         except Exception as e:
             res = template.parse_synergia_log(py.path.local(cfg_dir)) or {
@@ -40,12 +39,11 @@ def run_background(cfg_dir):
     distribution = data['models']['bunch']['distribution']
     run_with_mpi = distribution == 'lattice' or distribution == 'file'
     try:
-        with pkio.save_chdir(cfg_dir):
-            if run_with_mpi:
-                mpi.run_script(pkio.read_text(template_common.PARAMETERS_PYTHON_FILE))
-            else:
-                #TODO(pjm): MPI doesn't work with rsbeams distributions yet
-                exec(pkio.read_text(template_common.PARAMETERS_PYTHON_FILE), locals(), locals())
+        if run_with_mpi:
+            template_common.exec_parameters_with_mpi()
+        else:
+            #TODO(pjm): MPI doesn't work with rsbeams distributions yet
+            template_common.exec_parameters()
     except Exception as e:
         res = {
             'error': str(e),

--- a/sirepo/pkcli/warppba.py
+++ b/sirepo/pkcli/warppba.py
@@ -22,21 +22,22 @@ def run(cfg_dir):
         cfg_dir (str): directory to run code in
     """
     template = sirepo.template.import_module(pkinspect.module_basename(run))
-    with pkio.save_chdir(cfg_dir):
-        _run_code()
-        a = PKDict(
-            # see template.warppba.open_data_file (opens last frame)
-            frameIndex=None,
-            run_dir=pkio.py_path(cfg_dir),
-            sim_in=simulation_db.read_json(template_common.INPUT_BASE_NAME),
-        )
-        a.frameReport = a.sim_in.report
-        a.update(a.sim_in.models[a.frameReport])
-        if a.frameReport == 'laserPreviewReport':
-            res = template.sim_frame_fieldAnimation(a)
-        elif a.frameReport == 'beamPreviewReport':
-            res = template.sim_frame_beamAnimation(a)
-        simulation_db.write_result(res)
+    _run_code()
+    a = PKDict(
+        # see template.warppba.open_data_file (opens last frame)
+        frameIndex=None,
+        run_dir=pkio.py_path(cfg_dir),
+        sim_in=simulation_db.read_json(template_common.INPUT_BASE_NAME),
+    )
+    a.frameReport = a.sim_in.report
+    a.update(a.sim_in.models[a.frameReport])
+    if a.frameReport == 'laserPreviewReport':
+        res = template.sim_frame_fieldAnimation(a)
+    elif a.frameReport == 'beamPreviewReport':
+        res = template.sim_frame_beamAnimation(a)
+    else:
+        raise AssertionError('invalid report: {}'.format(a.frameReport))
+    simulation_db.write_result(res)
 
 
 def run_background(cfg_dir, sbatch=False):
@@ -45,34 +46,19 @@ def run_background(cfg_dir, sbatch=False):
     Args:
         cfg_dir (str): directory to run code in
     """
-    with pkio.save_chdir(cfg_dir):
-        mpi.run_script(_script())
-        simulation_db.write_result({})
-
-
-def sbatch_script(path):
-    """Write script to path
-
-    Args:
-        path (str): where to write file
-    """
-    pkio.write_text(path, _script())
+    template_common.exec_parameters_with_mpi()
+    simulation_db.write_result({})
 
 
 def _run_code():
     """Run code program with isolated locals()
     """
-    exec(_script(), locals(), locals())
+    r = template_common.exec_parameters()
     # advance the window until zmin is >= 0 (avoids mirroring in output)
-    doit = True
-    total_steps = 0
-    while doit:
-        step(inc_steps)
-        total_steps += inc_steps
-        if USE_BEAM:
-            doit = total_steps < diag_period
-        else:
-            doit = w3d.zmmin + top.zgrid < 0
-
-def _script():
-    return pkio.read_text(template_common.PARAMETERS_PYTHON_FILE)
+    i = r.inc_steps
+    if r.USE_BEAM:
+        for x in range(0, r.diag_period, i):
+            r.step(i)
+    else:
+        while r.w3d.zmmin + r.top.zgrid < 0:
+            r.step(i)

--- a/sirepo/pkcli/warpvnd.py
+++ b/sirepo/pkcli/warpvnd.py
@@ -15,19 +15,18 @@ import sirepo.template.warpvnd as template
 
 
 def run(cfg_dir):
-    with pkio.save_chdir(cfg_dir):
-        exec(_script(), locals(), locals())
-        data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
-        if data['report'] == 'fieldReport':
-            res = template.generate_field_report(data, cfg_dir)
-            res['tof_expected'] = field_results.tof_expected
-            res['steps_expected'] = field_results.steps_expected,
-            res['e_cross'] = field_results.e_cross
-        elif data['report'] == 'fieldComparisonReport':
-            wp.step(template.COMPARISON_STEP_SIZE)
-            res = template.generate_field_comparison_report(data, cfg_dir)
-        else:
-            raise RuntimeError('unknown report: {}'.format(data['report']))
+    template_common.exec_parameters()
+    data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
+    if data['report'] == 'fieldReport':
+        res = template.generate_field_report(data, cfg_dir)
+        res['tof_expected'] = field_results.tof_expected
+        res['steps_expected'] = field_results.steps_expected,
+        res['e_cross'] = field_results.e_cross
+    elif data['report'] == 'fieldComparisonReport':
+        wp.step(template.COMPARISON_STEP_SIZE)
+        res = template.generate_field_comparison_report(data, cfg_dir)
+    else:
+        raise RuntimeError('unknown report: {}'.format(data['report']))
     simulation_db.write_result(res)
 
 
@@ -37,22 +36,15 @@ def run_background(cfg_dir):
     Args:
         cfg_dir (str): directory to run warpvnd in
     """
-    with pkio.save_chdir(cfg_dir):
-        data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
-        #TODO(pjm): only run with mpi for 3d case for now
-        if data.models.simulationGrid.simulation_mode == '3d' \
-           and not data.report == 'optimizerAnimation' \
-           and data.models.simulation.executionMode == 'parallel':
-            pkdc('RUNNING MPI')
-            simulation_db.write_json(py.path.local(cfg_dir).join(template.MPI_SUMMARY_FILE), {
-                'mpiCores': mpi.cfg.cores,
-            })
-            mpi.run_script(_script())
-        else:
-            pkdc('RUNNING SINGLE PROCESS')
-            exec(_script(), locals(), locals())
-        simulation_db.write_result({})
-
-
-def _script():
-    return pkio.read_text(template_common.PARAMETERS_PYTHON_FILE)
+    data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
+    #TODO(pjm): only run with mpi for 3d case for now
+    if data.models.simulationGrid.simulation_mode == '3d' \
+        and not data.report == 'optimizerAnimation' \
+        and data.models.simulation.executionMode == 'parallel':
+        simulation_db.write_json(py.path.local(cfg_dir).join(template.MPI_SUMMARY_FILE), {
+            'mpiCores': mpi.cfg.cores,
+        })
+        template_common.exec_parameters_with_mpi()
+    else:
+        template_common.exec_parameters()
+    simulation_db.write_result({})

--- a/sirepo/pkcli/webcon.py
+++ b/sirepo/pkcli/webcon.py
@@ -14,7 +14,6 @@ import contextlib
 import numpy as np
 import os
 import py.path
-import pykern.pkrunpy
 import scipy.optimize
 import signal
 import sirepo.template.webcon as template
@@ -33,44 +32,42 @@ class AbortOptimizationException(Exception):
 
 
 def run(cfg_dir):
-    with pkio.save_chdir(cfg_dir):
-        try:
-            data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
-            if 'analysisReport' in data.report:
-                res = template.get_analysis_report(py.path.local(cfg_dir), data)
-            elif 'fftReport' in data.report:
-                res = template.get_fft(py.path.local(cfg_dir), data)
-            elif 'correctorSettingReport' in data.report:
-                res = template.get_settings_report(py.path.local(cfg_dir), data)
-            elif 'beamPositionReport' in data.report:
-                res = template.get_beam_pos_report(py.path.local(cfg_dir), data)
-            else:
-                raise sirepo.util.UserAlert('unknown report: {}'.format(data.report))
-        except sirepo.util.UserAlert as e:
-            res = PKDict(error=e.sr_args.error)
-        simulation_db.write_result(res)
+    try:
+        data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
+        if 'analysisReport' in data.report:
+            res = template.get_analysis_report(py.path.local(cfg_dir), data)
+        elif 'fftReport' in data.report:
+            res = template.get_fft(py.path.local(cfg_dir), data)
+        elif 'correctorSettingReport' in data.report:
+            res = template.get_settings_report(py.path.local(cfg_dir), data)
+        elif 'beamPositionReport' in data.report:
+            res = template.get_beam_pos_report(py.path.local(cfg_dir), data)
+        else:
+            raise sirepo.util.UserAlert('unknown report: {}'.format(data.report))
+    except sirepo.util.UserAlert as e:
+        res = PKDict(error=e.sr_args.error)
+    simulation_db.write_result(res)
 
 
 def run_background(cfg_dir):
-    with pkio.save_chdir(cfg_dir):
-        data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
-        res = {}
-        if data.report == 'epicsServerAnimation':
-            epics_settings = data.models.epicsServerAnimation
-            if epics_settings.serverType == 'local':
-                server_address = _run_epics(data)
-                epics_settings.serverAddress = server_address
-            else:
-                assert epics_settings.serverAddress, 'missing remote server address'
-                server_address = epics_settings.serverAddress
-            _run_epics_monitor(server_address)
-            if epics_settings.serverType == 'local':
-                res['error'] = _run_simulation_loop(server_address)
-            else:
-                res['error'] = _run_forever(server_address)
+    data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
+    res = {}
+    if data.report == 'epicsServerAnimation':
+        epics_settings = data.models.epicsServerAnimation
+        if epics_settings.serverType == 'local':
+            server_address = _run_epics(data)
+            epics_settings.serverAddress = server_address
         else:
-            assert False, 'unknown report: {}'.format(data.report)
-        simulation_db.write_result(res)
+            assert epics_settings.serverAddress, 'missing remote server address'
+            server_address = epics_settings.serverAddress
+        _run_epics_monitor(server_address)
+        if epics_settings.serverType == 'local':
+            res['error'] = _run_simulation_loop(server_address)
+        else:
+            res['error'] = _run_forever(server_address)
+    else:
+        assert False, 'unknown report: {}'.format(data.report)
+    simulation_db.write_result(res)
 
 
 def _check_beam_steering(is_steering):
@@ -204,7 +201,7 @@ def _run_forever(server_address):
 
 
 def _run_simulation_loop(server_address):
-    l = pykern.pkrunpy.run_path_as_module(template_common.PARAMETERS_PYTHON_FILE)
+    l = template_common.exec_parameters()
     return _wait_for_beam_steering(server_address, l.update_and_run_simulation)
 
 

--- a/sirepo/pkcli/zgoubi.py
+++ b/sirepo/pkcli/zgoubi.py
@@ -137,16 +137,14 @@ def _validate_estimate_output_file_size(data, res):
 
 
 def _run_tunes_report(cfg_dir, data):
-    with pkio.save_chdir(cfg_dir):
-        exec(pkio.read_text(template_common.PARAMETERS_PYTHON_FILE), locals(), locals())
-        pkio.write_text(template.TUNES_INPUT_FILE, tunes_file)
-        #TODO(pjm): uses datafile from animation directory
-        os.symlink('../animation/zgoubi.fai', 'zgoubi.fai')
-        subprocess.call([_TUNES_PATH])
-        simulation_db.write_result(template.extract_tunes_report(cfg_dir, data))
+    template_common.exec_parameters()
+    pkio.write_text(template.TUNES_INPUT_FILE, tunes_file)
+    #TODO(pjm): uses datafile from animation directory
+    os.symlink('../animation/zgoubi.fai', 'zgoubi.fai')
+    subprocess.call([_TUNES_PATH])
+    simulation_db.write_result(template.extract_tunes_report(cfg_dir, data))
 
 
-def _run_zgoubi(cfg_dir, python_file=template_common.PARAMETERS_PYTHON_FILE):
-    with pkio.save_chdir(cfg_dir):
-        exec(pkio.read_text(python_file), locals(), locals())
-        subprocess.call([_EXE_PATH])
+def _run_zgoubi(cfg_dir, python_file=None):
+    template_common.exec_parameters(python_file)
+    subprocess.call([_EXE_PATH])

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -13,6 +13,7 @@ from pykern.pkdebug import pkdc, pkdlog, pkdp, pkdexc
 import math
 import numpy
 import os.path
+import pykern.pkrunpy
 import re
 import sirepo.http_reply
 import sirepo.http_request
@@ -193,6 +194,16 @@ def enum_text(schema, name, value):
         if e[0] == value:
             return e[1]
     assert False, 'unknown {} enum value: {}'.format(name, value)
+
+
+def exec_parameters(path=None):
+    return pykern.pkrunpy.run_path_as_module(path or PARAMETERS_PYTHON_FILE)
+
+
+def exec_parameters_with_mpi():
+    import sirepo.mpi
+
+    return sirepo.mpi.run_script(pkio.read_text(PARAMETERS_PYTHON_FILE))
 
 
 def flatten_data(d, res, prefix=''):


### PR DESCRIPTION
save_chdir is unnecessary for pkcli codes since job_cmd
executes in the run_dir.
exec(PARAMETERS_PYTHON_FILE) is now template_common.exec_parameters
and exec_parameters_with_mpi.
Also cleaned up pkcli.warppba step loops