### PR TITLE
Fix #2518. Deleted run dirs do not result in an error.

### DIFF
--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -298,16 +298,12 @@ class _ComputeJob(PKDict):
             # at anytime so we need to check that they haven't
             if d.lastUpdateTime > _too_old:
                 return
+            cls._purged_jids_cache.add(db_file.purebasename)
             if d.status == job.JOB_RUN_PURGED:
-                cls._purged_jids_cache.add(db_file.purebasename)
                 return
             p = sirepo.simulation_db.simulation_run_dir(d)
             pkio.unchecked_remove(p)
-            _update_db(d)
-            cls._purged_jids_cache.add(db_file.purebasename)
-
-        def _update_db(db):
-            n = cls.__db_init_new(db, db)
+            n = cls.__db_init_new(d, d)
             n.status = job.JOB_RUN_PURGED
             cls.__db_write_file(n)
 

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -299,12 +299,17 @@ class _ComputeJob(PKDict):
             if d.lastUpdateTime > _too_old:
                 return
             if d.status == job.JOB_RUN_PURGED:
+                cls._purged_jids_cache.add(db_file.purebasename)
                 return
             p = sirepo.simulation_db.simulation_run_dir(d)
             pkio.unchecked_remove(p)
-            d.status = job.JOB_RUN_PURGED
-            cls.__db_write_file(d)
+            _update_db(d)
             cls._purged_jids_cache.add(db_file.purebasename)
+
+        def _update_db(db):
+            n = cls.__db_init_new(db, db)
+            n.status = job.JOB_RUN_PURGED
+            cls.__db_write_file(n)
 
         if not cfg.purge_non_premium_task_secs:
             return
@@ -378,51 +383,55 @@ class _ComputeJob(PKDict):
         return _DB_DIR.join(computeJid + sirepo.simulation_db.JSON_SUFFIX)
 
     def __db_init(self, req, prev_db=None):
-        c = req.content
-        self.db = PKDict(
+        self.db = self.__db_init_new(req.content, prev_db)
+        return self.db
+
+    @classmethod
+    def __db_init_new(cls, data, prev_db=None):
+        db = PKDict(
             alert=None,
             cancelledAfterSecs=None,
-            computeJid=c.computeJid,
-            computeJobHash=c.computeJobHash,
+            computeJid=data.computeJid,
+            computeJobHash=data.computeJobHash,
             computeJobSerial=0,
             computeJobStart=0,
             computeJobQueued=0,
             driverDetails=PKDict(),
             error=None,
             jobStatusMessage=None,
-            history=self.__db_init_history(prev_db),
-            isParallel=c.isParallel,
-            isPremiumUser=c.get('isPremiumUser'),
+            history=cls.__db_init_history(prev_db),
+            isParallel=data.isParallel,
+            isPremiumUser=data.get('isPremiumUser'),
             lastUpdateTime=0,
             simName=None,
-            simulationId=c.simulationId,
-            simulationType=c.simulationType,
-#TODO(robnagler) when would req come in with status?
-            status=req.get('status', job.MISSING),
-            uid=c.uid,
+            simulationId=data.simulationId,
+            simulationType=data.simulationType,
+            status=job.MISSING,
+            uid=data.uid,
         )
-        r = c.get('jobRunMode')
+        r = data.get('jobRunMode')
         if not r:
-            assert c.api != 'api_runSimulation', \
-                'api_runSimulation must have a jobRunMode content={}'.format(c)
+            assert data.api != 'api_runSimulation', \
+                'api_runSimulation must have a jobRunMode content={}'.format(data)
             # __db_init() will be called when runDirNotFound.
             # The api_* that initiated the request may not have
             # a jobRunMode (ex api_downloadDataFile). In that
             # case use the existing jobRunMode because the
             # request doesn't care about the jobRunMode
-            r = self.db.jobRunMode
+            r = prev_db.jobRunMode
 
-        self.db.pkupdate(
+        db.pkupdate(
             jobRunMode=r,
             nextRequestSeconds=_NEXT_REQUEST_SECONDS[r],
         )
-        if self.db.isParallel:
-            self.db.parallelStatus = PKDict(
+        if db.isParallel:
+            db.parallelStatus = PKDict(
                 ((k, 0) for k in _PARALLEL_STATUS_FIELDS),
             )
-        return self.db
+        return db
 
-    def __db_init_history(self, prev_db):
+    @classmethod
+    def __db_init_history(cls, prev_db):
         if prev_db is None:
             return []
         return prev_db.history + [

--- a/sirepo/srtime.py
+++ b/sirepo/srtime.py
@@ -33,7 +33,6 @@ def adjust_time(days):
         import sirepo.job_api
 
         if sirepo.util.in_flask_app_context():
-            # We are in the supervisor
             sirepo.job_api.adjust_supervisor_srtime(d)
 
     global _timedelta

--- a/sirepo/srunit.py
+++ b/sirepo/srunit.py
@@ -171,7 +171,7 @@ class _TestClient(flask.testing.FlaskClient):
         self.sr_sim_type = None
         self.sr_uid = None
 
-    def sr_animation_run(self, sim_name, compute_model, reports, **kwargs):
+    def sr_animation_run(self, sim_name, compute_model, reports=None, **kwargs):
         from pykern import pkunit
         from pykern.pkcollections import PKDict
         from pykern.pkdebug import pkdp, pkdlog


### PR DESCRIPTION
There are a few fixes:
1. In __db_init we use prev_db to get the jobRunMode.
2. When a run_dir is purged we initiliaze a new supervisor db.
Previously we didn't initialize a new db so the gui thought
there were frames available and requested them resulting in
"Report not generated." Initializing the db solves this by
re-initializing parallelStatus so the frameCount is 0 and no frames
are requested.
3. If a job status is in job_run_purged we need to add it to the
purged_jids_cache. Without this we read the db file for purged jobs
each time purge_free_simulations() runs.