### PR TITLE
Fix #2278. More informative sbatch login and sim frame retrieval afte…

### DIFF
--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -213,9 +213,9 @@ scancel -u $USER >& /dev/null || true
             PKDict(
                 host=self.cfg.host,
                 isModal=True,
-                nonJobExc=True,
+                isGeneral=True,
                 reason=reason,
-                report=msg.computeModel,
+                computeModel=msg.computeModel,
                 simulationId=msg.simulationId,
                 simulationType=msg.simulationType,
             ),

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -211,12 +211,13 @@ scancel -u $USER >& /dev/null || true
         raise util.SRException(
             'sbatchLogin',
             PKDict(
+                host=self.cfg.host,
                 isModal=True,
+                nonJobExc=True,
                 reason=reason,
+                report=msg.computeModel,
                 simulationId=msg.simulationId,
                 simulationType=msg.simulationType,
-                report=msg.computeModel,
-                host=self.cfg.host,
             ),
         )
 

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -713,17 +713,15 @@ class _ComputeJob(PKDict):
                 raise
             # There was a timeout getting the run started. Set the
             # error and let the user know. The timeout has destroyed
-            # the op so don't need to
+            # the op so don't need to destroy here
             _set_error(c, o.internal_error)
             return self._status_reply(req)
         except Exception as e:
             # _run destroys in the happy path (never got to _run here)
             o.destroy(cancel=False)
-            if isinstance(e, sirepo.util.SRException) and\
-               e.sr_args.params.get('nonJobExc'):
-                self.__db_update(
-                    status=s,
-                )
+            if isinstance(e, sirepo.util.SRException) and \
+               e.sr_args.params.get('isGeneral'):
+                self.__db_update(status=s)
             else:
                 _set_error(c, o.internal_error)
             raise

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -451,6 +451,10 @@ class _ComputeJob(PKDict):
                 h.setdefault(k, None)
         return d
 
+    def __db_restore(self, db):
+        self.db = db
+        self.__db_write()
+
     def __db_update(self, **kwargs):
         self.db.pkupdate(**kwargs)
         return self.__db_write()
@@ -673,7 +677,8 @@ class _ComputeJob(PKDict):
         )
         t = int(time.time())
         s = self.db.status
