### PR TITLE
Fix #2650 only cancel ops already in queue

### DIFF
--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -256,7 +256,7 @@ class DriverBase(PKDict):
                     t,
                     self._agent_starting_timeout_handler,
                 )
-                # POSIT: CancelledError isn't smothered by any of the below calls
+                # POSIT: Cancelled errors aren't smothered by any of the below calls
                 await self.kill()
                 await self._do_agent_start(op)
             except Exception as e:

--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -243,11 +243,8 @@ class DriverBase(PKDict):
                 t = self.cfg.agent_starting_secs
                 if pkconfig.channel_in_internal_test():
                     x = op.msg.pkunchecked_nested_get('data.models.dog.favoriteTreat')
-                    pkdp(op.msg.data)
                     if x:
-                        pkdp(x)
                         x = re.search(r'agent_start_delay=(\d+)', x)
-                        pkdp(x)
                         if x:
                             self._agent_start_delay = int(x.group(1))
                             t += self._agent_start_delay

--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -11,6 +11,7 @@ from sirepo import job
 import asyncio
 import importlib
 import pykern.pkio
+import re
 import sirepo.auth
 import sirepo.simulation_db
 import sirepo.srdb
@@ -210,6 +211,7 @@ class DriverBase(PKDict):
             env=(env or PKDict()).pksetdefault(
                 PYKERN_PKDEBUG_WANT_PID_TIME='1',
                 SIREPO_PKCLI_JOB_AGENT_AGENT_ID=self._agentId,
+                SIREPO_PKCLI_JOB_AGENT_START_DELAY=self.get('_agent_start_delay', 0),
                 SIREPO_PKCLI_JOB_AGENT_SUPERVISOR_URI=self.cfg.supervisor_uri.replace(
 #TODO(robnagler) figure out why we need ws (wss, implicit)
                     'http',
@@ -238,11 +240,23 @@ class DriverBase(PKDict):
             if self._agent_starting_timeout or self._websocket_ready.is_set():
                 return
             try:
+                t = self.cfg.agent_starting_secs
+                if pkconfig.channel_in_internal_test():
+                    x = op.msg.pkunchecked_nested_get('data.models.dog.favoriteTreat')
+                    pkdp(op.msg.data)
+                    if x:
+                        pkdp(x)
+                        x = re.search(r'agent_start_delay=(\d+)', x)
+                        pkdp(x)
+                        if x:
+                            self._agent_start_delay = int(x.group(1))
+                            t += self._agent_start_delay
+                            pkdlog('op={} agent_start_delay={}', op, self._agent_start_delay)
                 pkdlog('{} {} await _do_agent_start', self, op)
                 # All awaits must be after this. If a call hangs the timeout
                 # handler will cancel this task
                 self._agent_starting_timeout = tornado.ioloop.IOLoop.current().call_later(
-                    self.cfg.agent_starting_secs,
+                    t,
                     self._agent_starting_timeout_handler,
                 )
                 # POSIT: CancelledError isn't smothered by any of the below calls

--- a/sirepo/job_driver/docker.py
+++ b/sirepo/job_driver/docker.py
@@ -10,10 +10,10 @@ from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp, pkdlog, pkdexc, pkdc
 from sirepo import job
 from sirepo import job_driver
-import asyncio
 import io
 import os
 import re
+import sirepo.util
 import subprocess
 import tornado.ioloop
 import tornado.process
@@ -119,7 +119,7 @@ class DockerDriver(job_driver.DriverBase):
                     self._cname
                 ),
             )
-        except asyncio.CancelledError:
+        except sirepo.util.ASYNC_CANCELLED_ERROR:
             # CancelledErrors need to make it back out to be handled
             # by callers (ex job_supervisor.api_runSimulation)
             raise

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -19,6 +19,7 @@ import datetime
 import errno
 import sirepo.simulation_db
 import sirepo.srdb
+import sirepo.util
 import tornado.gen
 import tornado.ioloop
 
