### PR TITLE
Fix to handle FLASH distributed as an rpm not a zip.

### DIFF
--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -140,9 +140,6 @@ def api_runCancel():
 @api_perm.require_user
 def api_runSimulation():
     r = _request_content(PKDict(fixup_old_data=True))
-    # TODO(e-carlin): This should really be done in job_supervisor._lib_dir_symlink()
-    # but that is outside of the Flask context so it won't work
-    r.simulation_lib_dir = sirepo.simulation_db.simulation_lib_dir(r.simulationType)
     if r.isParallel:
         r.isPremiumUser = sirepo.auth.is_premium_user()
     return _request(_request_content=r)

--- a/sirepo/package_data/static/html/flash-physics.html
+++ b/sirepo/package_data/static/html/flash-physics.html
@@ -1,18 +1,18 @@
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-6" data-ng-if="physics.flashService.isFlashType('CapLaser')">
+    <div class="col-md-6" data-ng-if="physics.flashService.isFlashType('CapLaserBELLA')">
       <div data-basic-editor-panel="" data-view-name="physics:sourceTerms:EnergyDeposition:Laser"></div>
     </div>
-    <div class="col-md-6" data-ng-if="physics.flashService.isFlashType('CapLaser')">
+    <div class="col-md-6" data-ng-if="physics.flashService.isFlashType('CapLaserBELLA')">
       <div data-basic-editor-panel="" data-view-name="physics:RadTrans"></div>
     </div>
     <div class="col-md-6">
       <div data-basic-editor-panel="" data-view-name="physics:Hydro"></div>
     </div>
-    <div class="col-md-6" data-ng-if="physics.flashService.isFlashType('CapLaser')">
+    <div class="col-md-6" data-ng-if="physics.flashService.isFlashType('CapLaserBELLA')">
       <div data-basic-editor-panel="" data-view-name="physics:Diffuse"></div>
     </div>
-    <div class="col-md-6" data-ng-if="physics.flashService.isFlashType('CapLaser')">
+    <div class="col-md-6" data-ng-if="physics.flashService.isFlashType('CapLaserBELLA')">
       <div data-basic-editor-panel="" data-view-name="physics:materialProperties"></div>
     </div>
     <div class="col-md-6" data-ng-if="physics.flashService.isFlashType('RTFlame')">

--- a/sirepo/package_data/static/html/flash-source.html
+++ b/sirepo/package_data/static/html/flash-source.html
@@ -3,8 +3,8 @@
     <div class="col-md-6" data-ng-if="source.flashService.isFlashType('RTFlame')">
       <div data-basic-editor-panel="" data-view-name="Simulation:RTFlame"></div>
     </div>
-    <div class="col-md-6" data-ng-if="source.flashService.isFlashType('CapLaser')">
-      <div data-basic-editor-panel="" data-view-name="Simulation:magnetoHD:CapLaser"></div>
+    <div class="col-md-6" data-ng-if="source.flashService.isFlashType('CapLaserBELLA')">
+      <div data-basic-editor-panel="" data-view-name="Simulation:magnetoHD:CapLaserBELLA"></div>
     </div>
     <div class="col-md-6">
       <div data-basic-editor-panel="" data-view-name="Grid"></div>

--- a/sirepo/package_data/static/html/flash-visualization.html
+++ b/sirepo/package_data/static/html/flash-visualization.html
@@ -13,7 +13,7 @@
         <div class="col-md-12">
           <div data-basic-editor-panel="" data-view-name="Driver"></div>
         </div>
-        <div class="col-md-12" data-ng-if="visualization.flashService.isFlashType('CapLaser') && visualization.simState.hasFrames()">
+        <div class="col-md-12" data-ng-if="visualization.flashService.isFlashType('CapLaserBELLA') && visualization.simState.hasFrames()">
           <div data-report-panel="parameter" data-model-name="gridEvolutionAnimation"></div>
        </div>
       </div>

