### PR TITLE
Issue/2375

### DIFF
--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -13,6 +13,7 @@ import importlib
 import inspect
 import pykern.pkio
 import sirepo.srdb
+import sirepo.tornado
 import time
 import tornado.gen
 import tornado.ioloop
@@ -142,7 +143,7 @@ class DriverBase(PKDict):
 
     @classmethod
     def init_q(cls, maxsize):
-        res = tornado.queues.Queue(maxsize=maxsize)
+        res = sirepo.tornado.Queue(maxsize=maxsize)
         for i in range(1, maxsize + 1):
             res.put_nowait(i)
         return res

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -19,11 +19,11 @@ import pykern.pkio
 import sirepo.http_reply
 import sirepo.simulation_db
 import sirepo.srdb
+import sirepo.tornado
 import sirepo.util
 import time
 import tornado.ioloop
 import tornado.locks
-import tornado.queues
 
 #: where supervisor state is persisted to disk
 _DB_DIR = None
@@ -718,7 +718,7 @@ class _Op(PKDict):
         self.update(
             do_not_send=False,
             opId=job.unique_key(),
-            _reply_q=tornado.queues.Queue(),
+            _reply_q=sirepo.tornado.Queue(),
         )
         self.msg.update(opId=self.opId, opName=self.opName)
         pkdlog('{} runDir={}', self, self.msg.get('runDir'))

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -293,6 +293,46 @@ SIREPO.app.directive('buttons', function(appState, panelState) {
     };
 });
 
