### PR TITLE
Only skip job tests if SIREPO_FEATURE_CONFIG_JOB == 0 because SIREPO_FEATURE…

### DIFF
--- a/tests/adm_and_own_jobs_test.py
+++ b/tests/adm_and_own_jobs_test.py
@@ -11,8 +11,8 @@ from pykern.pkcollections import PKDict
 import time
 
 pytestmark = pytest.mark.skipif(
-    os.environ.get('SIREPO_FEATURE_CONFIG_JOB') != '1',
-    reason='SIREPO_FEATURE_CONFIG_JOB != 1'
+    os.environ.get('SIREPO_FEATURE_CONFIG_JOB') == '0',
+    reason='SIREPO_FEATURE_CONFIG_JOB == 0'
 )
 
 

--- a/tests/adm_and_own_jobs_test.py
+++ b/tests/adm_and_own_jobs_test.py
@@ -10,11 +10,6 @@ import os
 from pykern.pkcollections import PKDict
 import time
 
-pytestmark = pytest.mark.skipif(
-    os.environ.get('SIREPO_FEATURE_CONFIG_JOB') == '0',
-    reason='SIREPO_FEATURE_CONFIG_JOB == 0'
-)
-
 
 def setup_module(module):
     os.environ.update(

--- a/tests/sbatch_test.py
+++ b/tests/sbatch_test.py
@@ -11,8 +11,8 @@ import pytest
 
 
 pytestmark = pytest.mark.skipif(
-    os.environ.get('SIREPO_FEATURE_CONFIG_JOB') != '1',
-    reason='SIREPO_FEATURE_CONFIG_JOB != 1'
+    os.environ.get('SIREPO_FEATURE_CONFIG_JOB') == '0',
+    reason='SIREPO_FEATURE_CONFIG_JOB == 0'
 )
 
 # If you see: _timeout MAX_CASE_RUN_SECS=120 exceeded

--- a/tests/sbatch_test.py
+++ b/tests/sbatch_test.py
@@ -6,14 +6,8 @@ u"""test running of animations through sbatch
 """
 from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
-import os
 import pytest
 
-
-pytestmark = pytest.mark.skipif(
-    os.environ.get('SIREPO_FEATURE_CONFIG_JOB') == '0',
-    reason='SIREPO_FEATURE_CONFIG_JOB == 0'
-)
 
 # If you see: _timeout MAX_CASE_RUN_SECS=120 exceeded
 # Run sinfo to see if slurmd is down for this node.


### PR DESCRIPTION
…_CONFIG_JOB now defaults to 1

830595d6806ba07f021d97cccaba0964c166ccf2 changed the default value of job to True so checking != 1 meant the test was skipped when it shouldn't be.

On a side note, maybe we should have pykern test output what tests were skipped and why?
