### PR TITLE
Fix #2501. Allow NERSC project/repo selection.

### DIFF
--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -283,7 +283,7 @@ def _validate_and_add_sbatch_fields(request_content, compute_model):
         assert m.sbatchQueue in sirepo.job.NERSC_QUEUES, \
             f'sbatchQueue={m.sbatchQueue} not in NERSC_QUEUES={sirepo.job.NERSC_QUEUES}'
         c.sbatchQueue = m.sbatchQueue
-        c.sbatchRepo = m.sbatchRepo
+        c.sbatchProject = m.sbatchProject
     for f in 'sbatchCores', 'sbatchHours':
         assert m[f] > 0, f'{f}={m[f]} must be greater than 0'
         c[f] = m[f]

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -283,6 +283,7 @@ def _validate_and_add_sbatch_fields(request_content, compute_model):
         assert m.sbatchQueue in sirepo.job.NERSC_QUEUES, \
             f'sbatchQueue={m.sbatchQueue} not in NERSC_QUEUES={sirepo.job.NERSC_QUEUES}'
         c.sbatchQueue = m.sbatchQueue
+        c.sbatchRepo = m.sbatchRepo
     for f in 'sbatchCores', 'sbatchHours':
         assert m[f] > 0, f'{f}={m[f]} must be greater than 0'
         c[f] = m[f]

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -3153,7 +3153,7 @@ SIREPO.app.directive('sbatchOptions', function(appState) {
                 '<div data-model-field="\'sbatchCores\'" data-model-name="simState.model" data-label-size="3" data-field-size="3"></div>',
                 '<div data-ng-show="showNERSCFields()">',
                     '<div data-model-field="\'sbatchQueue\'" data-model-name="simState.model" data-label-size="3" data-field-size="3"  data-ng-click="sbatchQueueFieldIsDirty = true"></div>',
-                    '<div data-model-field="\'sbatchRepo\'" data-model-name="simState.model" data-label-size="3" data-field-size="3"></div>',
+                    '<div data-model-field="\'sbatchProject\'" data-model-name="simState.model" data-label-size="3" data-field-size="3"></div>',
                 '</div>',
                 '<div class="col-sm-12 text-right {{textClass()}}" data-ng-show="connectionStatusMessage()">{{ connectionStatusMessage() }}</div>',
             '</div>',

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -3153,6 +3153,7 @@ SIREPO.app.directive('sbatchOptions', function(appState) {
                 '<div data-model-field="\'sbatchCores\'" data-model-name="simState.model" data-label-size="3" data-field-size="3"></div>',
                 '<div data-ng-show="showNERSCFields()">',
                     '<div data-model-field="\'sbatchQueue\'" data-model-name="simState.model" data-label-size="3" data-field-size="3"  data-ng-click="sbatchQueueFieldIsDirty = true"></div>',
+                    '<div data-model-field="\'sbatchRepo\'" data-model-name="simState.model" data-label-size="3" data-field-size="3"></div>',
                 '</div>',
                 '<div class="col-sm-12 text-right {{textClass()}}" data-ng-show="connectionStatusMessage()">{{ connectionStatusMessage() }}</div>',
             '</div>',

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -162,7 +162,8 @@
             "result": ["Result", "String", ""],
             "sbatchCores": ["Cores", "Integer", 1],
             "sbatchHours": ["Hours", "Float", 0.4],
-            "sbatchQueue": ["Queue", "NERSCQueue", "debug"]
+            "sbatchQueue": ["Queue", "NERSCQueue", "debug"],
+            "sbatchRepo": ["Repository", "OptionalString", ""]
         }
     },
     "view": {

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -163,7 +163,7 @@
             "sbatchCores": ["Cores", "Integer", 1],
             "sbatchHours": ["Hours", "Float", 0.4],
             "sbatchQueue": ["Queue", "NERSCQueue", "debug"],
-            "sbatchRepo": ["Repository", "OptionalString", ""]
+            "sbatchProject": ["Project", "OptionalString", ""]
         }
     },
     "view": {

--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -666,6 +666,7 @@
             "sbatchCores": ["Cores", "Integer", 128],
             "sbatchHours": ["Hours", "Float", 0.4],
             "sbatchQueue": ["Queue", "NERSCQueue", "debug"],
+            "sbatchRepo": ["Repository", "OptionalString", ""],
             "stokesParameter": ["Representation of Stokes Parameters", "StokesParameter", "0"],
             "numberOfMacroElectrons": ["Number of Macro-Electrons", "Integer", 1000, "Number of macro-electrons (coherent wavefronts) for calculation of multi-electron wavefront propagation"],
             "integrationMethod": ["Multi-electron Integration Approximation Method", "MultiElectronIntegrationMethod", "0"],

--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -666,7 +666,7 @@
             "sbatchCores": ["Cores", "Integer", 128],
             "sbatchHours": ["Hours", "Float", 0.4],
             "sbatchQueue": ["Queue", "NERSCQueue", "debug"],
-            "sbatchRepo": ["Repository", "OptionalString", ""],
+            "sbatchProject": ["Project", "OptionalString", ""],
             "stokesParameter": ["Representation of Stokes Parameters", "StokesParameter", "0"],
             "numberOfMacroElectrons": ["Number of Macro-Electrons", "Integer", 1000, "Number of macro-electrons (coherent wavefronts) for calculation of multi-electron wavefront propagation"],
             "integrationMethod": ["Multi-electron Integration Approximation Method", "MultiElectronIntegrationMethod", "0"],

--- a/sirepo/package_data/static/json/warppba-schema.json
+++ b/sirepo/package_data/static/json/warppba-schema.json
@@ -163,7 +163,7 @@
             "sbatchCores": ["Cores", "Integer", 4],
             "sbatchHours": ["Hours", "Float", 0.4],
             "sbatchQueue": ["Queue", "NERSCQueue", "debug"],
-            "sbatchRepo": ["Repository", "OptionalString", ""]
+            "sbatchProject": ["Project", "OptionalString", ""]
         },
         "beamAnimation": {
             "x": ["X Value", "XValue", "z"],

--- a/sirepo/package_data/static/json/warppba-schema.json
+++ b/sirepo/package_data/static/json/warppba-schema.json
@@ -162,7 +162,8 @@
             "jobRunMode": ["Execution Mode", "JobRunMode", "parallel"],
             "sbatchCores": ["Cores", "Integer", 4],
             "sbatchHours": ["Hours", "Float", 0.4],
-            "sbatchQueue": ["Queue", "NERSCQueue", "debug"]
+            "sbatchQueue": ["Queue", "NERSCQueue", "debug"],
+            "sbatchRepo": ["Repository", "OptionalString", ""]
         },
         "beamAnimation": {
             "x": ["X Value", "XValue", "z"],


### PR DESCRIPTION
Users can now enter a NERSC repo and it will be used for running
the job. The field is optional. If no repo is supplied then one
won't be supplied to sbatch and the default repo for the user
will be used.

I'd like to test this before merging. Cori is down right now but when it is back up and we sort out networking issues with the VM on our server I will.