### PR TITLE
Fix #2652. Top-level marketing urls.

### DIFF
--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1731,6 +1731,8 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, localR
         // remove optional params missed and then that were replaced
         url = url.replace(/\/\?<[^>]+>/g, '');
         url = url.replace(/\/\?/g, '/');
+        // POSIT: char to replace matches sirepo.uri_router.PATH_INFO_CHAR
+        url = url.replace(/\/\*/g, '');
         var missing = url.match(/<[^>]+>/g);
         if (missing) {
             throw new Error(missing.join() + ': missing parameter(s) for route: ' + map[routeName]);

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1728,11 +1728,9 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, localR
                     encodeURIComponent(serializeValue(params[k], k)));
             }
         }
-        // remove optional params missed and then that were replaced
-        url = url.replace(/\/\?<[^>]+>/g, '');
+        // POSIT: ? and * are optional parameter chars sirepo.uri_router
+        url = url.replace(/\/[\?\*]<[^>]+>/g, '');
         url = url.replace(/\/\?/g, '/');
-        // POSIT: char to replace matches sirepo.uri_router.PATH_INFO_CHAR
-        url = url.replace(/\/\*/g, '');
         var missing = url.match(/<[^>]+>/g);
         if (missing) {
             throw new Error(missing.join() + ': missing parameter(s) for route: ' + map[routeName]);

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1845,7 +1845,7 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, localR
     self.globalRedirectRoot = function() {
         self.globalRedirect(
             'root',
-            {'<simulation_type>': SIREPO.APP_SCHEMA.simulationType}
+            {'<path_info>': SIREPO.APP_SCHEMA.simulationType}
         );
     };
 

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -81,6 +81,11 @@
         "shortName": "Sirepo",
         "longName": "Sirepo"
     },
