### PR TITLE
Fix #2280

### DIFF
--- a/sirepo/package_data/static/html/elegant-visualization.html
+++ b/sirepo/package_data/static/html/elegant-visualization.html
@@ -5,11 +5,7 @@
       <div data-basic-editor-panel="" data-view-name="simulationStatus" data-want-buttons="">
        <div data-cancelled-due-to-timeout-alert="visualization.simState"></div>
           <form name="form" class="form-horizontal" autocomplete="off" novalidate data-ng-show="visualization.simState.isProcessing()">
-            <div class="col-sm-12" data-ng-show="visualization.simState.isStatePending()">
-              <div>
-                {{ visualization.simState.stateAsText() }}  {{ visualization.simState.dots }}
-              </div>
-            </div>
+            <div class="col-sm-12" data-pending-link-to-simulations="" data-sim-state="visualization.simState"></div>
             <div class="col-sm-12" data-ng-show="visualization.simState.isStateRunning()">
               <div>
                 {{ visualization.runningStatusText() }}

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -1349,6 +1349,25 @@ SIREPO.app.directive('panelLayout', function(appState, utilities, $window) {
     };
 });
 
+SIREPO.app.directive('pendingLinkToSimulations', function(requestSender) {
+    return {
+        restrict: 'A',
+        scope: {
+            simState: '<',
+        },
+        template: [
+            '<div data-ng-show="simState.isStatePending()">',
+              '<a data-ng-href="{{ requestSender.formatUrlLocal(\'ownJobs\') }}" target="_blank" >',
+                '<span class="glyphicon glyphicon-hourglass"></span> {{ simState.stateAsText() }} {{ simState.dots }}',
+              '</a>',
+            '</div>',
+        ].join(''),
+        controller: function($scope) {
+            $scope.requestSender = requestSender;
+        },
+    };
+});
+
 SIREPO.app.directive('safePath', function() {
 
     // keep in sync with sirepo.srschem.py _NAME_ILLEGALS
@@ -3141,9 +3160,7 @@ SIREPO.app.directive('simStatusPanel', function(appState) {
         },
         template: [
             '<form name="form" class="form-horizontal" autocomplete="off" novalidate data-ng-show="simState.isProcessing()">',
-              '<div data-ng-show="simState.isStatePending()">',
-                '<div class="col-sm-12">{{ simState.stateAsText() }} {{ simState.dots }}</div>',
-              '</div>',
+              '<div data-pending-link-to-simulations="" data-sim-state="simState"></div>',
               '<div data-ng-show="simState.isStateRunning()">',
                 '<div class="col-sm-12">',
                   '<div data-ng-show="simState.isInitializing()">{{ initMessage() }} {{ simState.dots }}</div>',

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -1842,9 +1842,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
 
               '<div data-ng-if="simState.isProcessing()">',
                 '<div class="col-sm-6">',
-                  '<div data-ng-show="simState.isStatePending()">',
-                    '<span class="glyphicon glyphicon-hourglass"></span> {{ simState.stateAsText() }} {{ simState.dots }}',
-                  '</div>',
+                  '<div data-pending-link-to-simulations="" data-sim-state="simState"></div>',
                   '<div data-ng-show="simState.isInitializing()">',
                     '<span class="glyphicon glyphicon-hourglass"></span> Initializing Simulation {{ simState.dots }}',
                   '</div>',

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -2642,9 +2642,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, frameCache, pan
         template: [
             '<div data-simple-panel="{{ modelName }}">',
                 '<form name="form" class="form-horizontal" autocomplete="off" novalidate data-ng-show="simState.isProcessing()">',
-                  '<div data-ng-show="simState.isStatePending()">',
-                    '<div class="col-sm-12">{{ simState.stateAsText() }} {{ simState.dots }}</div>',
-                  '</div>',
+                  '<div data-pending-link-to-simulations="" data-sim-state="simState"></div>',
                   '<div data-ng-show="simState.isStateRunning()">',
                     '<div class="col-sm-12">',
                       '<div data-ng-show="simState.isInitializing() || simState.getFrameCount() > 0">',


### PR DESCRIPTION
The hour-glass and pending text is now a link to the user's currently running simulations so they can understand what may be blocking their run.

There is a lot of blue already on the screen so I'm a little concerned that users won't see the link. If others agree I'm open to suggestions to make the link more obvious.

![Screen Shot 2020-03-26 at 1 45 32 PM](https://user-images.githubusercontent.com/10264515/77695152-e9ef0f00-6f70-11ea-8f9c-c2c49fd17ec1.png)