--- a/sirepo/package_data/static/json/flash-schema.json
+++ b/sirepo/package_data/static/json/flash-schema.json
@@ -1,7 +1,7 @@
 {
     "enum": {
         "flashType": [
-            ["CapLaser", "CapLaser"],
+            ["CapLaserBELLA", "CapLaserBELLA"],
             ["RTFlame", "RTFlame"]
         ],
         "physics:Gravity:Constant:gdirec": [
@@ -163,11 +163,11 @@
             ["hybrid", "hybrid"],
             ["limited", "limited"]
         ],
-        "Simulation:magnetoHD:CapLaser:sim_eosFill": [
+        "Simulation:magnetoHD:CapLaserBELLA:sim_eosFill": [
             ["eos_tab", "eos_tab"],
             ["eos_gam", "eos_gam"]
         ],
-        "Simulation:magnetoHD:CapLaser:sim_eosWall": [
+        "Simulation:magnetoHD:CapLaserBELLA:sim_eosWall": [
             ["eos_tab", "eos_tab"],
             ["eos_gam", "eos_gam"]
         ],
@@ -885,10 +885,10 @@
             "op_fillLowTemp": ["op_fillLowTemp", "Float", 0.0],
             "op_wallLowTemp": ["op_wallLowTemp", "Float", 0.0]
         },
-        "Simulation:magnetoHD:CapLaser": {
+        "Simulation:magnetoHD:CapLaserBELLA": {
             "sim_condWall": ["sim_condWall", "Float", 195000.0, "Wall conductivity at the gas/wall interface"],
-            "sim_eosFill": ["Fill EOS Type", "Simulation:magnetoHD:CapLaser:sim_eosFill", "eos_gam"],
-            "sim_eosWall": ["Wall EOS Type", "Simulation:magnetoHD:CapLaser:sim_eosWall", "eos_tab"],
+            "sim_eosFill": ["Fill EOS Type", "Simulation:magnetoHD:CapLaserBELLA:sim_eosFill", "eos_gam"],
+            "sim_eosWall": ["Wall EOS Type", "Simulation:magnetoHD:CapLaserBELLA:sim_eosWall", "eos_tab"],
             "sim_peakField": ["sim_peakField", "Float", 2400.0, "peak field in gauss at capillary wall"],
             "sim_period": ["sim_period", "Float", 3e-07, "circuit period in seconds"],
             "sim_rhoFill": ["Fill Initial Density", "Float", 2.655e-07],
@@ -1483,8 +1483,8 @@
                 "allowDtSTSDominate"
             ]
         },
-        "Simulation:magnetoHD:CapLaser": {
-            "title": "CapLaser Settings",
+        "Simulation:magnetoHD:CapLaserBELLA": {
+            "title": "CapLaserBELLA Settings",
             "basic": [
                 ["Main", [
                     "sim_zminWall",

--- a/sirepo/package_data/template/flash/default-data.json
+++ b/sirepo/package_data/template/flash/default-data.json
@@ -384,7 +384,7 @@
             "vel_pert_amp": 0.0,
             "vel_pert_wavelength1": 1.0
         },
-        "Simulation:magnetoHD:CapLaser": {
+        "Simulation:magnetoHD:CapLaserBELLA": {
             "sim_condWall": 195000.0,
             "sim_eosFill": "eos_gam",
             "sim_eosWall": "eos_tab",

--- a/sirepo/package_data/template/flash/examples/caplaserbella.json
+++ b/sirepo/package_data/template/flash/examples/caplaserbella.json
@@ -384,7 +384,7 @@
             "vel_pert_amp": 0,
             "vel_pert_wavelength1": 1
         },
-        "Simulation:magnetoHD:CapLaser": {
+        "Simulation:magnetoHD:CapLaserBELLA": {
             "sim_condWall": 150000,
             "sim_eosFill": "eos_gam",
             "sim_eosWall": "eos_tab",
@@ -778,7 +778,7 @@
         "simFolder": {},
         "simulation": {
             "documentationUrl": "",
-            "flashType": "CapLaser",
+            "flashType": "CapLaserBELLA",
             "folder": "/Examples",
             "isExample": true,
             "name": "Cap Laser",

--- a/sirepo/package_data/template/flash/examples/rtflame.json
+++ b/sirepo/package_data/template/flash/examples/rtflame.json
@@ -384,7 +384,7 @@
             "vel_pert_amp": 0,
             "vel_pert_wavelength1": 1
         },
-        "Simulation:magnetoHD:CapLaser": {
+        "Simulation:magnetoHD:CapLaserBELLA": {
             "sim_condWall": 195000,
             "sim_eosFill": "eos_gam",
             "sim_eosWall": "eos_tab",

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -53,7 +53,7 @@ def audit_proprietary_lib_files(*uid):
             p = simulation_db.simulation_lib_dir(sim_type).join(f.basename)
             if not should_link:
                 pkio.unchecked_remove(p)
-                return
+                continue
             try:
                 assert f.check(file=True), f'{f} not found'
                 p.mksymlinkto(

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -49,10 +49,7 @@ def audit_proprietary_lib_files(*uid):
                 )
 
     def _link_or_unlink_proprietary_files(sim_type, should_link):
-        for f in proprietary_code_dir(sim_type).listdir(
-                fil=lambda x: x.check(file=True),
-                sort=True,
-        ):
+        for f in pkio.sorted_glob(proprietary_code_dir(sim_type).join('*')):
             p = simulation_db.simulation_lib_dir(sim_type).join(f.basename)
             if not should_link:
                 pkio.unchecked_remove(p)
@@ -114,7 +111,7 @@ def setup_dev_proprietary_code(sim_type, rpm_url):
 
     urllib.request.urlretrieve(
         rpm_url,
-        d.join(getattr(s, '{}_RPM'.format(sim_type.upper()))),
+        d.join(s.proprietary_code_rpm()),
     )
 
 

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -49,20 +49,20 @@ def audit_proprietary_lib_files(*uid):
                 )
 
     def _link_or_unlink_proprietary_files(sim_type, should_link):
-        d = proprietary_code_dir(sim_type)
-        for e in simulation_db.examples(sim_type):
-            b = sim_data.get_class(sim_type).proprietary_lib_file_basename(e)
-            p = simulation_db.simulation_lib_dir(sim_type).join(b)
-            if not should_link:
-                pkio.unchecked_remove(p)
-                continue
-            try:
-                p.mksymlinkto(
-                    d.join(b),
-                    absolute=False,
-                )
-            except py.error.EEXIST:
-                pass
+        b = sim_data.get_class(sim_type).FLASH_RPM_FILENAME
+        p = simulation_db.simulation_lib_dir(sim_type).join(b)
+        if not should_link:
+            pkio.unchecked_remove(p)
+            return
+        try:
+            s = proprietary_code_dir(sim_type).join(b)
+            assert s.check(file=True), f'{s} not found'
+            p.mksymlinkto(
+                s,
+                absolute=False,
+            )
+        except py.error.EEXIST:
+            pass
 
     server.init()
     t = feature_config.cfg().proprietary_sim_types

--- a/sirepo/pkcli/flash.py
+++ b/sirepo/pkcli/flash.py
@@ -20,7 +20,7 @@ import subprocess
 def run_background(cfg_dir):
     data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
     mpi.run_program(
-        [pkio.py_path(cfg_dir).join(sirepo.sim_data.get_class(data).EXE_NAME)],
+        [sirepo.sim_data.get_class(data).flash_exe_name(data)],
     )
 
 def setup_dev():
@@ -35,9 +35,10 @@ def setup_dev():
         _remote_file(dest)
 
     def _local_file(dest):
-        shutil.copy(pkio.py_path(
-            cfg.dev_depot_url.replace(_FILE_PREFIX, ''),
-        ).join(dest.basename), dest)
+        p = pkio.py_path(cfg.dev_depot_url.replace(_FILE_PREFIX, ''))
+        f = pkio.walk_tree(p.dirname, p.basename)
+        assert len(f) == 1, f'expecting only 1 file found {f}'
+        shutil.copy(f[0], dest)
 
     def _remote_file(dest):
         r = requests.get('{}/{}'.format(cfg.dev_depot_url, dest.basename))
@@ -53,14 +54,12 @@ def setup_dev():
     d = sirepo.pkcli.admin.proprietary_code_dir(t)
     pkio.mkdir_parent(d)
     s = sirepo.sim_data.get_class(t)
-    for e in simulation_db.examples(t):
-        _get_file(d.join(s.proprietary_lib_file_basename(e)))
+    _get_file(d.join(s.FLASH_RPM_FILENAME))
 
 
 cfg = pkconfig.init(
     dev_depot_url=(
-        # TODO(e-carlin): This should be radiasoft.depot.org
-        'file:///home/vagrant/src/FLASH4.6.2',
+        'file:///home/vagrant/src/yum/fedora/29/x86_64/dev/rscode-flash',
         str,
         'where to get flash files when in dev'
     )

--- a/sirepo/pkcli/flash.py
+++ b/sirepo/pkcli/flash.py
@@ -20,47 +20,5 @@ import subprocess
 def run_background(cfg_dir):
     data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
     mpi.run_program(
-        [sirepo.sim_data.get_class(data).flash_exe_name(data)],
+        [sirepo.sim_data.get_class(data).flash_exe_path(data)],
     )
-
-def setup_dev():
-    import requests
-    import shutil
-    import sirepo.pkcli.admin
-
-    def _get_file(dest):
-        if cfg.dev_depot_url.startswith(_FILE_PREFIX):
-            _local_file(dest)
-            return
-        _remote_file(dest)
-
-    def _local_file(dest):
-        p = pkio.py_path(cfg.dev_depot_url.replace(_FILE_PREFIX, ''))
-        f = pkio.walk_tree(p.dirname, p.basename)
-        assert len(f) == 1, f'expecting only 1 file found {f}'
-        shutil.copy(f[0], dest)
-
-    def _remote_file(dest):
-        r = requests.get('{}/{}'.format(cfg.dev_depot_url, dest.basename))
-        r.raise_for_status()
-        dest.write_binary(r.content)
-
-
-    assert pkconfig.channel_in('dev'), \
-        'Only to be used in dev. channel={}'.format(pkconfig.cfg.channel)
-
-    _FILE_PREFIX = 'file://'
-    t = 'flash'
-    d = sirepo.pkcli.admin.proprietary_code_dir(t)
-    pkio.mkdir_parent(d)
-    s = sirepo.sim_data.get_class(t)
-    _get_file(d.join(s.FLASH_RPM_FILENAME))
-
-
-cfg = pkconfig.init(
-    dev_depot_url=(
-        'file:///home/vagrant/src/yum/fedora/29/x86_64/dev/rscode-flash',
-        str,
-        'where to get flash files when in dev'
-    )
-)

--- a/sirepo/sim_data/__init__.py
+++ b/sirepo/sim_data/__init__.py
@@ -462,6 +462,10 @@ class SimDataBase(object):
         return 2 if cls.is_parallel(data) else 1
 
     @classmethod
+    def proprietary_code_rpm(cls):
+        return f'{cls.sim_type()}.rpm'
+
+    @classmethod
     def resource_dir(cls):
         return cls._memoize(resource_dir().join(cls.sim_type()))
 

--- a/sirepo/sim_data/__init__.py
+++ b/sirepo/sim_data/__init__.py
@@ -371,11 +371,7 @@ class SimDataBase(object):
             data (dict): simulation db
             run_dir (py.path): where to copy to
         """
-        # TODO(e-carlin): When remote we will pull the flash binary
-        # over the wire each time the user wants to run the sim. Could
-        # be a source of slowdown.
-        p = cls.proprietary_lib_file_basename(data)
-        for b in cls.lib_file_basenames(data) + ([p] if p else []):
+        for b in cls.lib_file_basenames(data):
             t = run_dir.join(b)
             s = cls.lib_file_abspath(b, data=data)
             if t != s:
@@ -464,12 +460,6 @@ class SimDataBase(object):
             int: number of seconds to poll
         """
         return 2 if cls.is_parallel(data) else 1
-
-    @classmethod
-    def proprietary_lib_file_basename(cls, data):
-        """Zip archive of proprietary file(s) used by the simulation
-        """
-        return None
 
     @classmethod
     def resource_dir(cls):

--- a/sirepo/sim_data/flash.py
+++ b/sirepo/sim_data/flash.py
@@ -13,8 +13,7 @@ import sirepo.util
 
 class SimData(sirepo.sim_data.SimDataBase):
 
-    FLASH_RPM = 'flash.rpm'
-    _FLASH_EXE_PREFIX = 'flash4'
+    _FLASH_PREFIX = 'flash4'
     _FLASH_SETUP_UNITS_PREFIX = 'setup_units'
 
     @classmethod
@@ -33,7 +32,7 @@ class SimData(sirepo.sim_data.SimDataBase):
         import distutils.spawn
         p = distutils.spawn.find_executable(
             '{}-{}'.format(
-                cls._FLASH_EXE_PREFIX,
+                cls._FLASH_PREFIX,
                 data.models.simulation.flashType,
             ),
         )
@@ -47,7 +46,7 @@ class SimData(sirepo.sim_data.SimDataBase):
             '..',
             '..',
             'share',
-            cls._FLASH_EXE_PREFIX,
+            cls._FLASH_PREFIX,
             f'{cls._FLASH_SETUP_UNITS_PREFIX}-{data.models.simulation.flashType}',
         )
 

--- a/sirepo/sim_data/flash.py
+++ b/sirepo/sim_data/flash.py
@@ -5,6 +5,7 @@ u"""simulation data operations
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from __future__ import absolute_import, division, print_function
+from pykern import pkio
 import sirepo.sim_data
 import sirepo.util
 
@@ -12,8 +13,9 @@ import sirepo.util
 
 class SimData(sirepo.sim_data.SimDataBase):
 
-    EXE_NAME = 'flash4'
-    SETUP_UNITS_FILE = 'setup_units'
+    FLASH_RPM_FILENAME = 'flash.rpm'
+    _FLASH_EXE_PREFIX = 'flash4'
+    _FLASH_SETUP_UNITS_PREFIX = 'setup_units'
 
     @classmethod
     def fixup_old_data(cls, data):
@@ -26,8 +28,21 @@ class SimData(sirepo.sim_data.SimDataBase):
             )
 
     @classmethod
-    def proprietary_lib_file_basename(cls, data):
-        return '{}.zip'.format(sirepo.util.secure_filename(data.models.simulation.flashType))
+    def flash_exe_name(cls, data):
+        return '{}-{}'.format(
+            cls._FLASH_EXE_PREFIX,
+            data.models.simulation.flashType,
+        )
+
+    @classmethod
+    def flash_setup_units_path(cls, data):
+        return pkio.py_path(
+            # TODO(e-carlin): talk with rn about sharing this path better with installer
+            '/home/vagrant/.local/share/flash4/{}-{}'.format(
+                cls._FLASH_SETUP_UNITS_PREFIX,
+                data.models.simulation.flashType,
+            )
+        )
 
     @classmethod
     def _compute_job_fields(cls, data, r, compute_model):

--- a/sirepo/sim_data/flash.py
+++ b/sirepo/sim_data/flash.py
@@ -13,7 +13,7 @@ import sirepo.util
 
 class SimData(sirepo.sim_data.SimDataBase):
 
-    FLASH_RPM_FILENAME = 'flash.rpm'
+    FLASH_RPM = 'flash.rpm'
     _FLASH_EXE_PREFIX = 'flash4'
     _FLASH_SETUP_UNITS_PREFIX = 'setup_units'
 
@@ -28,20 +28,27 @@ class SimData(sirepo.sim_data.SimDataBase):
             )
 
     @classmethod
-    def flash_exe_name(cls, data):
-        return '{}-{}'.format(
-            cls._FLASH_EXE_PREFIX,
-            data.models.simulation.flashType,
+    def flash_exe_path(cls, data):
+        from pykern import pkio
+        import distutils.spawn
+        p = distutils.spawn.find_executable(
+            '{}-{}'.format(
+                cls._FLASH_EXE_PREFIX,
+                data.models.simulation.flashType,
+            ),
         )
+        if p:
+            return pkio.py_path(p)
+        return  None
 
     @classmethod
     def flash_setup_units_path(cls, data):
-        return pkio.py_path(
-            # TODO(e-carlin): talk with rn about sharing this path better with installer
-            '/home/vagrant/.local/share/flash4/{}-{}'.format(
-                cls._FLASH_SETUP_UNITS_PREFIX,
-                data.models.simulation.flashType,
-            )
+        return cls.flash_exe_path(data).join(
+            '..',
+            '..',
+            'share',
+            cls._FLASH_EXE_PREFIX,
+            f'{cls._FLASH_SETUP_UNITS_PREFIX}-{data.models.simulation.flashType}',
         )
 
     @classmethod

--- a/sirepo/sim_data/flash.py
+++ b/sirepo/sim_data/flash.py
@@ -27,18 +27,19 @@ class SimData(sirepo.sim_data.SimDataBase):
             )
 
     @classmethod
-    def flash_exe_path(cls, data):
+    def flash_exe_path(cls, data, unchecked=False):
         from pykern import pkio
         import distutils.spawn
-        p = distutils.spawn.find_executable(
-            '{}-{}'.format(
-                cls._FLASH_PREFIX,
-                data.models.simulation.flashType,
-            ),
+        n = '{}-{}'.format(
+            cls._FLASH_PREFIX,
+            data.models.simulation.flashType,
         )
+        p = distutils.spawn.find_executable(n)
         if p:
             return pkio.py_path(p)
-        return  None
+        if unchecked:
+            return  None
+        raise AssertionError(f'unable to find executable={n}')
 
     @classmethod
     def flash_setup_units_path(cls, data):

--- a/sirepo/sim_data/flash.py
+++ b/sirepo/sim_data/flash.py
@@ -20,7 +20,7 @@ class SimData(sirepo.sim_data.SimDataBase):
     def fixup_old_data(cls, data):
         dm = data.models
         cls._init_models(dm)
-        if dm.simulation.flashType == 'CapLaser':
+        if dm.simulation.flashType == 'CapLaserBELLA':
             dm.IO.update(
                 plot_var_5='magz',
                 plot_var_6='depo',
@@ -59,6 +59,6 @@ class SimData(sirepo.sim_data.SimDataBase):
         t = data.models.simulation.flashType
         if t == 'RTFlame':
             return ['helm_table.dat']
-        if t == 'CapLaser':
+        if t == 'CapLaserBELLA':
             return ['al-imx-004.cn4', 'h-imx-004.cn4']
         raise AssertionError('invalid flashType: {}'.format(t))

--- a/sirepo/template/flash.py
+++ b/sirepo/template/flash.py
@@ -414,7 +414,7 @@ def _extract_rpm(data):
     #SECURITY: No user defined input in cmd so shell=True is ok
     subprocess.check_output(
         "rpm2cpio '{}' | cpio --extract --make-directories".format(
-            _SIM_DATA.lib_file_abspath(_SIM_DATA.FLASH_RPM),
+            _SIM_DATA.lib_file_abspath(_SIM_DATA.proprietary_code_rpm()),
         ),
         cwd='/',
         shell=True,

--- a/sirepo/template/flash.py
+++ b/sirepo/template/flash.py
@@ -407,21 +407,18 @@ def _cell_size(f, refine_max):
 
 
 def _extract_rpm(data):
-    import distutils.spawn
     import subprocess
 
-    if distutils.spawn.find_executable(_SIM_DATA.flash_exe_name(data)):
+    if _SIM_DATA.flash_exe_path(data):
         return
     #SECURITY: No user defined input in cmd so shell=True is ok
-    # TODO(e-carlin): think about stdout and stderr, where should they go?
-    subprocess.check_call(
-        'rpm2cpio {} | cpio -idv'.format(
-            simulation_db.simulation_lib_dir(SIM_TYPE).join(
-                _SIM_DATA.FLASH_RPM_FILENAME,
-            ),
+    subprocess.check_output(
+        "rpm2cpio '{}' | cpio --extract --make-directories".format(
+            _SIM_DATA.lib_file_abspath(_SIM_DATA.FLASH_RPM),
         ),
         cwd='/',
         shell=True,
+        stderr=subprocess.STDOUT,
     )
 
 

--- a/sirepo/template/flash.py
+++ b/sirepo/template/flash.py
@@ -409,14 +409,14 @@ def _cell_size(f, refine_max):
 def _extract_rpm(data):
     import subprocess
 
-    if _SIM_DATA.flash_exe_path(data):
+    if _SIM_DATA.flash_exe_path(data, unchecked=True):
         return
-    #SECURITY: No user defined input in cmd so shell=True is ok
     subprocess.check_output(
         "rpm2cpio '{}' | cpio --extract --make-directories".format(
             _SIM_DATA.lib_file_abspath(_SIM_DATA.proprietary_code_rpm()),
         ),
         cwd='/',
+        #SECURITY: No user defined input in cmd so shell=True is ok
         shell=True,
         stderr=subprocess.STDOUT,
     )

--- a/sirepo/template/flash.py
+++ b/sirepo/template/flash.py
@@ -86,7 +86,7 @@ _DEFAULT_VALUES = {
             'y3': 'Burning rate',
         },
     },
-    'CapLaser': {
+    'CapLaserBELLA': {
         'varAnimation': {
             'var': 'tele',
         },
@@ -261,7 +261,7 @@ _DEFAULT_VALUES = {
         'physics:Diffuse:Unsplit': {
             'diff_thetaImplct': 1.0,
         },
-        'Simulation:magnetoHD:CapLaser': {
+        'Simulation:magnetoHD:CapLaserBELLA': {
             'sim_peakField': 3.2e3,
             'sim_period': 400e-9,
             'sim_rhoWall': 2.7,
@@ -429,7 +429,7 @@ _PLOT_COLUMNS = {
         ['burned mass', 9],
         ['burning rate', 12],
     ],
-    'CapLaser': [
+    'CapLaserBELLA': [
         ['x-momentum', 2],
         ['y-momentum', 3],
         ['E kinetic', 6],

--- a/tests/pkcli/roles_test.py
+++ b/tests/pkcli/roles_test.py
@@ -13,6 +13,7 @@ def test_flash_change_role_change_lib_files(auth_fc):
     import sirepo.auth
     import sirepo.auth_db
     import sirepo.pkcli.roles
+    import sirepo.server
 
     def _change_role(add=True):
         f = getattr(sirepo.pkcli.roles, 'add_roles')
@@ -29,7 +30,8 @@ def test_flash_change_role_change_lib_files(auth_fc):
             [x.basename for x in pkio.walk_tree(fc.sr_user_dir(), _proprietary_file)],
         )
 
-    _proprietary_file = 'CapLaser.zip'
+    pkunit.data_dir().join('db').copy(sirepo.server._app.sirepo_db_dir)
+    _proprietary_file = 'flash.rpm'
     fc = auth_fc
     fc.sr_email_register('a@b.c', sim_type='flash')
 


### PR DESCRIPTION
The rpm is symlinked to the simulation_lib_dir and is lazily
loaded when flash is run. It will only be unpakced one time
for the life of an agent.