### PR TITLE
Fix #2934. Remove "simulation" from ML app.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ pykern.pksetup.setup(
         'Authlib>=0.13',
         'Flask>=1.1',
         'SQLAlchemy',
-        'SQLAlchemy',
         'aenum',
         'asyncssh',
         'cryptography>=2.8',

--- a/sirepo/package_data/static/html/elegant-visualization.html
+++ b/sirepo/package_data/static/html/elegant-visualization.html
@@ -17,7 +17,7 @@
               </div>
             </div>
             <div class="col-sm-6 pull-right">
-              <button class="btn btn-default" data-ng-click="visualization.simState.cancelSimulation()">End Simulation</button>
+              <button class="btn btn-default" data-ng-click="visualization.simState.cancelSimulation()">{{ visualization.stopButtonLabel() }}</button>
             </div>
           </form>
           <form name="form" class="form-horizontal" autocomplete="off" novalidate data-ng-show="visualization.simState.isStopped()">
@@ -36,7 +36,7 @@
             </div>
             <!--<div data-run-simulation-fields=""></div>-->
             <div class="col-sm-6 pull-right" data-ng-show="visualization.simState.isStopped()">
-              <button class="btn btn-default" data-ng-click="visualization.startSimulation()">Start New Simulation</button>
+              <button class="btn btn-default" data-ng-click="visualization.startSimulation()">{{ visualization.startButtonLabel() }}</button>
             </div>
           </form>
       </div>

--- a/sirepo/package_data/static/html/warpvnd-visualization.html
+++ b/sirepo/package_data/static/html/warpvnd-visualization.html
@@ -35,7 +35,7 @@
             <div class="form-group">
               <div data-ng-if="! visualization.warpvndService.isEGunMode()" data-model-field="'num_steps'" data-model-name="'simulationGrid'" data-label-size="4"></div>
               <div class="col-sm-5 pull-right">
-                <button class="btn btn-default" data-ng-click="$parent.startSimulation()">Start New Simulation</button>
+                <button class="btn btn-default" data-ng-click="$parent.startSimulation()">{{ visualization.startButtonLabel() }}</button>
               </div>
             </div>
           </div>

--- a/sirepo/package_data/static/js/elegant.js
+++ b/sirepo/package_data/static/js/elegant.js
@@ -440,7 +440,7 @@ SIREPO.app.controller('LatticeController', function(latticeService) {
     };
 });
 
