### PR TITLE
Fix #2778. Kill agents in agent_starting_timeout_handler.

### DIFF
--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -271,8 +271,9 @@ class DriverBase(PKDict):
             )
             self._agent_starting_timeout = None
 
-    def _agent_starting_timeout_handler(self):
+    async def _agent_starting_timeout_handler(self):
         pkdlog('{} timeout={}', self, self.cfg.agent_starting_secs)
+        await self.kill()
         self.free_resources(internal_error='timeout waiting for agent to start')
 
     def _receive(self, msg):


### PR DESCRIPTION
Agents may still be alive even if we never received an alive message
from them. We should make an attempt to kill them to eliminate
"zombie" agents consuming resources even though the supervisor
is unaware of them.