### PR TITLE
Fix #2805. Use opposite of decrease/increase for fixing time step.

### DIFF
--- a/sirepo/template/jspec.py
+++ b/sirepo/template/jspec.py
@@ -445,13 +445,13 @@ def _get_time_step_warning(run_dir):
     if s < 0.25 * r:
         w = (
             'The time step is too small. This can lead to long run times.\n'
-            'Please consider decreasing the total time and/or increasing\n'
+            'Please consider increasing the total time and/or decreasing\n'
             'the number of steps.'
         )
     elif s > 4 * r:
         w = (
             'The time step is too large. This can lead to innacurate results.\n'
-            'Please consider increasing the total time and/or decreasing\n'
+            'Please consider decreasing the total time and/or increasing\n'
             'the number of steps.'
         )
     return w


### PR DESCRIPTION
Apparently division was too complicated for me:/