-SIREPO.app.controller('VisualizationController', function(appState, elegantService, frameCache, panelState, persistentSimulation, $rootScope, $scope) {
+SIREPO.app.controller('VisualizationController', function(appState, elegantService, frameCache, panelState, persistentSimulation, stringsService, $rootScope, $scope) {
     var self = this;
     self.simScope = $scope;
     self.appState = appState;
@@ -619,8 +619,16 @@ SIREPO.app.controller('VisualizationController', function(appState, elegantServi
         return '';
     };
 
+    self.startButtonLabel = function() {
+        return stringsService.startButtonLabel();
+    };
+
     self.startSimulation = function() {
         self.simState.saveAndRunSimulation('simulation');
+    };
+
+    self.stopButtonLabel = function() {
+        return stringsService.stopButtonLabel();
     };
 
     self.simState = persistentSimulation.initSimulationState(self);

--- a/sirepo/package_data/static/js/irad.js
+++ b/sirepo/package_data/static/js/irad.js
@@ -317,7 +317,7 @@ SIREPO.app.directive('appHeader', function(appState, panelState) {
 	},
         template: [
             '<div data-app-header-brand="nav"></div>',
-            '<div data-app-header-left="nav" data-simulations-link-text="Studies"></div>',
+            '<div data-app-header-left="nav"></div>',
             '<div data-app-header-right="nav">',
               '<app-header-right-sim-loaded>',
 		'<div data-sim-sections="">',

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -787,15 +787,6 @@ SIREPO.app.controller('RadiaVisualizationController', function (appState, errorS
     };
 
     self.simState = persistentSimulation.initSimulationState(self);
-
-    self.simState.startButtonLabel = function() {
-        return 'Solve';
-    };
-
-    self.simState.stopButtonLabel = function() {
-        return 'Cancel';
-    };
-
 });
 
 

--- a/sirepo/package_data/static/js/rs4pi.js
+++ b/sirepo/package_data/static/js/rs4pi.js
@@ -285,31 +285,36 @@ SIREPO.app.directive('appHeader', function(appState, fileManager, panelState, rs
         },
         template: [
             '<div data-app-header-brand="nav"></div>',
-            '<div data-app-header-left="nav" data-simulations-link-text="Studies"></div>',
+            '<div data-app-header-left="nav"></div>',
             '<ul class="nav navbar-nav navbar-right" data-login-menu=""></ul>',
             '<ul class="nav navbar-nav navbar-right" data-ng-show="isLoaded()">',
               '<li data-ng-class="{active: nav.isActive(\'source\')}"><a href data-ng-click="nav.openSection(\'source\')"><span class="glyphicon glyphicon-equalizer"></span> Structure</a></li>',
               '<li data-ng-show="rs4piService.hasDoseFrames()" data-ng-class="{active: nav.isActive(\'dose\')}"><a href data-ng-click="nav.openSection(\'dose\')"><span class="glyphicon glyphicon-dashboard"></span> Dose</a></li>',
             '</ul>',
             '<ul class="nav navbar-nav navbar-right" data-ng-show="nav.isActive(\'simulations\')">',
-              '<li><a href data-ng-click="importDicomModal()"><span class="glyphicon glyphicon-plus sr-small-icon"></span><span class="glyphicon glyphicon-file"></span> Import DICOM</a></li>',
+              '<li><a href data-ng-click="importDicomModal()"><span class="glyphicon glyphicon-plus sr-small-icon"></span><span class="glyphicon glyphicon-file"></span> {{ newSimulationLabel() }}</a></li>',
               '<li><a href data-ng-click="showNewFolderModal()"><span class="glyphicon glyphicon-plus sr-small-icon"></span><span class="glyphicon glyphicon-folder-close"></span> New Folder</a></li>',
             '</ul>',
 
         ].join(''),
-        controller: function($scope) {
+        controller: function($scope, stringsService) {
             $scope.rs4piService = rs4piService;
-            $scope.isLoaded = function() {
-                return appState.isLoaded();
-            };
-            $scope.showNewFolderModal = function() {
-                appState.models.simFolder.parent = fileManager.defaultCreationFolderPath();
-                panelState.showModalEditor('simFolder');
-            };
             $scope.importDicomModal = function() {
                 $('#dicom-import').modal('show');
             };
 
+            $scope.isLoaded = function() {
+                return appState.isLoaded();
+            };
+
+            $scope.newSimulationLabel = function() {
+                return stringsService.newSimulationLabel();
+            };
+
+            $scope.showNewFolderModal = function() {
+                appState.models.simFolder.parent = fileManager.defaultCreationFolderPath();
+                panelState.showModalEditor('simFolder');
+            };
         },
     };
 });

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -401,7 +401,7 @@ SIREPO.app.directive('confirmationModal', function() {
     };
 });
 
-SIREPO.app.directive('copyConfirmation', function(appState, fileManager) {
+SIREPO.app.directive('copyConfirmation', function(appState, fileManager, stringsService) {
     return {
         restrict: 'A',
         scope: {
@@ -410,7 +410,7 @@ SIREPO.app.directive('copyConfirmation', function(appState, fileManager) {
             disabled: '<',
         },
         template: [
-            '<div data-confirmation-modal="" data-id="sr-copy-confirmation" data-title="Copy Simulation" data-ok-text="Create Copy" data-ok-clicked="copy()">',
+            '<div data-confirmation-modal="" data-id="sr-copy-confirmation" data-title="Copy {{ ::stringsService.formatKey(\'simulationDataType\') }}" data-ok-text="Create Copy" data-ok-clicked="copy()">',
               '<form class="form-horizontal" autocomplete="off">',
                 '<div class="form-group">',
                 '<label class="col-sm-3 control-label">New Name</label>',
@@ -429,6 +429,7 @@ SIREPO.app.directive('copyConfirmation', function(appState, fileManager) {
             '</div>',
         ].join(''),
         controller: function($scope) {
+            $scope.stringsService = stringsService;
             $scope.showFolders = function () {
                 return fileManager.getUserFolderPaths().length > 1;
             };
@@ -1457,6 +1458,7 @@ SIREPO.app.directive('simulationStoppedStatus', function(authState) {
         ].join(''),
         controller: function(appState, stringsService, $sce, $scope) {
 
+            //TODO(pjm): move into stringsService
             function format(template, args) {
                 return template.replace(
                     /{(\w*)}/g,
@@ -1485,7 +1487,7 @@ SIREPO.app.directive('simulationStoppedStatus', function(authState) {
                 }
                 const a = {
                     frameCount: f,
-                    typeOfSimulation: stringsService.ucfirst(s.typeOfSimulation),
+                    typeOfSimulation: stringsService.formatKey('typeOfSimulation'),
                     state: $scope.simState.stateAsText()
                 };
                 return  $sce.trustAsHtml(
@@ -1986,9 +1988,7 @@ SIREPO.app.directive('appHeaderLeft', function(appState, authState, panelState) 
         ].join(''),
         controller: function($scope, stringsService) {
             $scope.authState = authState;
-            $scope.simulationsLinkText = stringsService.ucfirst(
-                SIREPO.APP_SCHEMA.strings.simulationDataTypePlural
-            );
+            $scope.simulationsLinkText = stringsService.formatKey('simulationDataTypePlural');
 
             $scope.showTitle = function() {
                 return appState.isLoaded();
@@ -2239,7 +2239,7 @@ SIREPO.app.directive('importDialog', function(appState, fileManager, fileUpload,
     };
 });
 
-SIREPO.app.directive('settingsMenu', function(appDataService, appState, fileManager, panelState, requestSender, $compile, $window, $timeout) {
+SIREPO.app.directive('settingsMenu', function(appDataService, appState, fileManager, panelState, requestSender, stringsService, $compile, $timeout, $window) {
 
     return {
         restrict: 'A',
@@ -2266,7 +2266,7 @@ SIREPO.app.directive('settingsMenu', function(appDataService, appState, fileMana
                     '<li data-ng-if="! isExample()"><a href data-target="#delete-confirmation" data-toggle="modal"><span class="glyphicon glyphicon-trash"></span> Delete</a></li>',
                     '<li data-ng-if="hasRelatedSimulations()" class="divider"></li>',
                     '<li data-ng-if="hasRelatedSimulations()" class="sr-dropdown-submenu">',
-                      '<a href><span class="glyphicon glyphicon-menu-left"></span> Related Simulations</a>',
+                      '<a href><span class="glyphicon glyphicon-menu-left"></span> Related {{ ::stringsService.formatKey(\'simulationDataTypePlural\') }}</a>',
                       '<ul class="dropdown-menu">',
                         '<li data-ng-repeat="item in relatedSimulations"><a href data-ng-click="openRelatedSimulation(item)">{{ item.name }}</a></li>',
                       '</ul>',
@@ -2276,8 +2276,7 @@ SIREPO.app.directive('settingsMenu', function(appDataService, appState, fileMana
               '</ul>',
         ].join(''),
         controller: function($scope) {
-
-
+            $scope.stringsService = stringsService;
             var currentSimulationId = null;
 
             // We don't add this modal unless we need it
@@ -2612,9 +2611,7 @@ SIREPO.app.directive('commonFooter', function() {
             '<div data-sbatch-login-modal=""></div>',
         ].join(''),
         controller: function($scope, appState, stringsService) {
-            $scope.simulationModalTitle = stringsService.ucfirst(
-                SIREPO.APP_SCHEMA.strings.simulationDataType
-            );
+            $scope.simulationModalTitle = stringsService.formatKey('simulationDataType');
         }
     };
 });

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -916,6 +916,9 @@ SIREPO.app.factory('stringsService', function() {
 
     const strings = SIREPO.APP_SCHEMA.strings;
     return {
+        formatKey: (name) => {
+            return ucfirst(strings[name]);
+        },
         newSimulationLabel: () => {
             return strings.newSimulationLabel || `New ${ucfirst(strings.simulationDataType)}`;
         },

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -753,10 +753,6 @@ SIREPO.app.factory('appState', function(errorService, fileManager, requestQueue,
         return model;
     };
 
-    self.ucfirst = function(s) {
-        return s.charAt(0).toUpperCase() + s.slice(1);
-    };
-
     self.uniqueName = function(items, idField, template) {
         // find a unique name comparing against a list of items
         // template has {} replaced with a counter, ex. "my name (copy {})"
@@ -912,6 +908,27 @@ SIREPO.app.factory('notificationService', function(cookieService, $sce) {
 
     return self;
 });
+
+SIREPO.app.factory('stringsService', function() {
+    function ucfirst(str) {
+        return str.charAt(0).toUpperCase() + str.slice(1);
+    }
+
+    const strings = SIREPO.APP_SCHEMA.strings;
+    return {
+        newSimulationLabel: () => {
+            return strings.newSimulationLabel || `New ${ucfirst(strings.simulationDataType)}`;
+        },
+        startButtonLabel: () => {
+            return `Start New ${ucfirst(strings.typeOfSimulation)}`;
+        },
+        stopButtonLabel: () => {
+            return `End ${ucfirst(strings.typeOfSimulation)}`;
+        },
+        ucfirst: ucfirst
+    };
+});
+
 
 // manages validators for ngModels and provides other validation services
 SIREPO.app.service('validationService', function(utilities) {
@@ -1196,14 +1213,14 @@ SIREPO.app.factory('frameCache', function(appState, panelState, requestSender, $
     return self;
 });
 
-SIREPO.app.factory('authService', function(appState, authState, requestSender) {
+SIREPO.app.factory('authService', function(authState, requestSender, stringsService) {
     var self = {};
 
     function label(method) {
         if ('guest' == method) {
             return 'as Guest';
         }
-        return 'with ' + appState.ucfirst(method);
+        return 'with ' + stringsService.ucfirst(method);
     }
 
     self.methods = authState.visibleMethods.map(
@@ -2383,7 +2400,7 @@ SIREPO.app.factory('requestQueue', function($rootScope, requestSender) {
 });
 
 
-SIREPO.app.factory('persistentSimulation', function(simulationQueue, appState, authState, frameCache, $interval) {
+SIREPO.app.factory('persistentSimulation', function(simulationQueue, appState, authState, frameCache, stringsService, $interval) {
     var self = {};
     const ELAPSED_TIME_INTERVAL_SECS = 1;
 
@@ -2596,10 +2613,6 @@ SIREPO.app.factory('persistentSimulation', function(simulationQueue, appState, a
                 appState.models[state.model].jobRunMode ? 1 : 0;
         };
 
-        state.startButtonLabel = function() {
-            return 'Start New Simulation';
-        };
-
         state.stateAsText = function() {
             if (state.isStateError()) {
                 var e = state.getError();
@@ -2607,7 +2620,7 @@ SIREPO.app.factory('persistentSimulation', function(simulationQueue, appState, a
                     return 'Error: ' + e.split(/[\n\r]+/)[0];
                 }
             }
-            return appState.ucfirst(simulationStatus().state);
+            return stringsService.ucfirst(simulationStatus().state);
         };
 
         state.resetSimulation();
@@ -3273,9 +3286,9 @@ SIREPO.app.controller('LoginConfirmController', function (authState, requestSend
     return;
 });
 
-SIREPO.app.controller('LoginFailController', function (appState, requestSender, $route, $sce) {
+SIREPO.app.controller('LoginFailController', function (requestSender, stringsService, $route, $sce) {
     var self = this;
-    var t = $sce.getTrustedHtml(appState.ucfirst($route.current.params.method || ''));
+    var t = $sce.getTrustedHtml(stringsService.ucfirst($route.current.params.method || ''));
     var r = $route.current.params.reason || '';
     var login_text = function(text) {
         return '<a href="' + requestSender.formatUrlLocal('login')
@@ -3329,16 +3342,22 @@ SIREPO.app.controller('ServerUpgradedController', function (errorService, reques
     requestSender.globalRedirectRoot();
 });
 
-SIREPO.app.controller('SimulationsController', function (appState, cookieService, errorService, fileManager, notificationService, panelState, requestSender, $location, $rootScope, $sce, $scope) {
+SIREPO.app.controller('SimulationsController', function (appState, cookieService, errorService, fileManager, notificationService, panelState, requestSender, stringsService, $location, $rootScope, $sce, $scope) {
     var self = this;
 
     $rootScope.$broadcast('simulationUnloaded');
     var n = appState.clone(SIREPO.APP_SCHEMA.notifications.getStarted);
+    const s = SIREPO.APP_SCHEMA.strings;
     n.content = [
         '<div class="text-center"><strong>Welcome to Sirepo - ',
         $sce.getTrustedHtml(SIREPO.APP_SCHEMA.appInfo[SIREPO.APP_SCHEMA.simulationType].longName),
         '!</strong></div>',
-        'Below are some example simulations and folders containing simulations. Click on the simulation to open and view simulation results. You can create a new simulation by selecting the New Simulation link above.',
+        `Below are some example ${s.simulationDataTypePlural}` +
+            ` and folders containing ${s.simulationDataTypePlural}.` +
+            ` Click on the ${s.simulationDataType}` +
+            ` to open and view the ${s.simulationDataType} results.` +
+            ` You can create a new ${s.simulationDataType}` +
+            ` by selecting the "${stringsService.newSimulationLabel()}" link above.`
     ].join('');
     notificationService.addNotification(n);
 

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -2140,7 +2140,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
                   '</div>',
                 '</div>',
                 '<div class="col-sm-6 pull-right" data-ng-show="! isFluxWithApproximateMethod()">',
-                  '<button class="btn btn-default" data-ng-click="cancelPersistentSimulation()">End Simulation</button>',
+                  '<button class="btn btn-default" data-ng-click="cancelPersistentSimulation()">{{ stopButtonLabel() }}</button>',
                 '</div>',
               '</div>',
               '<div data-ng-show="simState.isStopped() && ! isFluxWithApproximateMethod()">',
@@ -2157,12 +2157,12 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
                   '</div>',
                 '</div>',
                 '<div class="col-sm-6 pull-right">',
-                  '<button class="btn btn-default" data-ng-click="startSimulation()">Start New Simulation</button>',
+                  '<button class="btn btn-default" data-ng-click="startSimulation()">{{ startButtonLabel() }}</button>',
                 '</div>',
               '</div>',
             '</form>',
         ].join(''),
-        controller: function($scope, appState, authState) {
+        controller: function($scope, appState, authState, stringsService) {
             var clientFields = ['colorMap', 'aspectRatio', 'plotScale'];
             var serverFields = ['intensityPlotsWidth', 'rotateAngle', 'rotateReshape'];
             var oldModel = null;
@@ -2223,6 +2223,14 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
             $scope.isFluxWithApproximateMethod = function() {
                 return $scope.model === 'fluxAnimation'
                     && appState.isLoaded() && appState.models.fluxAnimation.method == -1;
+            };
+
+            $scope.startButtonLabel = function() {
+                return stringsService.startButtonLabel();
+            };
+
+            $scope.stopButtonLabel = function() {
+                return stringsService.stopButtonLabel();
             };
 
             $scope.startSimulation = function() {

--- a/sirepo/package_data/static/js/warppba.js
+++ b/sirepo/package_data/static/js/warppba.js
@@ -68,10 +68,6 @@ SIREPO.app.controller('WarpPBADynamicsController', function(appState, frameCache
     };
 
     self.simState = persistentSimulation.initSimulationState(self);
-
-    self.simState.initMessage = function() {
-        return 'Initializing Laser Pulse and Plasma';
-    };
 });
 
 SIREPO.app.controller('WarpPBASourceController', function(appState, frameCache, warpPBAService, $scope) {

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -862,7 +862,7 @@ SIREPO.app.controller('OptimizationController', function (appState, frameCache, 
     };
 });
 
-SIREPO.app.controller('VisualizationController', function (appState, errorService, frameCache, panelState, requestSender, vtkPlotting, warpvndService, $scope) {
+SIREPO.app.controller('VisualizationController', function (appState, errorService, frameCache, panelState, requestSender, stringsService, vtkPlotting, warpvndService, $scope) {
     var self = this;
     self.warpvndService = warpvndService;
 
@@ -908,6 +908,10 @@ SIREPO.app.controller('VisualizationController', function (appState, errorServic
     $scope.$on('fieldAnimation.summaryData', function (evt, data) {
         self.ranIn3d = data.runMode3d;
     });
+
+    self.startButtonLabel = function() {
+        return stringsService.startButtonLabel();
+    };
 
     $scope.$on('fieldAnimation.editor.show', function () {
         panelState.showField('fieldAnimation', 'axes', warpvndService.is3D() && self.ranIn3d);
@@ -2654,7 +2658,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, frameCache, pan
                     '</div>',
                   '</div>',
                   '<div class="col-sm-6 pull-right">',
-                    '<button class="btn btn-default" data-ng-click="simState.cancelSimulation()">End Simulation</button>',
+                    '<button class="btn btn-default" data-ng-click="simState.cancelSimulation()">{{ stopButtonLabel() }}</button>',
                   '</div>',
                 '</form>',
                 '<form name="form" class="form-horizontal" autocomplete="off" novalidate data-ng-show="simState.isStopped()">',
@@ -2662,7 +2666,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, frameCache, pan
                 '</form>',
             '</div>',
         ].join(''),
-        controller: function($scope) {
+        controller: function($scope, stringsService) {
             var SINGLE_PLOTS = ['particleAnimation', 'impactDensityAnimation', 'particle3d'];
             var self = this;
             self.simScope = $scope;
@@ -2694,6 +2698,11 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, frameCache, pan
             $scope.startSimulation = function() {
                 $scope.simState.saveAndRunSimulation(['simulation', 'simulationGrid']);
             };
+
+            $scope.stopButtonLabel = function() {
+                return stringsService.stopButtonLabel();
+            };
+
 
             $scope.simState = persistentSimulation.initSimulationState(self);
         },

--- a/sirepo/package_data/static/json/irad-schema.json
+++ b/sirepo/package_data/static/json/irad-schema.json
@@ -77,6 +77,10 @@
             "libFilePrefix": ["", "String"]
         }
     },
+    "strings": {
+        "simulationDataType": "study",
+        "simulationDataTypePlural": "studies"
+    },
     "view": {
         "components": {
             "title": "Components",

--- a/sirepo/package_data/static/json/ml-schema.json
+++ b/sirepo/package_data/static/json/ml-schema.json
@@ -245,7 +245,10 @@
         "simulationStatus": {}
     },
     "strings": {
-        "completionState": ": {frameCount} epochs"
+        "completionState": ": {frameCount} epochs",
+        "simulationDataType": "dataset",
+        "simulationDataTypePlural": "datasets",
+        "typeOfSimulation": "training"
     },
     "view": {
         "columnChooser": {
@@ -373,7 +376,7 @@
             "advanced": []
         },
         "simulationSettings": {
-            "title": "Simulation Settings",
+            "title": "Training Settings",
             "basic": [
                 "classificationAnimation.classifier",
                 "knnClassification.kmin",

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -406,7 +406,8 @@
         }
     },
     "strings": {
-        "completionState": ""
+        "completionState": "",
+        "typeOfSimulation": "solve"
     },
     "view": {
         "circlePath": {

--- a/sirepo/package_data/static/json/rs4pi-schema.json
+++ b/sirepo/package_data/static/json/rs4pi-schema.json
@@ -104,6 +104,11 @@
             "description": ["Study Description", "String"]
         }
     },
+    "strings": {
+        "newSimulationLabel": "Import DICOM",
+        "simulationDataType": "study",
+        "simulationDataTypePlural": "studies"
+    },
     "view": {
         "dicomAnimation": {
             "title": "DICOM Viewer",

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -431,8 +431,11 @@
             }
         },
         "strings": {
-            "simulationState": "Simulation {state}",
-            "completionState": ": {frameCount} animation frames"
+            "completionState": ": {frameCount} animation frames",
+            "simulationDataType": "simulation",
+            "simulationDataTypePlural": "simulations",
+            "simulationState": "{typeOfSimulation} {state}",
+            "typeOfSimulation": "simulation"
         },
         "view": {
             "simDoc": {

--- a/sirepo/package_data/static/json/warppba-schema.json
+++ b/sirepo/package_data/static/json/warppba-schema.json
@@ -264,6 +264,9 @@
         },
         "simulationStatus": {}
     },
+    "strings": {
+        "initMessage": "Initializing Laser Pulse and Plasma"
+    },
     "view": {
         "beamAnimation": {
             "title": "Electron Beam Animation",

--- a/sirepo/srschema.py
+++ b/sirepo/srschema.py
@@ -162,7 +162,7 @@ def validate(schema):
     for t in schema.dynamicModules:
         for src in schema.dynamicModules[t]:
             pkresource.filename(src[1:])
-
+    _validate_strings(schema.strings)
 
 def _validate_cookie_def(c_def):
     """Validate the cookie definitions in the schema
@@ -202,6 +202,7 @@ def _validate_enum(val, sch_field_info, sch_enums):
     if str(val) not in map(lambda enum: str(enum[0]), sch_enums[type]):
         raise AssertionError(util.err(sch_enums, 'enum {} value {} not in schema', type, val))
 
+
 def _validate_model_name(model_name):
     """Ensure model name contain no special characters
 
@@ -211,6 +212,7 @@ def _validate_model_name(model_name):
 
     if not re.search(r'^[a-z_]\w*$', model_name, re.IGNORECASE):
         raise AssertionError(util.err(model_name, 'model name must be a Python identifier'))
+
 
 def _validate_number(val, sch_field_info):
     """Ensure the value of a numeric field falls within the supplied limits (if any)
@@ -237,3 +239,12 @@ def _validate_number(val, sch_field_info):
             return
         if fv > fmax:
             raise AssertionError(util.err(sch_field_info, 'numeric value {} out of range', val))
+
+
+def _validate_strings(strings):
+    c = 3
+    d = strings.simulationDataType[:c]
+    p = strings.simulationDataTypePlural[:c]
+    assert d == p, \
+        (f'strings.simulationDataType={d} does not appear to be the same as' +
+         f'strings.simulationDataTypePlural={p}')


### PR DESCRIPTION
Simulation was removed from ML app. In addition, a refactor to
move more strings onto the schema and to create consistency in messaging.
For example, in the "Welcome text" when the link to add a new simulation
says "New Dataset" then the welcome text will also say "New Dataset".
Previosly it would have said "New Simulation".