### PR TITLE
Fix #2592 auth_db init at module level

### DIFF
--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -143,7 +143,6 @@ def init_apis(*args, **kwargs):
         'Do not set $SIREPO_AUTH_LOGGED_IN_USER in server'
     uri_router = importlib.import_module('sirepo.uri_router')
     simulation_db = importlib.import_module('sirepo.simulation_db')
-    auth_db.init()
     p = pkinspect.this_module().__name__
     visible_methods = []
     valid_methods = cfg.methods.union(cfg.deprecated_methods)

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -17,7 +17,6 @@ import pykern.pkio
 import re
 import requests
 import sirepo.auth
-import sirepo.auth_db
 import sirepo.http_reply
 import sirepo.http_request
 import sirepo.job

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -160,7 +160,6 @@ def init():
         job.SBATCH: cfg.sbatch_poll_secs,
         job.SEQUENTIAL: 1,
     })
-    sirepo.auth_db.init(migrate_db_file=False)
     if sirepo.simulation_db.user_path().exists():
         if not _DB_DIR.exists():
             pkdlog('calling upgrade_runner_to_job_db path={}', _DB_DIR)


### PR DESCRIPTION
Removed direct calls to auth_db.init
made init() private and call
reduced race condition time in _migrate_db_file()
We can mitigate race condition by starting sirepo
without starting job_supervisor. This would be normal
for older installations.