@@ -169,7 +170,7 @@ disown
 
                 try:
                     await get_agent_log(c)
-                except asyncio.CancelledError:
+                except sirepo.util.ASYNC_CANCELLED_ERROR:
                     raise
                 except Exception as e:
                     pkdlog(

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -566,7 +566,7 @@ class _ComputeJob(PKDict):
             )
             if timed_out_op in self.ops:
                 r.add(timed_out_op)
-            return list(r)
+            return r
 
         r = PKDict(state=job.CANCELED)
         if (
@@ -584,6 +584,7 @@ class _ComputeJob(PKDict):
         ):
             # job is not relevant, but let the user know it isn't running
             return r
+        candidates = _ops_to_cancel()
         c = None
         o = []
         # No matter what happens the job is cancelled
@@ -592,12 +593,12 @@ class _ComputeJob(PKDict):
         try:
             for i in range(_MAX_RETRIES):
                 try:
-                    if _ops_to_cancel():
+                    if _ops_to_cancel().intersection(candidates):
                         #TODO(robnagler) cancel run_op, not just by jid, which is insufficient (hash)
                         if not c:
                             c = self._create_op(job.OP_CANCEL, req)
                         await c.prepare_send()
-                        o = _ops_to_cancel()
+                        o = _ops_to_cancel().intersection(candidates)
                     elif c:
                         c.destroy()
                         c = None

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -325,7 +325,7 @@ class _ComputeJob(PKDict):
                 o,
                 '_receive_' + req.content.api,
             )(req)
-        except asyncio.CancelledError:
+        except sirepo.util.ASYNC_CANCELLED_ERROR:
             return PKDict(state=job.CANCELED)
         except Exception as e:
             pkdlog('{} error={} stack={}', req, e, pkdexc())
@@ -701,7 +701,7 @@ class _ComputeJob(PKDict):
                     pass
             else:
                 raise AssertionError('too many retries {}'.format(req))
-        except asyncio.CancelledError:
+        except sirepo.util.ASYNC_CANCELLED_ERROR:
             if self.pkdel('_cancelled_serial') == c:
                 # We were cancelled due to api_runCancel.
                 # api_runCancel destroyed the op and updated the db
@@ -811,7 +811,7 @@ class _ComputeJob(PKDict):
                         self.__db_write()
                         if r.state in job.EXIT_STATUSES:
                             break
-                    except asyncio.CancelledError:
+                    except sirepo.util.ASYNC_CANCELLED_ERROR:
                         return
         except Exception as e:
             pkdlog('error={} stack={}', e, pkdexc())

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -54,12 +54,16 @@ def start():
 
     cfg = pkconfig.init(
         agent_id=pkconfig.Required(str, 'id of this agent'),
+        start_delay=(0, pkconfig.parse_seconds, 'delay startup in internal_test mode'),
         supervisor_uri=pkconfig.Required(
             str,
             'how to connect to the supervisor',
         ),
     )
     pkdlog('{}', cfg)
+    if pkconfig.channel_in_internal_test() and cfg.start_delay:
+        pkdlog('start_delay={}', cfg.start_delay)
+        time.sleep(cfg.start_delay)
     i = tornado.ioloop.IOLoop.current()
     d = _Dispatcher()
     def s(*args):

--- a/sirepo/pkcli/test_http.py
+++ b/sirepo/pkcli/test_http.py
@@ -154,7 +154,7 @@ def test():
             await t
         except Exception as e:
             await _cancel_all_tasks(s)
-            if isinstance(e, asyncio.CancelledError):
+            if isinstance(e, sirepo.util.ASYNC_CANCELLED_ERROR):
                 # Will only be cancelled by a signal handler
                 return
             pkdlog('error={} stack={} sims={}', e, pkdexc(), _sims)
@@ -414,7 +414,7 @@ class _Sim(PKDict):
                     finally:
                         if c:
                             await self._cancel(error=e)
