### PR TITLE
Fix #2779. Remove fastcgi sock file in terminate.

### DIFF
--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -333,18 +333,18 @@ class _Dispatcher(PKDict):
         if not self.fastcgi_cmd:
             m = msg.copy()
             m.jobCmd = 'fastcgi'
-            self._fastcgi_file = cfg.fastcgi_sock_dir.join(
+            self.fastcgi_file = cfg.fastcgi_sock_dir.join(
                 f'sirepo_job_cmd-{cfg.agent_id:8}.sock',
             )
             self._fastcgi_msg_q = sirepo.tornado.Queue(1)
-            pkio.unchecked_remove(self._fastcgi_file)
-            m.fastcgiFile = self._fastcgi_file
+            pkio.unchecked_remove(self.fastcgi_file)
+            m.fastcgiFile = self.fastcgi_file
             # Runs in a agent's directory, but chdir's to real runDirs
             m.runDir = pkio.py_path()
             # Kind of backwards, but it makes sense since we need to listen
             # so _do_fastcgi can connect
             self._fastcgi_remove_handler = tornado.netutil.add_accept_handler(
-                tornado.netutil.bind_unix_socket(str(self._fastcgi_file)),
+                tornado.netutil.bind_unix_socket(str(self.fastcgi_file)),
                 self._fastcgi_accept,
             )
             # last thing, because of await: start fastcgi process
@@ -536,6 +536,8 @@ class _Cmd(PKDict):
 
 class _FastCgiCmd(_Cmd):
     def destroy(self):
+        pkio.unchecked_remove(self.dispatcher.fastcgi_file)
+        self.dispatcher.fastcgi_file = None
         self.dispatcher.fastcgi_cmd = None
         super().destroy()
 


### PR DESCRIPTION
The file is now in a public namespace (/tmp) so we need to cleanup
after ourselves.