-        self.__db_init(req, prev_db=self.db)
+        d = self.db
+        self.__db_init(req, prev_db=d)
         self.__db_update(
             computeJobQueued=t,
             computeJobSerial=t,
@@ -721,7 +726,7 @@ class _ComputeJob(PKDict):
             o.destroy(cancel=False)
             if isinstance(e, sirepo.util.SRException) and \
                e.sr_args.params.get('isGeneral'):
-                self.__db_update(status=s)
+                self.__db_restore(d)
             else:
                 _set_error(c, o.internal_error)
             raise

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -3094,7 +3094,7 @@ SIREPO.app.directive('sbatchLoginModal', function() {
             });
 
             function handleResponse(data) {
-                if (data.state == 'error') {
+                if (data.state === 'error') {
                     errorResponse = data.error;
                 }
                 authState.sbatchLoginSuccess = data.loginSuccess;
@@ -3124,7 +3124,7 @@ SIREPO.app.directive('sbatchLoginModal', function() {
                         {
                             otp: $scope.otp,
                             password: $scope.password,
-                            report: data.report,
+                            computeModel: data.computeModel,
                             simulationId: data.simulationId,
                             simulationType: data.simulationType,
                             username: $scope.username,
@@ -3156,7 +3156,7 @@ SIREPO.app.directive('sbatchOptions', function(appState) {
                 '<div data-ng-show="showNERSCFields()">',
                     '<div data-model-field="\'sbatchQueue\'" data-model-name="simState.model" data-label-size="3" data-field-size="3"  data-ng-click="sbatchQueueFieldIsDirty = true"></div>',
                 '</div>',
-                '<div class="col-sm-12 text-right {{textInfoOrDanger()}}" data-ng-show="connectionStatusMessage()">{{ connectionStatusMessage() }}</div>',
+                '<div class="col-sm-12 text-right {{textClass()}}" data-ng-show="connectionStatusMessage()">{{ connectionStatusMessage() }}</div>',
             '</div>',
         ].join(''),
         controller: function($scope, authState) {
@@ -3184,8 +3184,9 @@ SIREPO.app.directive('sbatchOptions', function(appState) {
                 if  (authState.sbatchLoginSuccess === undefined) {
                     return null;
                 }
-                return authState.jobRunModeMap[appState.models[$scope.simState.model].jobRunMode]
-                    + (authState.sbatchLoginSuccess ? '' : ' no') + ' connection established';
+                var s = 'conntected to ' + authState.jobRunModeMap[appState.models[$scope.simState.model].jobRunMode];
+                s = (authState.sbatchLoginSuccess ? '' : 'not ') + s;
+                return s.charAt(0).toUpperCase() + s.slice(1);
             };
 
             $scope.showNERSCFields = function() {
@@ -3199,8 +3200,8 @@ SIREPO.app.directive('sbatchOptions', function(appState) {
                 return m && m.jobRunMode === 'sbatch';
             };
 
-            $scope.textInfoOrDanger = function () {
-                return authState.sbatchLoginSuccess? 'text-info': 'text-danger';
+            $scope.textClass = function () {
+                return authState.sbatchLoginSuccess? 'text-info' : 'text-danger';
             };
         }
     };

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -3080,7 +3080,7 @@ SIREPO.app.directive('sbatchLoginModal', function() {
                 if (errorResponse) {
                     r = {'state': 'error', 'error': errorResponse};
                 }
-                sbatchLoginStatusService.loginSuccess()
+                sbatchLoginStatusService.loginSuccess();
                 onHidden(r);
                 onHidden = null;
                 errorResponse = null;

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -2295,6 +2295,12 @@ SIREPO.app.factory('persistentSimulation', function(simulationQueue, appState, a
             return ! state.isProcessing();
         };
 
+        state.resetSimulation = function() {
+            setSimulationStatus({state: 'missing'});
+            frameCache.setFrameCount(0);
+            appState.whenModelsLoaded($scope, runStatus);
+        };
+
         state.runSimulation = function() {
             if (state.isStateRunning()) {
                 return;
@@ -2336,11 +2342,11 @@ SIREPO.app.factory('persistentSimulation', function(simulationQueue, appState, a
             return appState.ucfirst(simulationStatus().state);
         };
 
-        setSimulationStatus({state: 'missing'});
-        frameCache.setFrameCount(0);
+        state.resetSimulation();
         $scope.$on('$destroy', clearSimulation);
-        appState.whenModelsLoaded($scope, runStatus);
-
+        $scope.$on('sbatchLoginSuccess', function() {
+            state.resetSimulation();
+        });
         return state;
     };
     return self;

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -1826,6 +1826,7 @@ SIREPO.app.directive('propagationParametersTable', function(appState) {
     };
 });
 
+
 SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService, frameCache, panelState, persistentSimulation, srwService) {
     return {
         restrict: 'A',
@@ -1872,7 +1873,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
             //TODO(pjm): share with simStatusPanel directive in sirepo-components.js
                 '<div data-ng-if="simState.showJobSettings()">',
                   '<div class="form-group form-group-sm">',
-                    '<div data-model-field="\'jobRunMode\'" data-model-name="simState.model" data-label-size="6" data-field-size="6"></div>',
+                    '<div class="col-sm-14" data-model-field="\'jobRunMode\'" data-model-name="simState.model" data-label-size="6" data-field-size="6"></div>',
                     '<div data-sbatch-options="simState"></div>',
                   '</div>',
                 '</div>',
@@ -1886,7 +1887,6 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
             var clientFields = ['colorMap', 'aspectRatio', 'plotScale'];
             var serverFields = ['intensityPlotsWidth', 'rotateAngle', 'rotateReshape'];
             var oldModel = null;
-            $scope.frameCount = 0;
 
             function copyModel() {
                 oldModel = appState.cloneModel($scope.model);
@@ -1903,8 +1903,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
                 if (data.method && data.method != appState.models.fluxAnimation.method) {
                     // the output file on the server was generated with a different flux method
                     $scope.simState.timeData = {};
-                    $scope.frameCount = 0;
-                    frameCache.setFrameCount($scope.frameCount);
+                    frameCache.setFrameCount(0);
                     return;
                 }
                 if (data.percentComplete) {
@@ -1912,11 +1911,10 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
                     $scope.particleCount = data.particleCount;
                 }
                 if (data.frameCount) {
-                    if (data.frameCount != $scope.frameCount) {
-                        $scope.frameCount = data.frameCount;
-                        $scope.frameIndex = data.frameIndex;
-                        frameCache.setFrameCount($scope.frameCount);
-                        frameCache.setCurrentFrame($scope.model, $scope.frameIndex);
+
+                    if (data.frameCount != frameCache.getFrameCount($scope.model)) {
+                        frameCache.setFrameCount(data.frameCount);
+                        frameCache.setCurrentFrame($scope.model, data.frameIndex);
                     }
                     srwService.setShowCalcCoherence(data.calcCoherence);
                 }
@@ -1967,8 +1965,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
                 $scope.$on($scope.model + '.changed', function() {
                     if ($scope.simState.isReadyForModelChanges && hasReportParameterChanged()) {
                         $scope.cancelPersistentSimulation();
-                        $scope.frameCount = 0;
-                        frameCache.setFrameCount($scope.frameCount);
+                        frameCache.setFrameCount(0);
                         $scope.percentComplete = 0;
                         $scope.particleNumber = 0;
                     }
@@ -1984,7 +1981,6 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
        },
     };
 });
-
 //TODO(pjm): move this to sirepo-components and share with warpvnd
 SIREPO.app.service('vtkToPNG', function(plotToPNG, utilities) {
     this.pngCanvas = function(reportId, vtkRenderer, panel) {

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -1826,7 +1826,6 @@ SIREPO.app.directive('propagationParametersTable', function(appState) {
     };
 });
 
-
 SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService, frameCache, panelState, persistentSimulation, srwService) {
     return {
         restrict: 'A',
@@ -1981,6 +1980,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
        },
     };
 });
+
 //TODO(pjm): move this to sirepo-components and share with warpvnd
 SIREPO.app.service('vtkToPNG', function(plotToPNG, utilities) {
     this.pngCanvas = function(reportId, vtkRenderer, panel) {


### PR DESCRIPTION
…r entering creds.

This fixes 2 issues:
1. Improved sbatch login. There is no more "Error: Please try agin."
It is just the status of the job (ex missing) and there is now alert
text saying "NERSC connection established" or "NERSC no connection"
established after a user enters their credentials.
2. If sim frames are requested and the user doesn't have a NERSC agent
started they will be prompted for the credentials. Upon successfully
entering their credentials the sim frames will be retrieved without
further interaction.

![Screen Shot 2020-05-18 at 3 28 28 PM](https://user-images.githubusercontent.com/10264515/82261498-5573ae00-991c-11ea-8c7f-263837336c85.png)

The `issue/2278-sbatch-login-ui` is based on `issue/2500-select-nersc-queue`. Please review and merge `issue/2500-select-nersc-queue` first.
