### PR TITLE
Fix radiasoft/ops#509. runSimulation can result in an error.

### DIFF
--- a/sirepo/status.py
+++ b/sirepo/status.py
@@ -69,10 +69,8 @@ def _run_tests():
     d.report = _SIM_REPORT
     r = None
     try:
-        uri_router.call_api('runSimulation', data=d)
+        resp = uri_router.call_api('runSimulation', data=d)
         for _ in range(_MAX_CALLS):
-            time.sleep(_SLEEP)
-            resp = uri_router.call_api('runStatus', data=d)
             r = simulation_db.json_load(resp.data)
             if r.state == 'error':
                 raise RuntimeError('simulation error: resp={}'.format(r))
@@ -83,6 +81,8 @@ def _run_tests():
                         raise RuntimeError('received bad report output: resp={}', r)
                 return
             d = r.nextRequest
+            resp = uri_router.call_api('runStatus', data=d)
+            time.sleep(_SLEEP)
         raise RuntimeError(
             'simulation timed out: seconds={} resp='.format(_MAX_CALLS * _SLEEP, r),
         )


### PR DESCRIPTION
This just give a better error message when runSimulation results in an error.