### PR TITLE
Fix #2484. All sbatch ops are untimed.

### DIFF
--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -34,6 +34,8 @@ cfg = None
 
 OPS_THAT_NEED_SLOTS = frozenset((job.OP_ANALYSIS, job.OP_RUN))
 
+_UNTIMED_OPS = frozenset((job.OP_ALIVE, job.OP_CANCEL, job.OP_ERROR, job.OP_KILL, job.OP_OK))
+
 
 class AgentMsg(PKDict):
 
@@ -131,6 +133,9 @@ class DriverBase(PKDict):
             ),
             libFileList=[f.basename for f in d.listdir()],
         )
+
+    def op_is_untimed(self, op):
+        return op.opName in _UNTIMED_OPS
 
     def pkdebug_str(self):
         return pkdformat(

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -85,6 +85,9 @@ class SbatchDriver(job_driver.DriverBase):
         ).encode('ascii')
         return cls
 
+    def op_is_untimed(self, op):
+        return True
+
     async def prepare_send(self, op):
         m = op.msg
         c = m.pkdel('sbatchCredentials')
@@ -109,8 +112,6 @@ class SbatchDriver(job_driver.DriverBase):
             if self.cfg.cores:
                 m.sbatchCores = min(m.sbatchCores, self.cfg.cores)
             m.mpiCores = m.sbatchCores
-            if op.kind == job.PARALLEL:
-                op.maxRunSecs = 0
         m.shifterImage = self.cfg.shifter_image
         return await super().prepare_send(op)
 


### PR DESCRIPTION
Sbatch resources are not ours to manage therefore ops sent to
sbatch don't need to be timed.