-            except asyncio.CancelledError:
+            except sirepo.util.ASYNC_CANCELLED_ERROR:
                 # Don't log on cancel error, we initiate cancels so not interesting
                 raise
             except Exception as e:

--- a/sirepo/tornado.py
+++ b/sirepo/tornado.py
@@ -5,7 +5,7 @@ u"""Wrappers for Tornado
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from pykern.pkdebug import pkdlog, pkdexc
-import asyncio
+import sirepo.util
 import tornado.queues
 
 
@@ -24,7 +24,7 @@ class Queue(tornado.queues.Queue):
             # on the queue and before this task finishes the await.
             x = super().get()
             return await x
-        except (asyncio.CancelledError, concurrent.futures._base.CancelledError):
+        except sirepo.util.ASYNC_CANCELLED_ERROR:
             if x:
                 try:
                     r = x.result()

--- a/sirepo/tornado.py
+++ b/sirepo/tornado.py
@@ -24,7 +24,7 @@ class Queue(tornado.queues.Queue):
             # on the queue and before this task finishes the await.
             x = super().get()
             return await x
-        except asyncio.CancelledError:
+        except (asyncio.CancelledError, concurrent.futures._base.CancelledError):
             if x:
                 try:
                     r = x.result()

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -9,6 +9,8 @@ from pykern import pkcompat
 from pykern import pkconfig
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdlog, pkdp, pkdexc
+import asyncio
+import concurrent.futures
 import inspect
 import numconv
 import pykern.pkinspect
@@ -16,6 +18,9 @@ import pykern.pkio
 import pykern.pkjson
 import random
 
+
+#: All types of errors async code may throw when cancelled
+ASYNC_CANCELLED_ERROR = (asyncio.CancelledError, concurrent.futures.CancelledError)
 
 #: length of string returned by create_token
 TOKEN_SIZE = 16

--- a/tests/cancel_delay_test.py
+++ b/tests/cancel_delay_test.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+u"""test cancel of sim with agent_start_delay
+
+:copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from __future__ import absolute_import, division, print_function
+import pytest
+
+_REPORT = 'heightWeightReport'
+
+
+def test_myapp(fc):
+    from pykern import pkunit
+    from pykern.pkdebug import pkdc, pkdp, pkdlog
+    import threading
+    import time
+
+    d = fc.sr_sim_data()
+    d.models.dog.favoriteTreat = 'agent_start_delay=5'
+    x = dict(
+        forceRun=False,
+        models=d.models,
+        report=_REPORT,
+        simulationId=d.models.simulation.simulationId,
+        simulationType=d.simulationType,
+    )
+    t1 = threading.Thread(target=lambda: fc.sr_post('runSimulation', x))
+    t1.start()
+    time.sleep(1)
+    t2 = threading.Thread(target=lambda: fc.sr_post('runCancel', x))
+    t2.start()
+    time.sleep(1)
+    r = fc.sr_run_sim(d, _REPORT)
+    pkdp('abc')
+    p = r.get('plots')
+    pkunit.pkok(p, 'expecting truthy r.plots={}', p)

--- a/tests/job_concurrency1_test.py
+++ b/tests/job_concurrency1_test.py
@@ -117,7 +117,7 @@ def test_elegant_concurrent_sim_frame(fc):
             pkunit.pkeq('completed', f.state)
 
     def _t2(get_frames):
-            get_frames()
+        get_frames()
 
     d = fc.sr_sim_data(sim_name='Backtracking', sim_type='elegant' )
     s = sirepo.sim_data.get_class(fc.sr_sim_type)


### PR DESCRIPTION
runCancel takes snapshot of queue before doing anything,
and then intersects that with the list of current ops
at the time it starts to cancel. This avoids canceling
ops "in the future".
In myapp, setting favoriteTreat to agent_start_delay=N where
N is a number of seconds will cause agent to sleep for N seconds
before sending OP_LIVE.