### PR TITLE
Issue/2598 radia encapsulation

### DIFF
--- a/sirepo/package_data/static/html/radia-visualization.html
+++ b/sirepo/package_data/static/html/radia-visualization.html
@@ -1,7 +1,7 @@
 <div class="container-fluid">
   <div class="row">
       <div class="sr-plot">
-        <div data-radia-viewer="" data-model-name="magnetDisplay"></div>
+        <div data-radia-viewer="" data-model-name="magnetDisplay" data-viz="viz"></div>
       </div>
       <div data-radia-field-paths="" data-model-name="fieldPaths"></div>
       <div data-field-integral-table="" data-model-name="fieldPaths"></div>

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -158,6 +158,9 @@
             "density": ["Density", "Float", 1.0],
             "name": ["Name", "String", ""]
         },
+        "radiaReq": {
+
+        },
         "reset": {
         },
         "simulation": {

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -116,6 +116,7 @@
         "geometry": {
             "alpha": ["Alpha", "Range", 1.0, "", 0.0, 1.0],
             "beamAxis": ["Beam Axis", "BeamAxis", "z", "The beam will travel along this axis, used when exporting fields"],
+            "radiaId": ["_", "Integer", -1],
             "name": ["Name", "String", ""]
         },
         "geomObject": {
@@ -123,6 +124,7 @@
             "id": ["_", "String", ""],
             "material": ["Material", "String", ""],
             "name": ["Name", "String", ""],
+            "radiaId": ["_", "Integer", -1],
             "type": ["Type", "String", ""]
         },
         "linePath": {

--- a/sirepo/package_data/template/radia/geom.py.jinja
+++ b/sirepo/package_data/template/radia/geom.py.jinja
@@ -16,27 +16,24 @@ g_id = -1
 
 
 # always store the object
-g_data = radia_tk.geom_to_data(g_id, name='{{ geomName }}')
-with h5py.File('{{ dataFile }}', 'a') as hf:
-    template_common.dict_to_h5(g_data, hf, path='{{ h5ObjPath }}')
+g_obj_data = radia_tk.geom_to_data(g_id, name='{{ geomName }}')
+g_obj_h5_path = '{{ h5ObjPath }}'
 
+g_solution_data = None
+g_solution_h5_path = 'solution'
 {% if doSolve %}
-res = radia_tk.solve(g_id, {{ solvePrec }}, {{ solveMaxIter }}, {{ solveMethod }})
-with h5py.File('{{ dataFile }}', 'a') as hf:
-    template_common.dict_to_h5(res, hf, path='solution')
+g_solution = radia_tk.solve(g_id, {{ solvePrec }}, {{ solveMaxIter }}, {{ solveMethod }})
 {% endif %}
 
+g_field_data = None
+g_field_h5_path = '{{ h5FieldPath }}'
 if '{{ viewType }}' == VIEW_TYPE_FIELD:
     f_type = '{{ fieldType }}'
     if f_type == radia_tk.FIELD_TYPE_MAG_M:
         f = radia_tk.get_magnetization(g_id)
     elif f_type in radia_tk.POINT_FIELD_TYPES:
         f = radia_tk.get_field(g_id, f_type, {{ fieldPoints }})
-    g_data = radia_tk.vector_field_to_data(g_id, '{{ geomName }}', f, radia_tk.FIELD_UNITS[f_type])
-
-    with h5py.File('{{ dataFile }}', 'a') as hf:
-        template_common.dict_to_h5(g_data, hf, path='{{ h5FieldPath }}')
+    g_field_data = radia_tk.vector_field_to_data(g_id, '{{ geomName }}', f, radia_tk.FIELD_UNITS[f_type])
 
 
-with open('{{ dmpFile }}', 'wb') as f:
-    f.write(radia_tk.dump_bin(g_id))
+

--- a/sirepo/package_data/template/radia/geom.py.jinja
+++ b/sirepo/package_data/template/radia/geom.py.jinja
@@ -22,11 +22,15 @@ g_id = {{ gId }}
 # always store the object
 g_obj_data = radia_tk.geom_to_data(g_id, name='{{ geomName }}')
 g_obj_h5_path = '{{ h5ObjPath }}'
+with h5py.File('{{ dataFile }}', 'a') as hf:
+    template_common.dict_to_h5(g_obj_data, hf, path='{{ h5ObjPath }}')
 
 g_solution_data = None
 g_solution_h5_path = 'solution'
 {% if doSolve %}
 g_solution_data = radia_tk.solve(g_id, {{ solvePrec }}, {{ solveMaxIter }}, {{ solveMethod }})
+with h5py.File('{{ dataFile }}', 'a') as hf:
+    template_common.dict_to_h5(g_solution_data, hf, path='solution')
 {% endif %}
 
 g_field_data = None
@@ -39,5 +43,8 @@ if '{{ viewType }}' == VIEW_TYPE_FIELD:
         f = radia_tk.get_field(g_id, f_type, {{ fieldPoints }})
     g_field_data = radia_tk.vector_field_to_data(g_id, '{{ geomName }}', f, radia_tk.FIELD_UNITS[f_type])
 
+    with h5py.File('{{ dataFile }}', 'a') as hf:
+        template_common.dict_to_h5(g_field_data, hf, path='{{ h5FieldPath }}')
 
-
+with open('{{ dmpFile }}', 'wb') as f:
+    f.write(radia_tk.dump_bin(g_id))

--- a/sirepo/package_data/template/radia/geom.py.jinja
+++ b/sirepo/package_data/template/radia/geom.py.jinja
@@ -9,7 +9,6 @@ from sirepo.template import template_common
 VIEW_TYPE_OBJ = 'objects'
 VIEW_TYPE_FIELD = 'fields'
 
-pkdp('START GEOM.PY.JINJA')
 {% if gId == -1 %}
 {% if isExample %}
 g_id = radia_examples.build('{{ geomName }}')
@@ -28,7 +27,6 @@ g_solution_data = None
 g_solution_h5_path = 'solution'
 {% if doSolve %}
 g_solution_data = radia_tk.solve(g_id, {{ solvePrec }}, {{ solveMaxIter }}, {{ solveMethod }})
-pkdp('SOL {}', g_solution_data)
 {% endif %}
 
 g_field_data = None

--- a/sirepo/package_data/template/radia/geom.py.jinja
+++ b/sirepo/package_data/template/radia/geom.py.jinja
@@ -27,7 +27,8 @@ g_obj_h5_path = '{{ h5ObjPath }}'
 g_solution_data = None
 g_solution_h5_path = 'solution'
 {% if doSolve %}
-g_solution = radia_tk.solve(g_id, {{ solvePrec }}, {{ solveMaxIter }}, {{ solveMethod }})
+g_solution_data = radia_tk.solve(g_id, {{ solvePrec }}, {{ solveMaxIter }}, {{ solveMethod }})
+pkdp('SOL {}', g_solution_data)
 {% endif %}
 
 g_field_data = None

--- a/sirepo/package_data/template/radia/geom.py.jinja
+++ b/sirepo/package_data/template/radia/geom.py.jinja
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import h5py
+from pykern.pkdebug import pkdc, pkdp
 from sirepo.template import radia_tk
 from sirepo.template import radia_examples
 from sirepo.template import template_common
@@ -8,12 +9,16 @@ from sirepo.template import template_common
 VIEW_TYPE_OBJ = 'objects'
 VIEW_TYPE_FIELD = 'fields'
 
+pkdp('START GEOM.PY.JINJA')
+{% if gId == -1 %}
 {% if isExample %}
 g_id = radia_examples.build('{{ geomName }}')
 {% else %}
 g_id = -1
 {% endif %}
-
+{% else %}
+g_id = {{ gId }}
+{% endif %}
 
 # always store the object
 g_obj_data = radia_tk.geom_to_data(g_id, name='{{ geomName }}')

--- a/sirepo/pkcli/radia.py
+++ b/sirepo/pkcli/radia.py
@@ -21,14 +21,6 @@ _GEOM_FILE = 'geom.h5'
 
 def run(cfg_dir):
     r = template_common.exec_parameters()
-    with open(_DMP_FILE, 'wb') as f:
-        f.write(sirepo.template.radia_tk.dump_bin(r.g_id))
-    template.append_h5(r.g_obj_data, r.g_obj_h5_path, _GEOM_FILE)
-    if r.g_solution_data:
-        template.append_h5(r.g_solution_data, r.g_solution_h5_path, _GEOM_FILE)
-    if r.g_field_data:
-        template.append_h5(r.g_field_data, r.g_field_h5_path, _GEOM_FILE)
-
     data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
     template.extract_report_data(py.path.local(cfg_dir), data)
 

--- a/sirepo/pkcli/radia.py
+++ b/sirepo/pkcli/radia.py
@@ -33,9 +33,9 @@ def run(cfg_dir):
 
     data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
     # save the run_dir so we can refer to it later
-    if 'radiaReq' not in data.models.geometry:
-        data.models.geometry.radiaReq = PKDict()
-    data.models.geometry.radiaReq.runDir = py.path.local(cfg_dir)
+    #if 'radiaReq' not in data.models.geometry:
+    #    data.models.geometry.radiaReq = PKDict()
+    #data.models.geometry.radiaReq.runDir = py.path.local(cfg_dir)
     template.extract_report_data(py.path.local(cfg_dir), data)
 
 

--- a/sirepo/pkcli/radia.py
+++ b/sirepo/pkcli/radia.py
@@ -20,7 +20,9 @@ _GEOM_FILE = 'geom.h5'
 
 
 def run(cfg_dir):
+    pkdp('RUN IN {}', cfg_dir)
     r = template_common.exec_parameters()
+    pkdp('DONE RUNNING, GID {}', r.g_id)
     with open(_DMP_FILE, 'wb') as f:
         f.write(sirepo.template.radia_tk.dump_bin(r.g_id))
     template.append_h5(r.g_obj_data, r.g_obj_h5_path, _GEOM_FILE)
@@ -30,6 +32,10 @@ def run(cfg_dir):
         template.append_h5(r.g_field_data, r.g_field_h5_path, _GEOM_FILE)
 
     data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
+    # save the run_dir so we can refer to it later
+    if 'radiaReq' not in data.models.geometry:
+        data.models.geometry.radiaReq = PKDict()
+    data.models.geometry.radiaReq.runDir = py.path.local(cfg_dir)
     template.extract_report_data(py.path.local(cfg_dir), data)
 
 

--- a/sirepo/pkcli/radia.py
+++ b/sirepo/pkcli/radia.py
@@ -13,10 +13,22 @@ from sirepo import simulation_db
 from sirepo.template import template_common
 import py.path
 import sirepo.template.radia as template
+import sirepo.template.radia_tk
+
+_DMP_FILE = 'geom.dat'
+_GEOM_FILE = 'geom.h5'
 
 
 def run(cfg_dir):
-    template_common.exec_parameters()
+    r = template_common.exec_parameters()
+    with open(_DMP_FILE, 'wb') as f:
+        f.write(sirepo.template.radia_tk.dump_bin(r.g_id))
+    template.append_h5(r.g_obj_data, r.g_obj_h5_path, _GEOM_FILE)
+    if r.g_solution_data:
+        template.append_h5(r.g_solution, r.g_solution_h5_path, _GEOM_FILE)
+    if r.g_field_data:
+        template.append_h5(r.g_field_data, r.g_field_h5_path, _GEOM_FILE)
+
     data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
     template.extract_report_data(py.path.local(cfg_dir), data)
 

--- a/sirepo/pkcli/radia.py
+++ b/sirepo/pkcli/radia.py
@@ -20,9 +20,7 @@ _GEOM_FILE = 'geom.h5'
 
 
 def run(cfg_dir):
-    pkdp('RUN IN {}', cfg_dir)
     r = template_common.exec_parameters()
-    pkdp('DONE RUNNING, GID {}', r.g_id)
     with open(_DMP_FILE, 'wb') as f:
         f.write(sirepo.template.radia_tk.dump_bin(r.g_id))
     template.append_h5(r.g_obj_data, r.g_obj_h5_path, _GEOM_FILE)

--- a/sirepo/pkcli/radia.py
+++ b/sirepo/pkcli/radia.py
@@ -27,15 +27,11 @@ def run(cfg_dir):
         f.write(sirepo.template.radia_tk.dump_bin(r.g_id))
     template.append_h5(r.g_obj_data, r.g_obj_h5_path, _GEOM_FILE)
     if r.g_solution_data:
-        template.append_h5(r.g_solution, r.g_solution_h5_path, _GEOM_FILE)
+        template.append_h5(r.g_solution_data, r.g_solution_h5_path, _GEOM_FILE)
     if r.g_field_data:
         template.append_h5(r.g_field_data, r.g_field_h5_path, _GEOM_FILE)
 
     data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
-    # save the run_dir so we can refer to it later
-    #if 'radiaReq' not in data.models.geometry:
-    #    data.models.geometry.radiaReq = PKDict()
-    #data.models.geometry.radiaReq.runDir = py.path.local(cfg_dir)
     template.extract_report_data(py.path.local(cfg_dir), data)
 
 

--- a/sirepo/sim_data/radia.py
+++ b/sirepo/sim_data/radia.py
@@ -13,6 +13,17 @@ class SimData(sirepo.sim_data.SimDataBase):
     ANALYSIS_ONLY_FIELDS = frozenset(('colorMap', 'name', 'notes', 'scaling'))
 
     @classmethod
+    def fixup_old_data(cls, data):
+        cls._init_models(data.models)
+        cls._organize_example(data)
+
+    @classmethod
+    def is_parallel(cls, data_or_model):
+        if data_or_model in ('solver',):
+            return True
+        return super(SimData, cls).is_parallel(data_or_model)
+
+    @classmethod
     def _compute_job_fields(cls, data, r, compute_model):
         #res = cls._non_analysis_fields(data, r) + []
         res = []
@@ -24,12 +35,6 @@ class SimData(sirepo.sim_data.SimDataBase):
         if analysis_model in ('geometry', 'reset', 'solver',):
             return 'geometry'
         return super(SimData, cls)._compute_model(analysis_model, *args, **kwargs)
-
-    @classmethod
-    def fixup_old_data(cls, data):
-        cls._init_models(data.models)
-        cls._organize_example(data)
-
 
     @classmethod
     def _lib_file_basenames(cls, data):

--- a/sirepo/sim_data/radia.py
+++ b/sirepo/sim_data/radia.py
@@ -11,7 +11,6 @@ import sirepo.sim_data
 
 class SimData(sirepo.sim_data.SimDataBase):
     ANALYSIS_ONLY_FIELDS = frozenset(('colorMap', 'name', 'notes', 'scaling'))
-    GEOM_FILE = 'geom.h5'
 
     @classmethod
     def _compute_job_fields(cls, data, r, compute_model):
@@ -21,10 +20,13 @@ class SimData(sirepo.sim_data.SimDataBase):
     @classmethod
     def _compute_model(cls, analysis_model, *args, **kwargs):
         #pkdp('_compute_model {}', analysis_model)
-        if analysis_model in (
-            'solver',
-        ):
-            return 'animation'
+        # put everything in geometry?
+        if analysis_model in ('solver',):
+            #pkdp('analysis_model {} -> geometry', analysis_model)
+            return 'geometry'
+        if analysis_model in ('geometry', 'reset',):
+            #pkdp('analysis_model {} -> geometry', analysis_model)
+            return 'geometry'
         return super(SimData, cls)._compute_model(analysis_model, *args, **kwargs)
 
     @classmethod

--- a/sirepo/sim_data/radia.py
+++ b/sirepo/sim_data/radia.py
@@ -14,18 +14,14 @@ class SimData(sirepo.sim_data.SimDataBase):
 
     @classmethod
     def _compute_job_fields(cls, data, r, compute_model):
-        res = cls._non_analysis_fields(data, r) + []
+        #res = cls._non_analysis_fields(data, r) + []
+        res = []
         return res
 
     @classmethod
     def _compute_model(cls, analysis_model, *args, **kwargs):
-        #pkdp('_compute_model {}', analysis_model)
-        # put everything in geometry?
-        if analysis_model in ('solver',):
-            #pkdp('analysis_model {} -> geometry', analysis_model)
-            return 'geometry'
-        if analysis_model in ('geometry', 'reset',):
-            #pkdp('analysis_model {} -> geometry', analysis_model)
+        # funnel everything into geometry so they all use the same run_dir
+        if analysis_model in ('geometry', 'reset', 'solver',):
             return 'geometry'
         return super(SimData, cls)._compute_model(analysis_model, *args, **kwargs)
 
@@ -43,7 +39,6 @@ class SimData(sirepo.sim_data.SimDataBase):
     @classmethod
     def _lib_file_basenames(cls, data):
         res = []
-        #pkdp('LIB FILES FROM {}', data)
         if 'fieldType' in data:
             res.append(cls.lib_file_name_with_model_field(
                 'fieldPath',

--- a/sirepo/sim_data/radia.py
+++ b/sirepo/sim_data/radia.py
@@ -30,11 +30,6 @@ class SimData(sirepo.sim_data.SimDataBase):
         cls._init_models(data.models)
         cls._organize_example(data)
 
-    #@classmethod
-    #def _compute_job_fields(cls, data, *args, **kwargs):
-    #    return [
-    #        data.report,
-    #    ]
 
     @classmethod
     def _lib_file_basenames(cls, data):

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -364,6 +364,9 @@ def _generate_parameters_file(data, run_dir=None):
     res, v = template_common.generate_parameters_file(data)
     g = data.models.geometry
 
+    v['dmpFile'] = _dmp_file(run_dir)
+    v['dataFile'] = _geom_file(run_dir)
+
     v['gId'] = g_id
     v['isExample'] = data.models.simulation.get('isExample', False)
     v['geomName'] = g.name

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -36,7 +36,7 @@ _FIELD_MAP_COLS = ['x', 'y', 'z', 'Bx', 'By', 'Bz']
 _FIELD_MAP_UNITS = ['m', 'm', 'm', 'T', 'T', 'T']
 _GEOM_DIR = 'geometry'
 _GEOM_FILE = 'geom.h5'
-_METHODS = ['get_field', 'get_field_integrals', 'get_geom', 'save_field']
+_METHODS = ['get_field', 'get_field_integrals', 'get_geom', 'save_field', 'solve']
 _SIM_DATA, SIM_TYPE, _SCHEMA = sirepo.sim_data.template_globals()
 _SDDS_INDEX = 0
 
@@ -76,7 +76,6 @@ def background_percent_complete(report, run_dir, is_running):
 
 
 def extract_report_data(run_dir, sim_in):
-    pkdp('EXTRACT RPT {} REQ {}', sim_in.report, sim_in.models.radiaReq)
     if sim_in.report in ('geometry', 'solver',):
         # radiaReq should be set by the client - we know the run_dir so add it to the
         # input for get_application_data
@@ -101,7 +100,7 @@ def extract_report_data(run_dir, sim_in):
 # if the file exists but the data we seek does not, have Radia generate it here.  We
 # should only have to blow away the file after a solve (???)
 def get_application_data(data, **kwargs):
-    pkdp('get_application_data from {} kw {}', data, kwargs)
+    #pkdp('get_application_data from {} kw {}', data, kwargs)
     if 'method' not in data:
         raise RuntimeError('no application data method')
     if data.method not in _METHODS:
@@ -180,9 +179,6 @@ def python_source_for_model(data, model):
 
 
 def write_parameters(data, run_dir, is_parallel):
-    # remove centralized geom files?
-    #pkio.unchecked_remove(_geom_file(data.simulationId), _dmp_file(data.simulationId))
-    pkdp('WRITE PRM FOR RPT {}', data.report)
     pkio.write_text(
         run_dir.join(template_common.PARAMETERS_PYTHON_FILE),
         _generate_parameters_file(data, run_dir),

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -51,6 +51,12 @@ VIEW_TYPES = [VIEW_TYPE_OBJ, VIEW_TYPE_FIELD]
 _cfg = PKDict(sdds=None)
 
 
+def append_h5(data, h5path, file_path):
+    #pkdp('ADDING DATA TO F {} AT P {}', file_path, h5path)
+    with h5py.File(file_path, 'a') as hf:
+        template_common.dict_to_h5(data, hf, path=h5path)
+
+
 def background_percent_complete(report, run_dir, is_running):
     res = PKDict(
         percentComplete=0,
@@ -174,7 +180,7 @@ def write_parameters(data, run_dir, is_parallel):
     pkio.unchecked_remove(_geom_file(data.simulationId), _dmp_file(data.simulationId))
     pkio.write_text(
         run_dir.join(template_common.PARAMETERS_PYTHON_FILE),
-        _generate_parameters_file(data),
+        _generate_parameters_file(data, run_dir),
     )
 
 
@@ -350,7 +356,7 @@ def _generate_obj_data(g_id, name):
     return radia_tk.geom_to_data(g_id, name=name)
 
 
-def _generate_parameters_file(data):
+def _generate_parameters_file(data, run_dir):
     report = data.get('report', '')
     res, v = template_common.generate_parameters_file(data)
     sim_id = data.simulationId
@@ -383,7 +389,7 @@ def _generate_parameters_file(data):
     if 'reset' in report:
         radia_tk.reset()
         data.report = 'geometry'
-        return _generate_parameters_file(data)
+        return _generate_parameters_file(data, run_dir)
     v['h5ObjPath'] = _geom_h5_path(VIEW_TYPE_OBJ)
     v['h5FieldPath'] = _geom_h5_path(VIEW_TYPE_FIELD, f_type)
 

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -113,6 +113,8 @@ def get_application_data(data, **kwargs):
         solution=_read_solution(run_dir)
     )
     g_id = _load_radia_bin(run_dir)
+    if g_id < 0:
+        return PKDict(warning='No dump file')
     if data.method == 'get_field':
         f_type = data.get('fieldType')
         if f_type in radia_tk.POINT_FIELD_TYPES:


### PR DESCRIPTION
Fix #2598

To preface, this solution uses```get_application_data()``` to fetch or compute results from a stored Radia dump file.  However, that function is unaware of the run_dir, so I provide it in the input data once it is known.  sim_id has been expunged.

1) All compute models fold into 'geometry'
2) A new model ```radiaReq``` persists the input to ```get_application_data()```
3) In ```get_application_data()```, if run_dir is not known or the desired file does not exist, the client calls ```panelState.requestData()``` and ```pkcli.run()``` executes generated python.
4) ```template.extract_report_data()``` knows about run_dir, and passes it to ```get_application_data()``` to return the requested data, plus radiaReq, to the client
5) The client saves the radiaReq model so the run_dir is provided in future requests

After all that, some jiggery-pokery was still required on the client side to re-render properly after a solve: 'computeJobHash-mismatch' is happening so there is something incorrect even though it "works"...