### PR TITLE
Fix part of #2684. Use on 'l' in canceled.

### DIFF
--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -256,7 +256,7 @@ class DriverBase(PKDict):
                     t,
                     self._agent_starting_timeout_handler,
                 )
-                # POSIT: Cancelled errors aren't smothered by any of the below calls
+                # POSIT: Canceled errors aren't smothered by any of the below calls
                 await self.kill()
                 await self._do_agent_start(op)
             except Exception as e:

--- a/sirepo/job_driver/docker.py
+++ b/sirepo/job_driver/docker.py
@@ -119,8 +119,8 @@ class DockerDriver(job_driver.DriverBase):
                     self._cname
                 ),
             )
-        except sirepo.util.ASYNC_CANCELLED_ERROR:
-            # CancelledErrors need to make it back out to be handled
+        except sirepo.util.ASYNC_CANCELED_ERROR:
+            # CanceledErrors need to make it back out to be handled
             # by callers (ex job_supervisor.api_runSimulation)
             raise
         except Exception as e:

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -170,7 +170,7 @@ disown
 
                 try:
                     await get_agent_log(c)
-                except sirepo.util.ASYNC_CANCELLED_ERROR:
+                except sirepo.util.ASYNC_CANCELED_ERROR:
                     raise
                 except Exception as e:
                     pkdlog(

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -41,7 +41,7 @@ _NEXT_REQUEST_SECONDS = None
 
 _HISTORY_FIELDS = frozenset((
     'alert',
-    'cancelledAfterSecs',
+    'canceledAfterSecs',
     'computeJobQueued',
     'computeJobSerial',
     'computeJobStart',
@@ -325,7 +325,7 @@ class _ComputeJob(PKDict):
                 o,
                 '_receive_' + req.content.api,
             )(req)
-        except sirepo.util.ASYNC_CANCELLED_ERROR:
+        except sirepo.util.ASYNC_CANCELED_ERROR:
             return PKDict(state=job.CANCELED)
         except Exception as e:
             pkdlog('{} error={} stack={}', req, e, pkdexc())
@@ -371,7 +371,7 @@ class _ComputeJob(PKDict):
     def __db_init_new(cls, data, prev_db=None):
         db = PKDict(
             alert=None,
-            cancelledAfterSecs=None,
+            canceledAfterSecs=None,
             computeJid=data.computeJid,
             computeJobHash=data.computeJobHash,
             computeJobQueued=0,
@@ -422,22 +422,27 @@ class _ComputeJob(PKDict):
 
     @classmethod
     def __db_load(cls, compute_jid):
+        v = None
         d = pkcollections.json_load_any(
             cls.__db_file(compute_jid),
         )
         for k in [
                 'alert',
-                'cancelledAfterSecs',
+                'canceledAfterSecs',
                 'isPremiumUser',
                 'jobStatusMessage',
                 'internalError',
         ]:
-            d.setdefault(k, None)
+            d.setdefault(k, v)
             for h in d.history:
-                h.setdefault(k, None)
+                h.setdefault(k, v)
         d.pksetdefault(
             computeModel=lambda: sirepo.sim_data.split_jid(compute_jid).compute_model,
         )
+        if 'cancelledAfterSecs' in d:
+            d.canceledAfterSecs = d.pkdel('cancelledAfterSecs', default=v)
+            for h in d.history:
+               h.canceledAfterSecs = d.pkdel('cancelledAfterSecs', default=v)
         return d
 
     def __db_restore(self, db):
@@ -548,20 +553,20 @@ class _ComputeJob(PKDict):
         """Cancel a run and related ops
 
         Analysis ops that are for a parallel run (ex. sim frames) will not
-        be cancelled.
+        be canceled.
 
         Args:
             req (ServerReq): The cancel request
             timed_out_op (_Op, Optional): the op that was timed out, which
                 needs to be canceled
         Returns:
-            PKDict: Message with state=cancelled
+            PKDict: Message with state=canceled
         """
 
         def _ops_to_cancel():
             r = set(
                 o for o in self.ops
-                # Do not cancel sim frames. Allow them to come back for a cancelled run
+                # Do not cancel sim frames. Allow them to come back for a canceled run
                 if not (self.db.isParallel and o.opName == job.OP_ANALYSIS)
             )
             if timed_out_op in self.ops:
@@ -570,7 +575,7 @@ class _ComputeJob(PKDict):
 
         r = PKDict(state=job.CANCELED)
         if (
-            # a running simulation may be cancelled due to a
+            # a running simulation may be canceled due to a
             # downloadDataFile request timeout in another browser window (only the
             # computeJids must match between the two requests). This might be
             # a weird UX but it's important to do, because no op should take
@@ -587,9 +592,9 @@ class _ComputeJob(PKDict):
         candidates = _ops_to_cancel()
         c = None
         o = []
-        # No matter what happens the job is cancelled
+        # No matter what happens the job is canceled
         self.__db_update(status=job.CANCELED)
-        self._cancelled_serial = self.db.computeJobSerial
+        self._canceled_serial = self.db.computeJobSerial
         try:
             for i in range(_MAX_RETRIES):
                 try:
@@ -606,7 +611,7 @@ class _ComputeJob(PKDict):
                     for x in filter(lambda e: e != c, o):
                         x.destroy(cancel=True)
                     if timed_out_op:
-                        self.db.cancelledAfterSecs = timed_out_op.max_run_secs
+                        self.db.canceledAfterSecs = timed_out_op.max_run_secs
                     if c:
                         c.msg.opIdsToCancel = [x.opId for x in o]
                         c.send()
@@ -701,9 +706,9 @@ class _ComputeJob(PKDict):
                     pass
             else:
                 raise AssertionError('too many retries {}'.format(req))
-        except sirepo.util.ASYNC_CANCELLED_ERROR:
-            if self.pkdel('_cancelled_serial') == c:
-                # We were cancelled due to api_runCancel.
+        except sirepo.util.ASYNC_CANCELED_ERROR:
+            if self.pkdel('_canceled_serial') == c:
+                # We were canceled due to api_runCancel.
                 # api_runCancel destroyed the op and updated the db
                 raise
             # There was a timeout getting the run started. Set the
@@ -811,7 +816,7 @@ class _ComputeJob(PKDict):
                         self.__db_write()
                         if r.state in job.EXIT_STATUSES:
                             break
-                    except sirepo.util.ASYNC_CANCELLED_ERROR:
+                    except sirepo.util.ASYNC_CANCELED_ERROR:
                         return
         except Exception as e:
             pkdlog('error={} stack={}', e, pkdexc())
@@ -850,8 +855,8 @@ class _ComputeJob(PKDict):
     def _status_reply(self, req):
         def res(**kwargs):
             r = PKDict(**kwargs)
-            if self.db.cancelledAfterSecs is not None:
-                r.cancelledAfterSecs = self.db.cancelledAfterSecs
+            if self.db.canceledAfterSecs is not None:
+                r.canceledAfterSecs = self.db.canceledAfterSecs
             if self.db.error:
                 r.error = self.db.error
             if self.db.alert:
@@ -937,7 +942,7 @@ class _Op(PKDict):
         await self.driver.prepare_send(self)
 
     async def reply_get(self):
-        # If we get an exception (cancelled), task is not done.
+        # If we get an exception (canceled), task is not done.
         # Had to look at the implementation of Queue to see that
         # task_done should only be called if get actually removes
         # the item from the queue.

--- a/sirepo/package_data/static/html/elegant-visualization.html
+++ b/sirepo/package_data/static/html/elegant-visualization.html
@@ -3,7 +3,7 @@
     <div class="col-md-6 col-xl-4">
 
       <div data-basic-editor-panel="" data-view-name="simulationStatus" data-want-buttons="">
-       <div data-cancelled-due-to-timeout-alert="visualization.simState"></div>
+       <div data-canceled-due-to-timeout-alert="visualization.simState"></div>
           <form name="form" class="form-horizontal" autocomplete="off" novalidate data-ng-show="visualization.simState.isProcessing()">
             <div class="col-sm-12" data-pending-link-to-simulations="" data-sim-state="visualization.simState"></div>
             <div class="col-sm-12" data-ng-show="visualization.simState.isStateRunning()">

--- a/sirepo/package_data/static/html/warpvnd-visualization.html
+++ b/sirepo/package_data/static/html/warpvnd-visualization.html
@@ -4,7 +4,7 @@
       <div class="row">
         <div class="col-sm-12">
           <div data-simulation-status-panel="simulationStatus">
-            <div data-cancelled-due-to-timeout-alert="$parent.simState"></div>
+            <div data-canceled-due-to-timeout-alert="$parent.simState"></div>
             <div class="col-sm-12" data-ng-show="$parent.simState.getFrameCount() >= 1">
               Simulation
               <span>{{ $parent.simState.stateAsText() }}</span><span>:

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -302,17 +302,17 @@ SIREPO.app.directive('buttons', function(appState, panelState) {
     };
 });
 
-SIREPO.app.directive('cancelledDueToTimeoutAlert', function(authState) {
+SIREPO.app.directive('canceledDueToTimeoutAlert', function(authState) {
     return {
         restrict: 'A',
         scope: {
             seconds: '<',
-            simState: '=cancelledDueToTimeoutAlert',
+            simState: '=canceledDueToTimeoutAlert',
         },
         template: [
-            '<div data-ng-if="simState.getCancelledAfterSecs()" class="alert alert-warning" role="alert">',
-              '<h4 class="alert-heading">Cancelled: Maximum runtime exceeded</h4>',
-              '<p>Your simulation ran for {{getTime()}}. To increase your maximum runtime please upgrade to <a href="https://radiasoft.net/sirepo" target="_blank">Sirepo {{ premiumOrEnterprise() }}</a>.</p>',
+            '<div data-ng-if="simState.getCanceledAfterSecs()" class="alert alert-warning" role="alert">',
+              '<h4 class="alert-heading"><b>Canceled: Maximum runtime exceeded</b></h4>',
+              '<p>Your runtime limit is {{getTime()}}. To increase your maximum runtime, please upgrade to <a href="https://radiasoft.net/sirepo" target="_blank">Sirepo {{ premiumOrEnterprise() }}</a>.</p>',
             '</div>',
         ].join(''),
         controller: function($scope) {
@@ -324,7 +324,7 @@ SIREPO.app.directive('cancelledDueToTimeoutAlert', function(authState) {
             }
 
             $scope.getTime = function() {
-                var s = $scope.simState.getCancelledAfterSecs();
+                var s = $scope.simState.getCanceledAfterSecs();
                 var h = leftPadZero(Math.floor(s / 3600));
                 s %= 3600;
                 var m = leftPadZero(Math.floor(s / 60));
@@ -3272,7 +3272,7 @@ SIREPO.app.directive('simStatusPanel', function(appState) {
                   '<div data-sbatch-options="simState"></div>',
                 '</div>',
               '</div>',
-              '<div data-cancelled-due-to-timeout-alert="simState"></div>',
+              '<div data-canceled-due-to-timeout-alert="simState"></div>',
               '<div class="col-sm-6 pull-right">',
                 '<button class="btn btn-default" data-ng-click="start()">{{ startButtonLabel() }}</button>',
               '</div>',
@@ -3300,8 +3300,8 @@ SIREPO.app.directive('simStatusPanel', function(appState) {
                 return callSimState('stopButtonLabel') || 'End Simulation';
             };
 
-            $scope.cancelledAfterSecs = function() {
-                return callSimState('getCancelledAfterSecs');
+            $scope.canceledAfterSecs = function() {
+                return callSimState('getCanceledAfterSecs');
             };
 
             $scope.errorMessage = function() {

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -2207,7 +2207,7 @@ SIREPO.app.factory('persistentSimulation', function(simulationQueue, appState, a
             }
             if (state.model in appState.models.simulationStatus) {
                 delete appState.models.simulationStatus[state.model].alert;
-                delete appState.models.simulationStatus[state.model].cancelledAfterSecs;
+                delete appState.models.simulationStatus[state.model].canceledAfterSecs;
             }
             data.report = state.model;
             appState.models.simulationStatus[state.model] = angular.extend(
@@ -2239,8 +2239,8 @@ SIREPO.app.factory('persistentSimulation', function(simulationQueue, appState, a
             return simulationStatus().alert;
         };
 
-        state.getCancelledAfterSecs = function() {
-            return simulationStatus().cancelledAfterSecs;
+        state.getCanceledAfterSecs = function() {
+            return simulationStatus().canceledAfterSecs;
         };
 
         state.getError = function() {

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -2052,7 +2052,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
         },
         template: [
             '<form name="form" class="form-horizontal" autocomplete="off" novalidate>',
-              '<div data-cancelled-due-to-timeout-alert="simState"></div>',
+              '<div data-canceled-due-to-timeout-alert="simState"></div>',
               '<div class="progress" data-ng-if="simState.isProcessing()">',
                 '<div class="progress-bar" data-ng-class="{ \'progress-bar-striped active\': simState.isInitializing() }" role="progressbar" aria-valuenow="{{ simState.getPercentComplete() }}" aria-valuemin="0" aria-valuemax="100" data-ng-attr-style="width: {{ simState.getPercentComplete() }}%"></div>',
               '</div>',

--- a/sirepo/pkcli/test_http.py
+++ b/sirepo/pkcli/test_http.py
@@ -154,8 +154,8 @@ def test():
             await t
         except Exception as e:
             await _cancel_all_tasks(s)
-            if isinstance(e, sirepo.util.ASYNC_CANCELLED_ERROR):
-                # Will only be cancelled by a signal handler
+            if isinstance(e, sirepo.util.ASYNC_CANCELED_ERROR):
+                # Will only be canceled by a signal handler
                 return
             pkdlog('error={} stack={} sims={}', e, pkdexc(), _sims)
             raise
@@ -218,7 +218,7 @@ async def _cancel_all_tasks(tasks):
         t.cancel()
     # We need a gather() after cancel() because there are awaits in the
     # finally blocks (ex await post('run-cancel)). We need return_exceptions
-    # so the CancelledErrors aren't raised which would cancel the gather.
+    # so the CanceledErrors aren't raised which would cancel the gather.
     await asyncio.gather(*tasks, return_exceptions=True)
 
 
@@ -414,7 +414,7 @@ class _Sim(PKDict):
                     finally:
                         if c:
                             await self._cancel(error=e)
-            except sirepo.util.ASYNC_CANCELLED_ERROR:
+            except sirepo.util.ASYNC_CANCELED_ERROR:
                 # Don't log on cancel error, we initiate cancels so not interesting
                 raise
             except Exception as e:

--- a/sirepo/tornado.py
+++ b/sirepo/tornado.py
@@ -12,7 +12,7 @@ import tornado.queues
 class Queue(tornado.queues.Queue):
 
     async def get(self):
-        """Implements a cancellable Queue.get
+        """Implements a cancelable Queue.get
 
         See https://github.com/radiasoft/sirepo/issues/2375
         """
@@ -20,11 +20,11 @@ class Queue(tornado.queues.Queue):
         try:
             # this returns a future, which may get a result
             # before the await returns, that is, if the task
-            # is cancelled after another task has put something
+            # is canceled after another task has put something
             # on the queue and before this task finishes the await.
             x = super().get()
             return await x
-        except sirepo.util.ASYNC_CANCELLED_ERROR:
+        except sirepo.util.ASYNC_CANCELED_ERROR:
             if x:
                 try:
                     r = x.result()
@@ -40,7 +40,7 @@ class Queue(tornado.queues.Queue):
                         self.task_done()
                         self.put_nowait(r)
                     except Exception as e:
-                        # at this point, the task is cancelled so
+                        # at this point, the task is canceled so
                         # we can't raise another exception, but we
                         # should log that an error has occurred.
                         # It's an unlikely situation, but definitely a

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -19,8 +19,8 @@ import pykern.pkjson
 import random
 
 
-#: All types of errors async code may throw when cancelled
-ASYNC_CANCELLED_ERROR = (asyncio.CancelledError, concurrent.futures.CancelledError)
+#: All types of errors async code may throw when canceled
+ASYNC_CANCELED_ERROR = (asyncio.CancelledError, concurrent.futures.CancelledError)
 
 #: length of string returned by create_token
 TOKEN_SIZE = 16

--- a/tests/job_timeout_test.py
+++ b/tests/job_timeout_test.py
@@ -41,7 +41,7 @@ def test_srw(fc):
             if r.state == 'canceled':
                 pkunit.pkeq(
                     int(_MAX_SECS_PARALLEL_PREMIUM),
-                    r.cancelledAfterSecs,
+                    r.canceledAfterSecs,
                 )
                 cancel = None
                 break


### PR DESCRIPTION
For ease of mind I think we should just use one 'l' in canceled regardless of whether the value may or may not be presented to the user.