### PR TITLE
Fix #2537 protect zip extract in mpi4py

### DIFF
--- a/sirepo/package_data/template/srw/parameters.py.jinja
+++ b/sirepo/package_data/template/srw/parameters.py.jinja
@@ -260,7 +260,7 @@ def setup_magnetic_measurement_files(filename, v):
     f = None
     r = 0
     try:
-        import mpi4py
+        import mpi4py.MPI
         if mpi4py.MPI.COMM_WORLD.Get_size() > 1:
             c = mpi4py.MPI.COMM_WORLD
             r = c.Get_rank()

--- a/sirepo/package_data/template/srw/parameters.py.jinja
+++ b/sirepo/package_data/template/srw/parameters.py.jinja
@@ -256,16 +256,38 @@ varParam = srwl_bl.srwl_uti_ext_options([
 {% if setupMagneticMeasurementFiles %}
 def setup_magnetic_measurement_files(filename, v):
     import os
-    import re
-    import zipfile
-    z = zipfile.ZipFile(filename)
-    z.extractall()
-    for f in z.namelist():
-        if re.search(r'\.txt', f):
-            v.und_mfs = os.path.basename(f)
-            v.und_mdir = os.path.dirname(f) or './'
-            return
-    raise RuntimeError('missing magnetic measurement index *.txt file')
+    c = None
+    f = None
+    r = 0
+    try:
+        import mpi4py
+        if mpi4py.MPI.COMM_WORLD.Get_size() > 1:
+            c = mpi4py.MPI.COMM_WORLD
+            r = c.Get_rank()
+    except Exception:
+        pass
+    if r == 0:
+        try:
+            import zipfile
+            z = zipfile.ZipFile(filename)
+            f = [x for x in z.namelist() if x.endswith('.txt')]
+            if len(f) != 1:
+                raise RuntimeError(
+                    '{} magnetic measurement index (*.txt) file={}'.format(
+                        'too many' if len(f) > 0 else 'missing',
+                        filename,
+                    )
+                )
+            f = f[0]
+            z.extractall()
+        except Exception:
+            if c:
+                c.Abort(1)
+            raise
+    if c:
+        f = c.bcast(f, root=0)
+    v.und_mfs = os.path.basename(f)
+    v.und_mdir = os.path.dirname(f) or './'
 {% endif %}
 
 def main():


### PR DESCRIPTION
Abort mpi if extract fails
communicate zip file via bcast
If too many files, also raise exception