+    "rootRedirectUri": {
+        "fete": "/warpvnd",
+        "plans": "/en/plans.html",
+        "warp": "/warppba"
+    },
     "route": {
         "adjustTime": "/adjust-time/?<days>",
         "admJobs": "/adm-jobs",
@@ -119,7 +124,7 @@
         "ownJobs": "/own-jobs",
         "pythonSource": "/python-source/<simulation_type>/<simulation_id>/?<model>/?<title>",
         "robotsTxt": "/robots.txt",
-        "root": "/<simulation_type>",
+        "root": "/*<path_info>",
         "runCancel": "/run-cancel",
         "runSimulation": "/run-simulation",
         "runStatus": "/run-status",

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -390,7 +390,7 @@ def api_robotsTxt():
         # We include dev so we can test
         if pkconfig.channel_in('prod', 'dev'):
             u = [
-                sirepo.uri.api('root', params={'simulation_type': x})
+                sirepo.uri.api('root', params={'path_info': x})
                 for x in sorted(feature_config.cfg().sim_types)
             ]
         else:
@@ -402,15 +402,14 @@ def api_robotsTxt():
 
 
 @api_perm.allow_visitor
-def api_root(simulation_type):
+def api_root(path_info):
     try:
-        req = http_request.parse_params(type=simulation_type)
+        req = http_request.parse_params(type=path_info)
     except AssertionError:
-        if simulation_type == 'warp':
-            return http_reply.gen_redirect(sirepo.uri.app_root('warppba'))
-        if simulation_type == 'fete':
-            return http_reply.gen_redirect(sirepo.uri.app_root('warpvnd'))
-        sirepo.util.raise_not_found('Invalid simulation_type={}', simulation_type)
+        u = sirepo.uri.root_redirect(path_info)
+        if u:
+            return http_reply.gen_redirect(u)
+        sirepo.util.raise_not_found(f'uknown path={path_info}')
     return _render_root_page('index', PKDict(app_name=req.type))
 
 

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -403,14 +403,12 @@ def api_robotsTxt():
 
 @api_perm.allow_visitor
 def api_root(path_info):
-    try:
-        req = http_request.parse_params(type=path_info)
-    except AssertionError:
-        u = sirepo.uri.root_redirect(path_info)
-        if u:
-            return http_reply.gen_redirect(u)
-        sirepo.util.raise_not_found(f'uknown path={path_info}')
-    return _render_root_page('index', PKDict(app_name=req.type))
+    if sirepo.template.is_sim_type(path_info):
+        return _render_root_page('index', PKDict(app_name=path_info))
+    u = sirepo.uri.unchecked_root_redirect(path_info)
+    if u:
+        return http_reply.gen_redirect(u)
+    sirepo.util.raise_not_found(f'uknown path={path_info}')
 
 
 @api_perm.require_user

--- a/sirepo/srunit.py
+++ b/sirepo/srunit.py
@@ -329,7 +329,7 @@ class _TestClient(flask.testing.FlaskClient):
         self.sr_sim_type_set(sim_type)
         return self.__req(
             'root',
-            {'simulation_type': self.sr_sim_type},
+            {'path_info': self.sr_sim_type},
             None,
             self.get,
             raw_response=True,

--- a/sirepo/uri.py
+++ b/sirepo/uri.py
@@ -21,6 +21,12 @@ except ImportError:
 #: allows us to search more easily for use of http root
 ROOT = '/'
 
+#: route parsing
+PARAM_RE = r'([\?\*]?)<{}>'
+
+#: optional parameter that consumes rest of parameters
+PATH_INFO_CHAR = '*'
+
 
 def api(*args, **kwargs):
     """Alias for `uri_router.uri_for_api`"""
@@ -104,7 +110,7 @@ def server_route(route_or_uri, params, query):
     route = simulation_db.SCHEMA_COMMON['route'][route_or_uri]
     if params:
         for k, v in params.items():
-            k2 = f'\??\{sirepo.uri_router.PATH_INFO_CHAR}?<{k}>'
+            k2 = PARAM_RE.format(k)
             n = re.sub(k2, _to_uri(str(v)), route)
             assert n != route, \
                 '{}: not found in "{}"'.format(k2, route)

--- a/sirepo/uri.py
+++ b/sirepo/uri.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function
 from pykern.pkdebug import pkdp
 import pykern.pkinspect
 import re
+import sirepo.uri_router
 
 try:
     # py3
@@ -103,7 +104,7 @@ def server_route(route_or_uri, params, query):
     route = simulation_db.SCHEMA_COMMON['route'][route_or_uri]
     if params:
         for k, v in params.items():
-            k2 = r'\??<' + k + '>'
+            k2 = f'\??\{sirepo.uri_router.PATH_INFO_CHAR}?<{k}>'
             n = re.sub(k2, _to_uri(str(v)), route)
             assert n != route, \
                 '{}: not found in "{}"'.format(k2, route)

--- a/sirepo/uri.py
+++ b/sirepo/uri.py
@@ -5,6 +5,7 @@ u"""uri formatting
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from __future__ import absolute_import, division, print_function
+from pykern.pkdebug import pkdp
 import pykern.pkinspect
 import re
 
@@ -78,6 +79,10 @@ def local_route(sim_type, route_name=None, params=None, query=None):
                 continue
         u += '/' + _to_uri(params[p])
     return app_root(t) + '#' + u + _query(query)
+
+
+def root_redirect(path):
+    return simulation_db.SCHEMA_COMMON.rootRedirectUri.get(path)
 
 
 def server_route(route_or_uri, params, query):

--- a/sirepo/uri.py
+++ b/sirepo/uri.py
@@ -81,10 +81,6 @@ def local_route(sim_type, route_name=None, params=None, query=None):
     return app_root(t) + '#' + u + _query(query)
 
 
-def root_redirect(path):
-    return simulation_db.SCHEMA_COMMON.rootRedirectUri.get(path)
-
-
 def server_route(route_or_uri, params, query):
     """Convert name to uri found in SCHEMA_COMMON
 
@@ -117,6 +113,10 @@ def server_route(route_or_uri, params, query):
         '{}: missing params'.format(route)
     route += _query(query)
     return route
+
+
+def unchecked_root_redirect(path):
+    return simulation_db.SCHEMA_COMMON.rootRedirectUri.get(path)
 
 
 def _query(query):

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -25,12 +25,6 @@ import werkzeug.exceptions
 #: route for sirepo.srunit
 srunit_uri = None
 
-#: optional parameter that consumes rest of parameters
-PATH_INFO_CHAR = '*'
-
-#: route parsing
-_PARAM_RE = re.compile(r'^([\?\*]?)<(.+?)>$')
-
 #: prefix for api functions
 _FUNC_PREFIX = 'api_'
 
@@ -295,7 +289,7 @@ def _split_uri(uri):
     for p in parts:
         assert not in_path_info, \
             'path_info parameter={} must be last: next={}'.format(rp.name, p)
-        m = _PARAM_RE.search(p)
+        m = re.search(f"^{sirepo.uri.PARAM_RE.format('(.+?)')}$", p)
         if not m:
             assert first is None, \
                 'too many non-parameter components of uri={}'.format(uri)
@@ -305,7 +299,7 @@ def _split_uri(uri):
         params.append(rp)
         rp.is_optional = bool(m.group(1))
         if rp.is_optional:
-            rp.is_path_info = m.group(1) == PATH_INFO_CHAR
+            rp.is_path_info = m.group(1) == sirepo.uri.PATH_INFO_CHAR
             in_path_info = rp.is_path_info
         else:
             rp.is_path_info = False

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -26,7 +26,7 @@ import werkzeug.exceptions
 srunit_uri = None
 
 #: optional parameter that consumes rest of parameters
-_PATH_INFO_CHAR = '*'
+PATH_INFO_CHAR = '*'
 
 #: route parsing
 _PARAM_RE = re.compile(r'^([\?\*]?)<(.+?)>$')
@@ -212,7 +212,7 @@ def _dispatch(path):
                     raise sirepo.util.raise_not_found('{}: uri missing parameter ({})', path, p.name)
                 break
             if p.is_path_info:
-                kwargs[p.name] = '/'.join([x.lstrip(_PATH_INFO_CHAR) for x in parts])
+                kwargs[p.name] = '/'.join(parts)
                 parts = None
                 break
             kwargs[p.name] = parts.pop(0)
@@ -305,7 +305,7 @@ def _split_uri(uri):
         params.append(rp)
         rp.is_optional = bool(m.group(1))
         if rp.is_optional:
-            rp.is_path_info = m.group(1) == _PATH_INFO_CHAR
+            rp.is_path_info = m.group(1) == PATH_INFO_CHAR
             in_path_info = rp.is_path_info
         else:
             rp.is_path_info = False


### PR DESCRIPTION
@robnagler one possible issue: the URLS are formatted like v.radia.run:8000/*elegant in the address bar. Is this what you want or should the * be removed?