### PR TITLE
WIP #2691 html.render: non-jinja templating

### DIFF
--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -85,7 +85,11 @@ def api_authCompleteRegistration():
 
 @api_perm.allow_visitor
 def api_authState():
-    return http_reply.render_static('auth-state', 'js', PKDict(auth_state=_auth_state()))
+    return http_reply.render_static_jinja(
+        'auth-state',
+        'js',
+        PKDict(auth_state=_auth_state()),
+    )
 
 
 @api_perm.allow_visitor

--- a/sirepo/html.py
+++ b/sirepo/html.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+u"""html template
+
+:copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from __future__ import absolute_import, division, print_function
+from pykern.pkcollections import PKDict
+from pykern.pkdebug import pkdc, pkdlog, pkdp
+import pykern.pkio
+import re
+import sys
+
+
+_CALL_RE = re.compile(r'(\w+)\(([^\)]*)\);', flags=re.MULTILINE)
+
+_ARGS_RE = re.compile(r'\s*,\s*')
+
+_ARG_RE = re.compile(r'^(\w+)=(.*)$', flags=re.DOTALL)
+
+_FUNC_MAP = PKDict()
+
+_FUNC_PREFIX = '_widget_'
+
+def render(path):
+    def _dispatch(match):
+        f = match.group(1)
+        assert f in _FUNC_MAP, \
+            f'function={f} not in map path={path}'
+        k = PKDict(ctx=PKDict(path=path))
+        for a in  _ARGS_RE.split(match.group(2).strip()):
+            m = _ARG_RE.search(a)
+            assert m, \
+                f'invalid keyword argument={a} function={f} path={path}'
+            assert m.group(1) not in k, \
+                f'duplicate keyword argument={a} function={f} path={path}'
+            k[m.group(1)] = m.group(2)
+        return _FUNC_MAP[f](**k)
+
+    return _CALL_RE.sub(_dispatch, pykern.pkio.read_text(path))
+
+
+def _init():
+    import sys, inspect
+    for n, o in inspect.getmembers(sys.modules[__name__]):
+        if n.startswith(_FUNC_PREFIX) and inspect.isfunction(o):
+            _FUNC_MAP[n[len(_FUNC_PREFIX):]] = o
+
+
+def _widget_sim_settings_and_status(ctx, scope):
+    return f'''<div class="col-md-6 col-xl-4">
+      <div data-basic-editor-panel="" data-view-name="simulationSettings"></div>
+    </div>
+    <div class="col-md-6 col-xl-4">
+      <div data-simple-panel="simulationStatus">
+        <div data-sim-status-panel="{scope}.simState"></div>
+      </div>
+    </div>
+    <div class="clearfix"></div>'''
+
+
+_init()

--- a/sirepo/package_data/static/html/synergia-visualization.html
+++ b/sirepo/package_data/static/html/synergia-visualization.html
@@ -1,14 +1,6 @@
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-6 col-xl-4">
-      <div data-basic-editor-panel="" data-view-name="simulationSettings"></div>
-    </div>
-    <div class="col-md-6 col-xl-4">
-      <div data-simple-panel="simulationStatus">
-        <div data-sim-status-panel="visualization.simState"></div>
-      </div>
-    </div>
-    <div class="clearfix"></div>
+    sim_settings_and_status(scope=visualization);
     <div class="col-md-6 col-xl-4" data-ng-if="visualization.simState.hasFrames()">
       <div data-report-panel="parameter" data-model-name="beamEvolutionAnimation"></div>
     </div>

--- a/sirepo/package_data/static/html/zgoubi-visualization.html
+++ b/sirepo/package_data/static/html/zgoubi-visualization.html
@@ -1,14 +1,6 @@
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-6 col-xl-4">
-      <div data-basic-editor-panel="" data-view-name="simulationSettings"></div>
-    </div>
-    <div class="col-md-6 col-xl-4">
-      <div data-simple-panel="simulationStatus">
-        <div data-sim-status-panel="visualization.simState"></div>
-      </div>
-    </div>
-    <div class="clearfix"></div>
+    sim_settings_and_status(scope=visualization);
     <div data-column-for-aspect-ratio="bunchAnimation" data-ng-if="visualization.simState.hasFrames()">
       <div data-report-panel="{{ visualization.reportType('bunchAnimation') }}" data-model-name="bunchAnimation" data-panel-title="{{ visualization.bunchReportHeading('bunchAnimation') }}">
         <div data-ng-if="visualization.isComputingRanges" class="text-center text-info">Computing plot range across frames...</div>


### PR DESCRIPTION
The template syntax looks like:

```txt
  <div class="row">
    sim_settings_and_status(scope=visualization);
    <div class="col-md-6 col-xl-4" data-ng-if="visualization.simState.hasFrames()">
```

We could make it recursive and nested. Not important right now. I want to explore how we could simplify the html templates, and then the inline templates in the js.