+SIREPO.app.directive('cancelledDueToTimeoutAlert', function(authState) {
+    return {
+        restrict: 'A',
+        scope: {
+            seconds: '<',
+            simState: '=cancelledDueToTimeoutAlert',
+        },
+        template: [
+            '<div data-ng-if="simState.getCancelledAfterSecs()" class="alert alert-warning" role="alert">',
+              '<h4 class="alert-heading">Cancelled: Maximum runtime exceeded</h4>',
+              '<p>Your simulation ran for {{getTime()}}. To increase your maximum runtime please upgrade to <a href="https://radiasoft.net/sirepo" target="_blank">Sirepo {{ premiumOrEnterprise() }}</a>.</p>',
+            '</div>',
+        ].join(''),
+        controller: function($scope) {
+            function leftPadZero(num) {
+                if (num < 10) {
+                    return '0' + num;
+                }
+                return num;
+            }
+
+            $scope.getTime = function() {
+                var s = $scope.simState.getCancelledAfterSecs();
+                var h = leftPadZero(Math.floor(s / 3600));
+                s %= 3600;
+                var m = leftPadZero(Math.floor(s / 60));
+                return h + ':' + m + ':' + leftPadZero(Math.floor(s % 60));
+            };
+
+            $scope.premiumOrEnterprise = function() {
+                if (authState.roles.includes('premium')) {
+                    return 'Enterprise';
+                }
+                return 'Premium';
+            };
+        },
+    };
+});
+
+>>>>>>> Stashed changes
 SIREPO.app.directive('confirmationModal', function() {
     return {
         restrict: 'A',

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -18,6 +18,7 @@ import os
 import re
 import signal
 import sirepo.auth
+import sirepo.tornado
 import socket
 import subprocess
 import sys
@@ -305,7 +306,7 @@ class _Dispatcher(PKDict):
             m = msg.copy()
             m.jobCmd = 'fastcgi'
             self._fastcgi_file = 'job_cmd_fastcgi.sock'
-            self._fastcgi_msg_q = tornado.queues.Queue(1)
+            self._fastcgi_msg_q = sirepo.tornado.Queue(1)
             pkio.unchecked_remove(self._fastcgi_file)
             # Avoid OSError: AF_UNIX path too long (max=100)
             # Use relative path

--- a/sirepo/tornado.py
+++ b/sirepo/tornado.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+u"""Wrappers for Tornado
+
+:copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+import asyncio
+import tornado.queues
+
+
+class Queue(tornado.queues.Queue):
+
+    async def get(self):
+        """Implements a cancellable Queue.get
+
+        See https://github.com/radiasoft/sirepo/issues/2375
+        """
+        x = None
+        try:
+            x = super().get()
+            return await x
+        except asyncio.CancelledError:
+            if x:
+                try:
+                    self.put_nowait(x.result())
+                except Exception:
+                    pass
+            raise

--- a/sirepo/tornado.py
+++ b/sirepo/tornado.py
@@ -4,6 +4,7 @@ u"""Wrappers for Tornado
 :copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+from pykern.pkdebug import pkdlog, pkdexc
 import asyncio
 import tornado.queues
 
@@ -17,12 +18,37 @@ class Queue(tornado.queues.Queue):
         """
         x = None
         try:
+            # this returns a future, which may get a result
+            # before the await returns, that is, if the task
+            # is cancelled after another task has put something
+            # on the queue and before this task finishes the await.
             x = super().get()
             return await x
         except asyncio.CancelledError:
             if x:
                 try:
-                    self.put_nowait(x.result())
+                    r = x.result()
                 except Exception:
+                    # there are many exceptions that can happen,
+                    # including throwing an exception on the Future.
+                    # However, none need to be cascaded as the task
+                    # has already been canceled.
                     pass
+                else:
+                    try:
+                        # got a valid result so put it back.
+                        self.task_done()
+                        self.put_nowait(r)
+                    except Exception as e:
+                        # at this point, the task is cancelled so
+                        # we can't raise another exception, but we
+                        # should log that an error has occurred.
+                        # It's an unlikely situation, but definitely a
+                        # bug in the code.
+                        pkdlog(
+                            'exception={} unable to put back result={} stack={}',
+                            e,
+                            r,
+                            pkdexc(),
+                        )
             raise

--- a/tests/job_concurrency1_test.py
+++ b/tests/job_concurrency1_test.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+u"""Concurrency testing
+
+This test does not always fail when there is a problem (false
+positive), because it depends on a specific sequence of events
+that can't be controlled by the test.
+
+:copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+
+"""
+from __future__ import absolute_import, division, print_function
+import pytest
+
+_REPORT = 'heightWeightReport'
+
+
+def test_myapp(fc):
+    """https://github.com/radiasoft/sirepo/issues/2346"""
+    from pykern import pkunit
+    import time
+    import threading
+    from pykern.pkdebug import pkdlog
+
+    d = fc.sr_sim_data()
+    d.models.simulation.name = 'srunit_long_run'
+    pkdlog('start 1')
+    r1 = fc.sr_post(
+        'runSimulation',
+        dict(
+            forceRun=False,
+            models=d.models,
+            report=_REPORT,
+            simulationId=d.models.simulation.simulationId,
+            simulationType=d.simulationType,
+        ),
+    )
+    for _ in range(10):
+        pkdlog(r1)
+        pkunit.pkok(r1.state != 'error', 'unexpected error state: {}')
+        if r1.state == 'running':
+            break
+        time.sleep(.1)
+        r1 = fc.sr_post('runStatus', r1.nextRequest)
+    else:
+        pkunit.pkfail('runStatus: failed to start running: {}', r1)
+
+    def _t2():
+        pkdlog('start 2')
+        r2 = fc.sr_post(
+            'runSimulation',
+            dict(
+                forceRun=False,
+                models=d.models,
+                report=_REPORT,
+                simulationId=d.models.simulation.simulationId,
+                simulationType=d.simulationType,
+            ),
+        )
+        pkdlog(r2)
+        for _ in range(20):
+            pkunit.pkok(r2.state != 'error', 'unexpected error state: {}')
+            if r2.state == 'running':
+                break
+            if r2.state == 'canceled':
+                pkdlog('canceled')
+                break
+            time.sleep(.1)
+            pkdlog('runStatus 2')
+            r2 = fc.sr_post('runStatus', r2.nextRequest)
+        else:
+            pkunit.pkfail('runStatus: failed to start running: {}', r2)
+
+
+    t2 = threading.Thread(target=_t2)
+    t2.start()
+    time.sleep(.1)
+    pkdlog('runCancel')
+    c = fc.sr_post('runCancel', r1.nextRequest)
+    pkunit.pkeq('canceled', c.state)
+
+    pkdlog('start 3')
+    r1 = fc.sr_post(
+        'runSimulation',
+        dict(
+            forceRun=False,
+            models=d.models,
+            report=_REPORT,
+            simulationId=d.models.simulation.simulationId,
+            simulationType=d.simulationType,
+        ),
+    )
+    for _ in range(10):
+        pkunit.pkok(r1.state != 'error', 'unexpected error state: {}')
+        if r1.state == 'running':
+            break
+        time.sleep(.1)
+        r1 = fc.sr_post('runStatus', r1.nextRequest)
+    else:
+        pkunit.pkfail('runStatus: failed to start running: {}', r1)
+    c = fc.sr_post('runCancel', r1.nextRequest)
+    pkunit.pkeq('canceled', c.state)

--- a/tests/job_concurrency1_test.py
+++ b/tests/job_concurrency1_test.py
@@ -24,26 +24,6 @@ def test_myapp(fc):
 
     d = fc.sr_sim_data()
     d.models.simulation.name = 'srunit_long_run'
-    pkdlog('start 1')
-    r1 = fc.sr_post(
-        'runSimulation',
-        dict(
-            forceRun=False,
-            models=d.models,
-            report=_REPORT,
-            simulationId=d.models.simulation.simulationId,
-            simulationType=d.simulationType,
-        ),
-    )
-    for _ in range(10):
-        pkdlog(r1)
-        pkunit.pkok(r1.state != 'error', 'unexpected error state: {}')
-        if r1.state == 'running':
-            break
-        time.sleep(.1)
-        r1 = fc.sr_post('runStatus', r1.nextRequest)
-    else:
-        pkunit.pkfail('runStatus: failed to start running: {}', r1)
 
     def _t2():
         pkdlog('start 2')
@@ -71,6 +51,26 @@ def test_myapp(fc):
         else:
             pkunit.pkfail('runStatus: failed to start running: {}', r2)
 
+    pkdlog('start 1')
+    r1 = fc.sr_post(
+        'runSimulation',
+        dict(
+            forceRun=False,
+            models=d.models,
+            report=_REPORT,
+            simulationId=d.models.simulation.simulationId,
+            simulationType=d.simulationType,
+        ),
+    )
+    for _ in range(10):
+        pkdlog(r1)
+        pkunit.pkok(r1.state != 'error', 'unexpected error state: {}')
+        if r1.state == 'running':
+            break
+        time.sleep(.1)
+        r1 = fc.sr_post('runStatus', r1.nextRequest)
+    else:
+        pkunit.pkfail('runStatus: failed to start running: {}', r1)
 
     t2 = threading.Thread(target=_t2)
     t2.start()


### PR DESCRIPTION
I'm not convinced this will work well enough in job_agent to avoid the problem of dropped queue items. In order for it to work, the cancelled task has to have a chance to run before anyone else checks the queue. For simple gets that's probably ok, but job_agent [checks the queue without awaits](https://github.com/radiasoft/sirepo/blob/830595d6806ba07f021d97cccaba0964c166ccf2/sirepo/pkcli/job_agent.py#L299) when there's a fastcgi error. 

I think it works in the job_driver (slot) cases, because all access is via Queue.get.