### PR TITLE
Purge non premium users.

### DIFF
--- a/tests/pkcli/admin_test.py
+++ b/tests/pkcli/admin_test.py
@@ -7,23 +7,18 @@ u"""test sirepo.pkcli.admin
 from __future__ import absolute_import, division, print_function
 import pytest
 
+# TODO(e-carlin): remove ordering need?
 # NOTE: order of the tests matters, and pytest picks them up in order
 # of definition, but we are documenting this with test_1 and test_2 prefixes
 
-def test_1_purge_users_no_guests(monkeypatch, auth_fc):
-    from sirepo import auth_db
+def test_1_purge_users_all_premium(fc):
     from pykern.pkunit import pkeq, pkok
-    from sirepo import srunit
-    from sirepo.pkcli import admin
-    from sirepo import auth
+    from sirepo import auth_db
     from sirepo import srtime
+    from sirepo.pkcli import admin
 
-    if not auth_fc.sr_uid:
-        auth_fc.sr_login_as_guest()
-    days = 1
-    adjusted_time = days + 10
-
-    res = admin.purge_guest_users(days=days, confirm=False)
+    d = 1
+    res = admin.purge_guest_users(days=d, confirm=False)
     pkeq({}, res, '{}: no old users so no deletes', res)
 
     dirs_in_fs = _get_dirs()
@@ -31,11 +26,10 @@ def test_1_purge_users_no_guests(monkeypatch, auth_fc):
     pkeq(1, len(dirs_in_fs), '{}: expecting exactly one user dir', dirs_in_fs)
     pkeq(1, len(uids_in_db), '{}: expecting exactly one uid in db', uids_in_db)
 
-    srtime.adjust_time(adjusted_time)
+    srtime.adjust_time(d + 10)
 
-    monkeypatch.setattr(auth, 'guest_uids', lambda: [])
-    res = admin.purge_guest_users(days=days, confirm=False)
-    pkeq({}, res, '{}: no guest users so no deletes', res)
+    res = admin.purge_guest_users(days=d, confirm=False)
+    pkeq({}, res, '{}: all premium users so no deletes', res)
     pkok(dirs_in_fs[0].check(dir=True), '{}: directory not deleted', dirs_in_fs)
     pkeq(
         auth_db.UserRegistration.search_by(uid=uids_in_db[0]).uid,
@@ -43,33 +37,35 @@ def test_1_purge_users_no_guests(monkeypatch, auth_fc):
         '{}: expecting uid to still be in db', uids_in_db
     )
 
-def test_2_purge_users_guests_present(auth_fc):
-    from sirepo import auth_db
-    from pykern.pkunit import pkeq, pkok
-    from sirepo import srunit
-    from sirepo.pkcli import admin
+def test_2_purge_non_premium(fc):
+    from pykern import pkunit
+    from pykern.pkdebug import pkdp
     from sirepo import srtime
+    from sirepo.pkcli import admin
+    import sirepo.auth
+    import sirepo.auth_db
 
-    if not auth_fc.sr_uid:
-        auth_fc.sr_login_as_guest()
-    days = 1
-    adjusted_time = days + 10
-    dirs_in_fs = _get_dirs()
-    uids_in_db = auth_db.UserRegistration.search_all_for_column('uid')
-    dirs_and_uids = {dirs_in_fs[0]: uids_in_db[0]}
-    srtime.adjust_time(adjusted_time)
-
-    res = admin.purge_guest_users(days=days, confirm=False)
-    pkeq(dirs_and_uids, res, '{}: one guest user so one dir and uid to delete', res)
-
-    res = admin.purge_guest_users(days=days, confirm=True)
-    pkeq(dirs_and_uids, res, '{}: one guest user so one dir and uid to delete', res)
-    pkok(not res.keys()[0].check(dir=True), '{}: directory deleted', res)
-    pkeq(
-        auth_db.UserRegistration.search_by(uid=res.values()[0]),
-        None,
-        '{}: expecting uid to deleted from db', res
+    u = fc.sr_login_as_guest()
+    sirepo.auth_db.UserRole.delete_roles(u, [sirepo.auth.ROLE_PREMIUM])
+    pkunit.pkeq(
+        2,
+        len(sirepo.auth_db.UserRegistration.search_all_for_column('uid')),
     )
+    d = 1
+    srtime.adjust_time(d + 10)
+    v = admin.purge_guest_users(days=d, confirm=False).items()
+    pkunit.pkeq(1, len(v))
+    pkunit.pkok(
+        u in str(v[0][0]),
+        'expecting uid in path to dir',
+    )
+    pkunit.pkok(
+        u == str(v[0][1]),
+        'expecting uid to delete to be the uid of the non premium user',
+    )
+    v = admin.purge_guest_users(days=d, confirm=True).items()
+    pkunit.pkok(not v[0][0].check(dir=True), '{}: directory not deleted', v)
+
 
 def _get_dirs():
     from pykern import pkio


### PR DESCRIPTION
This depends on #2373. Please merge that PR first.

Fix #1888

Part of #2360 
- revive pruning pkcli
- Differentiate between premium and non-premium users