### PR TITLE
Fix #2912. Correct confusion_matrix heatmap labels

### DIFF
--- a/sirepo/package_data/static/js/ml.js
+++ b/sirepo/package_data/static/js/ml.js
@@ -508,8 +508,8 @@ SIREPO.app.directive('heatmapModifications', function() {
                 for (let i = 0 ; i < data.z_matrix.length; i++) {
                     for (let j = 0; j < data.z_matrix[i].length; j++) {
                         commonAttributes('.x', data.z_matrix[i][j], CLASS_RESULT)
-                            .attr('x', elementPosition(i, 'width'))
-                            .attr('y', elementPosition(j, 'height'));
+                            .attr('x', elementPosition(j, 'width'))
+                            .attr('y', elementPosition(i, 'height'));
 
                     }
                 }

--- a/sirepo/template/ml.py
+++ b/sirepo/template/ml.py
@@ -273,9 +273,9 @@ def _compute_numpy_info(path):
 def _confusion_matrix_to_heatmap_report(frame_args, filename, title):
     r = pkjson.load_any(frame_args.run_dir.join(filename))
     a = None
-    for i, _ in enumerate(r.matrix):
-        for j, v in enumerate(r.matrix[i]):
-            t = np.repeat([[i, j]], v, axis=0)
+    for y, _ in enumerate(r.matrix):
+        for x, v in enumerate(r.matrix[y]):
+            t = np.repeat([[x, y]], v, axis=0)
             a = t if a is None else np.vstack([t, a])
     return template_common.heatmap(
         a,


### PR DESCRIPTION
The x dimension on the heatmap corresponds to the i (row) in the
confusion_matrix output. The y corresponds to the j (column).