### PR TITLE
Fix #2527. Better error when NERSC is down.

### DIFF
--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -3095,7 +3095,7 @@ SIREPO.app.directive('sbatchLoginModal', function() {
                 if (data.state === 'error') {
                     errorResponse = data.error;
                 }
-                sbatchLoginStatusService.loggedIn = data.loginSuccess;
+                sbatchLoginStatusService.loggedIn = data.loginSuccess ? true: false;
                 el.modal('hide');
             }
 
@@ -3126,7 +3126,8 @@ SIREPO.app.directive('sbatchLoginModal', function() {
                             simulationId: data.simulationId,
                             simulationType: data.simulationType,
                             username: $scope.username,
-                        }
+                        },
+                        handleResponse
                     );
                 };
                 el.modal('show');


### PR DESCRIPTION
When NERSC is down for maintenance a ProtocolError is raised.
We now catch it and let the user know that we were unable to
connect. In addition, the modal now disappears when there is an
error so the user can see the alert text.