### PR TITLE
Fix #2606. Control when auth_db is initialized.

### DIFF
--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -143,6 +143,7 @@ def init_apis(*args, **kwargs):
         'Do not set $SIREPO_AUTH_LOGGED_IN_USER in server'
     uri_router = importlib.import_module('sirepo.uri_router')
     simulation_db = importlib.import_module('sirepo.simulation_db')
+    auth_db.init()
     p = pkinspect.this_module().__name__
     visible_methods = []
     valid_methods = cfg.methods.union(cfg.deprecated_methods)

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -78,17 +78,7 @@ def audit_proprietary_lib_files(uid):
                 pass
 
 
-def init_model(callback):
-    with thread_lock:
-        callback(UserDbBase)
-        UserDbBase.metadata.create_all(_engine)
-
-
-def _db_filename():
-    return sirepo.srdb.root().join(_SQLITE3_BASENAME)
-
-
-def _init():
+def init():
     global _session, _engine, UserDbBase, UserRegistration, UserRole
     assert not _session
 
@@ -195,13 +185,17 @@ def _init():
                     cls.role.in_(sirepo.auth.PAID_USER_ROLES),
                 ).distinct().all()
             ]
+    UserDbBase.metadata.create_all(_engine)
 
-    #TODO(pjm): work-around for #2585
-    try:
-        # only creates tables that don't already exist
+
+def init_model(callback):
+    with thread_lock:
+        callback(UserDbBase)
         UserDbBase.metadata.create_all(_engine)
-    except sqlalchemy.exc.OperationalError:
-        pass
+
+
+def _db_filename():
+    return sirepo.srdb.root().join(_SQLITE3_BASENAME)
 
 
 def _migrate_db_file(fn):
@@ -255,6 +249,3 @@ def _migrate_db_file(fn):
         raise
     x.rename(o + '-migrated')
     pkdlog('migrated user.db to auth.db')
-
-
-_init()

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -160,6 +160,7 @@ def init():
         job.SBATCH: cfg.sbatch_poll_secs,
         job.SEQUENTIAL: 1,
     })
+    sirepo.auth_db.init()
     if sirepo.simulation_db.user_path().exists():
         if not _DB_DIR.exists():
             pkdlog('calling upgrade_runner_to_job_db path={}', _DB_DIR)


### PR DESCRIPTION
This partially reverts pulls/2594. In that pull we moved
auth_db.init() to the module level and the auth_db was initialized on
import. This caused agents to init the db which they don't have access
to. This reverts part of that pull so auth_db.init() is called by
those who need it initialized.