### PR TITLE
Fix #2791 - missing condition on values in parser

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1304,7 +1304,7 @@ SIREPO.app.directive('numberList', function() {
                 $scope.field = $scope.values.join(', ');
             };
             $scope.parseValues = function() {
-                if ($scope.field) {
+                if ($scope.field && ! $scope.values) {
                     $scope.values = $scope.field.split(/\s*,\s*/);
                 }
                 return $scope.values;


### PR DESCRIPTION
I had removed the condition on ```$scope.values``` to keep illegal values from even showing up in the text box.  In the interest of expediency I have put it back