### PR TITLE
Fix #2740. Use chrome instead of phantomjs for testing.

### DIFF
--- a/etc/jshint.conf
+++ b/etc/jshint.conf
@@ -4,7 +4,7 @@
     "globalstrict": true,
     "predef": ["angular", "$", "console", "d3", "SIREPO", "saveAs", "Colorbar", "Detector", "Modernizr", "Split", "domtoimage", "vtk", "katex"],
     "curly": true,
-    "esversion": 5,
+    "esversion": 6,
     "freeze": true,
     "futurehostile": true,
     "noarg": true,

--- a/etc/karma-conf.js
+++ b/etc/karma-conf.js
@@ -1,12 +1,5 @@
 // Karma configuration
-// Generated on Tue Jul 21 2015 19:52:26 GMT+0000 (UCT)
-// before running the first time:
-//   npm install karma --save-dev
-//   npm install karma-jasmine --save-dev
-//   npm install karma-phantomjs-launcher
-//   npm install jasmine-core --save-dev
-// then:
-//   ./node_modules/karma/bin/karma start etc/karma-conf.js
+// npm run test
 
 module.exports = function(config) {
   config.set({
@@ -88,10 +81,8 @@ module.exports = function(config) {
     autoWatch: true,
 
 
-    // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    //browsers: ['Chrome'],
-    browsers: ['PhantomJS'],
+    browsers: ['ChromeHeadless'],
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: true

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "sirepo",
+  "description": "Accelerator code gui",
+  "dependencies": {},
+  "devDependencies": {
+    "jasmine-core": "latest",
+    "jshint": "latest",
+    "karma": "latest",
+    "karma-chrome-launcher": "latest",
+    "karma-jasmine": "latest"
+  },
+  "scripts": {
+      "test": "npx karma start etc/karma-conf.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/radiasoft/sirepo.git"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/radiasoft/sirepo/issues"
+  },
+  "homepage": "https://github.com/radiasoft/sirepo#readme"
+}

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -2191,7 +2191,7 @@ SIREPO.app.factory('requestQueue', function($rootScope, requestSender) {
 
 SIREPO.app.factory('persistentSimulation', function(simulationQueue, appState, authState, frameCache, $interval) {
     var self = {};
-    var ELAPSED_TIME_INTERVAL_SECS = 1;
+    const ELAPSED_TIME_INTERVAL_SECS = 1;
 
     self.initSimulationState = function(controller) {
         var state = {

--- a/test.sh
+++ b/test.sh
@@ -29,7 +29,6 @@ test_main() {
     test_no_prints '\s(pkdp|print)\(' "${pyfiles[@]}"
     local jsfiles=( sirepo/package_data/static/js/*.js )
     test_no_prints '\s(srdbg|console.log)\(' "${jsfiles[@]}"
-    test_no_prints '(startsWith|Object\.assign)\(' "${jsfiles[@]}"
     test_no_h5py
     test_jshint
     if [[ -x ./node_modules/karma/bin/karma ]]; then

--- a/test.sh
+++ b/test.sh
@@ -33,7 +33,7 @@ test_main() {
     test_no_h5py
     test_jshint
     if [[ -x ./node_modules/karma/bin/karma ]]; then
-       ./node_modules/karma/bin/karma start etc/karma-conf.js
+        npm run test
     fi
     pykern test
     if [[ -n ${PKSETUP_PYPI_PASSWORD:+hide-secret} ]]; then


### PR DESCRIPTION
Phantomjs doesn't support ES6 and it is deprecated.
Use Chrome Headless for testing instead.

This depends on radiasoft/download#115.