### PR TITLE
Fix #2827. Strip * from url without optional params

### DIFF
--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1754,7 +1754,8 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, localR
             }
         }
         // POSIT: ? and * are optional parameter chars sirepo.uri_router
-        url = url.replace(/\/[\?\*]<[^>]+>/g, '');
+        url = url.replace(/\/\?<[^>]+>/g, '');
+        url = url.replace(/\*/g, '');
         url = url.replace(/\/\?/g, '/');
         var missing = url.match(/<[^>]+>/g);
         if (missing) {


### PR DESCRIPTION
@robnagler in https://github.com/radiasoft/sirepo/commit/d8ea1bab46d53e05ed40c59d87e3acd76912f310#r41568979 we talked about changing the regex to strip '*' (and '?') from urls. That regex doesn't work. The url coming for login before any manipulation looks like /*elegant. So I propose this.