### PR TITLE
Fix #2927 radia example design tab error

### DIFF
--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -15,6 +15,7 @@ _PROD_FOSS_CODES = frozenset((
     'madx',
     'ml',
     'opal',
+    'radia',
     'shadow',
     'srw',
     'synergia',
@@ -28,7 +29,6 @@ _PROD_FOSS_CODES = frozenset((
 _NON_PROD_FOSS_CODES = frozenset((
     'irad',
     'myapp',
-    'radia',
     'rcscon',
     'rs4pi',
 ))

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -270,8 +270,8 @@ SIREPO.app.controller('RadiaSourceController', function (appState, geometry, pan
         var copy = appState.clone(o);
         copy.name = newObjectName(copy);
         addObject(copy);
+        self.editObject(copy);
     };
-
 
     self.editTool = function(tool) {
         if (tool.isInactive) {
@@ -440,7 +440,6 @@ SIREPO.app.controller('RadiaSourceController', function (appState, geometry, pan
             self.getObject(oId).groupId = o.id;
         //    ++n;
         });
-        self.editObject(o);
         //if (n > 0) {
         //    let z = groupBounds(o.members);
         //    o.size = '0,0,0';

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -11,10 +11,10 @@ SIREPO.app.config(function() {
           '<div data-color-picker="" data-form="form" data-color="model.color" data-model-name="modelName" data-model="model" data-field="field" data-default-color="defaultColor"></div>',
         '</div>',
         '<div data-ng-switch-when="FloatStringArray" class="col-sm-7">',
-            '<div data-number-list="" data-field="model[field]" data-info="info" data-type="Float" data-count=""></div>',
+            '<div data-number-list="" data-model="model" data-field="model[field]" data-info="info" data-type="Float" data-count=""></div>',
         '</div>',
         '<div data-ng-switch-when="IntStringArray" class="col-sm-7">',
-            '<div data-number-list="" data-field="model[field]" data-info="info" data-type="Integer" data-count=""></div>',
+            '<div data-number-list="" data-model="model" data-field="model[field]" data-info="info" data-type="Integer" data-count=""></div>',
         '</div>',
         '<div data-ng-switch-when="Group" class="col-sm-12">',
           '<div data-group-editor="" data-field="model[field]" data-model="model"></div>',
@@ -440,6 +440,7 @@ SIREPO.app.controller('RadiaSourceController', function (appState, geometry, pan
             self.getObject(oId).groupId = o.id;
         //    ++n;
         });
+        self.editObject(o);
         //if (n > 0) {
         //    let z = groupBounds(o.members);
         //    o.size = '0,0,0';
@@ -953,7 +954,7 @@ SIREPO.app.directive('appHeader', function(appState, panelState) {
             '<div data-app-header-right="nav">',
               '<app-header-right-sim-loaded>',
                 '<div data-sim-sections="">',
-                  '<li class="sim-section" data-ng-class="{active: nav.isActive(\'source\')}"><a href data-ng-click="nav.openSection(\'source\')"><span class="glyphicon glyphicon-magnet"></span> Design</a></li>',
+                  '<li data-ng-if="! isExampleLoaded()" class="sim-section" data-ng-class="{active: nav.isActive(\'source\')}"><a href data-ng-click="nav.openSection(\'source\')"><span class="glyphicon glyphicon-magnet"></span> Design</a></li>',
                   '<li class="sim-section" data-ng-class="{active: nav.isActive(\'visualization\')}"><a href data-ng-click="nav.openSection(\'visualization\')"><span class="glyphicon glyphicon-picture"></span> Visualization</a></li>',
                 '</div>',
               '</app-header-right-sim-loaded>',
@@ -967,6 +968,11 @@ SIREPO.app.directive('appHeader', function(appState, panelState) {
               '</app-header-right-sim-list>',
             '</div>',
         ].join(''),
+        controller: function($scope) {
+            $scope.isExampleLoaded = function() {
+                return (appState.models.simulation || {}).isExample;
+            };
+        },
     };
 });
 
@@ -1105,10 +1111,19 @@ SIREPO.app.directive('fieldPathPicker', function(appState, panelState, radiaServ
                         radiaService.addOrModifyPath(t);
                     });
                 });
+
+                let el = $('#sr-fieldpaths-editor');
+                el.on('hidden.bs.modal', function() {
+                    appState.cancelChanges(radiaService.pathTypeModel($scope.getPathType()));
+                    $scope.$apply();
+                });
+
                 $scope.$on('cancelChanges', function(e, name) {
-                    if ($scope.pathTypeModels.indexOf(name) >= 0) {
-                        radiaService.showPathPicker(false);
+                    if ($scope.pathTypeModels.indexOf(name) < 0) {
+                        return;
                     }
+                    appState.removeModel(name);
+                    radiaService.showPathPicker(false);
                 });
                 $scope.$watch('model.path', function (m) {
                     var o = $($element).find('.modal').css('opacity');
@@ -1298,6 +1313,10 @@ SIREPO.app.directive('fieldPathTable', function(appState, panelState, radiaServi
             '</table>',
         ].join(''),
         controller: function($scope) {
+            const watchedModels = SIREPO.APP_SCHEMA.enum.PathType.map(function (e) {
+                return e[SIREPO.ENUM_INDEX_VALUE];
+            });
+
             $scope.svc = radiaService;
 
             $scope.hasPaths = function() {
@@ -1305,6 +1324,13 @@ SIREPO.app.directive('fieldPathTable', function(appState, panelState, radiaServi
             };
 
             $scope.copyPath = function(path) {
+                let copy = appState.clone(path);
+                copy.name = newPathName(copy);
+                copy.id = nextId();
+                $scope.paths.push(copy);
+                appState.saveChanges(['fieldPaths', radiaService.pathTypeModel(copy.type)], function () {
+                    $scope.editPath(copy);
+                });
             };
 
            $scope.deletePath = function(path, index) {
@@ -1329,6 +1355,14 @@ SIREPO.app.directive('fieldPathTable', function(appState, panelState, radiaServi
                });
                return res;
            };
+
+           function newPathName(path) {
+               return appState.uniqueName(appState.models.fieldPaths, 'name', path.name + ' {}');
+           }
+
+           function nextId() {
+               return appState.maxId(appState.models.fieldPaths.paths, 'id');
+           }
 
            appState.whenModelsLoaded($scope, function() {
                $scope.paths = appState.models.fieldPaths.paths;
@@ -1412,28 +1446,35 @@ SIREPO.app.directive('numberList', function() {
         restrict: 'A',
         scope: {
             field: '=',
+            model: '=',
             info: '<',
             type: '@',
             count: '@',
         },
         template: [
             '<div data-ng-repeat="defaultSelection in parseValues() track by $index" style="display: inline-block" >',
-            '<label style="margin-right: 1ex">{{ valueLabels[$index] || \'Plane \' + $index }}</label>',
-            '<input class="form-control sr-list-value" data-string-to-number="{{ numberType }}" data-ng-model="values[$index]" data-min="min" data-max="max" data-ng-change="didChange()" class="form-control" style="text-align: right" required />',
+                '<label style="margin-right: 1ex">{{ valueLabels[$index] || \'Plane \' + $index }}</label>',
+                '<input class="form-control sr-list-value" data-string-to-number="{{ numberType }}" data-ng-model="values[$index]" data-min="min" data-max="max" data-ng-change="didChange()" class="form-control" style="text-align: right" required />',
             '</div>'
         ].join(''),
-        controller: function($scope) {
+        controller: function($scope, $element) {
+
+            let lastModel = null;
             // NOTE: does not appear to like 'model.field' format
             $scope.values = null;
             $scope.numberType = $scope.type.toLowerCase();
             $scope.min = $scope.numberType === 'int' ? Number.MIN_SAFE_INTEGER : -Number.MAX_VALUE;
             $scope.max = $scope.numberType === 'int' ? Number.MAX_SAFE_INTEGER : Number.MAX_VALUE;
-            //TODO(pjm): share implementation with enumList
             $scope.valueLabels = ($scope.info[4] || '').split(/\s*,\s*/);
             $scope.didChange = function() {
                 $scope.field = $scope.values.join(', ');
             };
             $scope.parseValues = function() {
+                // values were sticking around when the model changed
+                if (! lastModel || lastModel !== $scope.model) {
+                    lastModel = $scope.model;
+                    $scope.values = null;
+                }
                 if ($scope.field && ! $scope.values) {
                     $scope.values = $scope.field.split(/\s*,\s*/);
                 }
@@ -1630,7 +1671,6 @@ SIREPO.app.directive('transformTable', function(appState, panelState, radiaServi
                     }
                     $scope.selectedItem = null;
                     if (! isEditing) {
-                        //($scope.$id, 'add', name, 'to', $scope.modelName, $scope.fieldName, $scope.field);
                         appState.models[modelName].id = nextId();
                         $scope.field.push(appState.models[modelName]);
                         isEditing = true;

--- a/sirepo/package_data/template/radia/examples/dipole.json
+++ b/sirepo/package_data/template/radia/examples/dipole.json
@@ -9,12 +9,8 @@
             "paths": [
                 {
                     "_super": "fieldPath",
-                    "beginX": -60,
-                    "beginY": 0,
-                    "beginZ": 10,
-                    "endX": 60,
-                    "endY": 0,
-                    "endZ": 10,
+                    "begin": "-60,0,10",
+                    "end": "60,0,10",
                     "id": 0,
                     "name": "X Axis Offset",
                     "numPoints": 21,

--- a/sirepo/package_data/template/radia/examples/undulator.json
+++ b/sirepo/package_data/template/radia/examples/undulator.json
@@ -1,8 +1,22 @@
 {
     "models": {
+        "fieldDisplay": {
+            "colorMap": "viridis",
+            "scaling": "linear"
+        },
          "fieldPaths": {
             "path": "line",
-            "paths": []
+            "paths": [
+                {
+                    "_super": "fieldPath",
+                    "begin": "0, -125, 0",
+                    "end": "0, 125, 0",
+                    "id": 0,
+                    "name": "Y Axis",
+                    "numPoints": 251,
+                    "type": "line"
+                }
+            ]
         },
         "geometry": {
             "name": "Undulator",
@@ -49,7 +63,7 @@
         "magnetDisplay": {
             "bgColor": "#ffffff",
             "fieldPoints": [],
-            "fieldType": "M",
+            "fieldType": "B",
             "notes": "",
             "viewType": "objects"
         },

--- a/sirepo/sim_data/rs4pi.py
+++ b/sirepo/sim_data/rs4pi.py
@@ -31,7 +31,7 @@ class SimData(sirepo.sim_data.SimDataBase):
     @classmethod
     def fixup_old_data(cls, data):
         dm = data.models
-        dm.setdefault(
+        dm.pksetdefault(
             'dicomEditorState', PKDict(),
             'doseCalculation', PKDict(selectedPTV='', selectedOARs=[]),
             'dicomDose', PKDict(frameCount=0),
@@ -50,7 +50,7 @@ class SimData(sirepo.sim_data.SimDataBase):
         if 'roiNumbers' not in x and x.get('roiNumber', None):
             x.roiNumbers = [x.roiNumber]
             del x['roiNumber']
-        dm.dicomAnimation4.setdefault('doseTransparency', 56)
+        dm.dicomAnimation4.pksetdefault('doseTransparency', 56)
 
 
     @classmethod


### PR DESCRIPTION
The design tab cannot be used with the current examples, which are built from hard-coded python.  This update hides the tab.  It also fixes some other issues:

- #2995 - the json for this example was using individual fields for point coords, which is no longer correct. It's been updated to use a single comma-delimited field
- #2996 - added a line along the y axis
- #2997 - now the copy button actually makes a copy of the path

