### PR TITLE
Fix #2911. Do not show epoch count

### DIFF
--- a/sirepo/package_data/static/js/ml.js
+++ b/sirepo/package_data/static/js/ml.js
@@ -231,6 +231,10 @@ SIREPO.app.controller('ClassificationController', function(appState, frameCache,
         }
     };
 
+    self.simShowCompletionState = function() {
+        return false;
+    };
+
     self.simState = persistentSimulation.initSimulationState(self);
 
     self.simState.errorMessage = function() {

--- a/sirepo/package_data/static/js/ml.js
+++ b/sirepo/package_data/static/js/ml.js
@@ -231,8 +231,8 @@ SIREPO.app.controller('ClassificationController', function(appState, frameCache,
         }
     };
 
-    self.simShowCompletionState = function() {
-        return false;
+    self.simCompletionState = function(statusText) {
+        return '';
     };
 
     self.simState = persistentSimulation.initSimulationState(self);

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -1480,11 +1480,8 @@ SIREPO.app.directive('simulationStoppedStatus', function(authState) {
                 var s = SIREPO.APP_SCHEMA.strings;
                 var f = $scope.simState.getFrameCount();
                 var c = f > 0 ? s.completionState : '';
-                if (
-                    $scope.simState.controller.simShowCompletionState &&
-                        ! $scope.simState.controller.simShowCompletionState()
-                ) {
-                    c = '';
+                if ($scope.simState.controller.simCompletionState) {
+                    c = $scope.simState.controller.simCompletionState(c);
                 }
                 var a = {state: $scope.simState.stateAsText(), frameCount: f};
                 return  $sce.trustAsHtml(

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -1480,6 +1480,12 @@ SIREPO.app.directive('simulationStoppedStatus', function(authState) {
                 var s = SIREPO.APP_SCHEMA.strings;
                 var f = $scope.simState.getFrameCount();
                 var c = f > 0 ? s.completionState : '';
+                if (
+                    $scope.simState.controller.simShowCompletionState &&
+                        ! $scope.simState.controller.simShowCompletionState()
+                ) {
+                    c = '';
+                }
                 var a = {state: $scope.simState.stateAsText(), frameCount: f};
                 return  $sce.trustAsHtml(
                     '<div>' +


### PR DESCRIPTION
We just went through cleaning up this bit of code and [removing the ability](https://github.com/radiasoft/sirepo/commit/370e8da108b0e0350d1c86f0a4e3ead154ce72e2) for controllers to define the text. I added in back in some control. I'm not sure what the right way to handle this case is. The regression tab needs a different completionState string (`: {frameCount} epochs`) than the classification tab (no epochs) in the ml app.