### PR TITLE
Support Jupyterhub under sirepo.com

### DIFF
--- a/etc/run-jupyterhub.sh
+++ b/etc/run-jupyterhub.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -eou pipefail
+
+export SIREPO_AUTH_METHODS='email'
+export SIREPO_FEATURE_CONFIG_SIM_TYPES='jupyterhublogin:srw'
+
+if [[ "${1:-}" ]]; then
+    if [[ "$#" -ne 2 ]]; then
+        echo 'Must supply no args or excatly 2 args (GitHub key and secret).'
+        exit 1
+    fi
+    export SIREPO_AUTH_GITHUB_KEY='$1'
+    export SIREPO_AUTH_GITHUB_METHOD_VISIBLE=''
+    export SIREPO_AUTH_GITHUB_SECRET='$2'
+    export SIREPO_AUTH_METHODS="$SIREPO_AUTH_METHODS:github"
+    export SIREPO_SIM_API_JUPYTERHUBLOGIN_RS_JUPYTER_MIGRATE='1'
+fi
+
+sirepo service nginx-proxy &
+sirepo service uwsgi &
+sirepo job_supervisor &
+sirepo service jupyterhub &
+
+# If one of the procs fails on startup then we want to kill
+# all others and exit.
+# Need to sleep a bit to give the procs time time to fail
+sleep 2
+if [[ $(jobs | wc -l) -eq 4 ]]; then
+    echo 'waiting'
+    jobs | wc -l
+    wait -n
+fi
+
+for p in $(jobs -p); do
+    kill "$p" > /dev/null 2>&1
+    # wait is a builtin so it can't be used with timeout.
+    # Use tail instead.
+    if ! timeout 2 tail --pid="$p" -f /dev/null; then
+        kill -9 "$p" > /dev/null 2>&1
+    fi
+done

--- a/etc/run-jupyterhub.sh
+++ b/etc/run-jupyterhub.sh
@@ -9,11 +9,11 @@ if [[ "${1:-}" ]]; then
         echo 'Must supply no args or excatly 2 args (GitHub key and secret).'
         exit 1
     fi
-    export SIREPO_AUTH_GITHUB_KEY='$1'
-    export SIREPO_AUTH_GITHUB_METHOD_VISIBLE=''
-    export SIREPO_AUTH_GITHUB_SECRET='$2'
+    export SIREPO_AUTH_GITHUB_KEY="$1"
+    export SIREPO_AUTH_GITHUB_METHOD_VISIBLE=""
+    export SIREPO_AUTH_GITHUB_SECRET="$2"
     export SIREPO_AUTH_METHODS="$SIREPO_AUTH_METHODS:github"
-    export SIREPO_SIM_API_JUPYTERHUBLOGIN_RS_JUPYTER_MIGRATE='1'
+    export SIREPO_SIM_API_JUPYTERHUBLOGIN_RS_JUPYTER_MIGRATE="1"
 fi
 
 sirepo service nginx-proxy &

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -114,7 +114,7 @@ def api_authLogout(simulation_type=None):
     if _is_logged_in():
         events.emit(
             events.Type.AUTH_LOGOUT,
-            kwargs=PKDict(uid=logged_in_user()),
+            kwargs=PKDict(uid=_get_user()),
         )
         cookie.set_value(_COOKIE_STATE, _STATE_LOGGED_OUT)
         _set_log_user()

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -473,10 +473,9 @@ def user_if_logged_in(method):
 
 
 def user_name():
-    with auth_db.thread_lock:
-       return _METHOD_MODULES[cookie.unchecked_get_value(
-           _COOKIE_METHOD,
-       )].user_name()
+    return _METHOD_MODULES[cookie.unchecked_get_value(
+        _COOKIE_METHOD,
+    )].user_name()
 
 
 def user_registration(uid):

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -112,10 +112,7 @@ def api_authLogout(simulation_type=None):
         except AssertionError:
             pass
     if _is_logged_in():
-        events.emit(
-            events.Type.AUTH_LOGOUT,
-            kwargs=PKDict(uid=_get_user()),
-        )
+        events.emit('auth_logout', PKDict(uid=_get_user()))
         cookie.set_value(_COOKIE_STATE, _STATE_LOGGED_OUT)
         _set_log_user()
     return http_reply.gen_redirect_for_app_root(req and req.type)

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -112,6 +112,9 @@ def api_authLogout(simulation_type=None):
         except AssertionError:
             pass
     if _is_logged_in():
+        # TODO(e-carlin): Do not check for jupyterhub
+        # Just emit logout event and jupyterhub will be registered
+        # In sim_api/jupyterhub register if we are in feat_conf.sim_types
         if sirepo.feature_config.cfg().jupyterhub:
             # Must be before setting _STATE_LOGGED_OUT so we can get the
             # user name of the logged in user

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -22,7 +22,6 @@ import contextlib
 import datetime
 import importlib
 import sirepo.feature_config
-import sirepo.jupyterhub
 import sirepo.template
 import sirepo.uri
 import werkzeug.exceptions

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -208,6 +208,20 @@ def logged_in_user(check_path=True):
     return u
 
 
+def logged_in_user_name():
+    u = _get_user()
+    if not _is_logged_in():
+        return None
+    m = cookie.unchecked_get_value(_COOKIE_METHOD)
+    assert u, \
+        'no user in cookie: state={} method={}'.format(
+            cookie.unchecked_get_value(_COOKIE_STATE),
+            m,
+        )
+    with auth_db.thread_lock:
+       return _METHOD_MODULES[m].UserModel.search_by(uid=u).user_name
+
+
 def login(module, uid=None, model=None, sim_type=None, display_name=None, is_mock=False, want_redirect=False):
     """Login the user
 

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -208,20 +208,6 @@ def logged_in_user(check_path=True):
     return u
 
 
-def logged_in_user_name():
-    u = _get_user()
-    if not _is_logged_in():
-        return None
-    m = cookie.unchecked_get_value(_COOKIE_METHOD)
-    assert u, \
-        'no user in cookie: state={} method={}'.format(
-            cookie.unchecked_get_value(_COOKIE_STATE),
-            m,
-        )
-    with auth_db.thread_lock:
-       return _METHOD_MODULES[m].UserModel.search_by(uid=u).user_name
-
-
 def login(module, uid=None, model=None, sim_type=None, display_name=None, is_mock=False, want_redirect=False):
     """Login the user
 
@@ -487,6 +473,13 @@ def user_if_logged_in(method):
     if m != method:
         return None
     return _get_user()
+
+
+def user_name():
+    with auth_db.thread_lock:
+       return _METHOD_MODULES[cookie.unchecked_get_value(
+           _COOKIE_METHOD,
+       )].UserModel.search_by(uid=logged_in_user()).user_name
 
 
 def user_registration(uid):

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -112,9 +112,10 @@ def api_authLogout(simulation_type=None):
         except AssertionError:
             pass
     if _is_logged_in():
-        # Emit before setting _STATE_LOGGED_OUT so any handlers
-        # can access the logged in user
-        events.emit(events.Type.AUTH_LOGOUT)
+        events.emit(
+            events.Type.AUTH_LOGOUT,
+            kwargs=PKDict(uid=logged_in_user()),
+        )
         cookie.set_value(_COOKIE_STATE, _STATE_LOGGED_OUT)
         _set_log_user()
     return http_reply.gen_redirect_for_app_root(req and req.type)

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -479,7 +479,7 @@ def user_name():
     with auth_db.thread_lock:
        return _METHOD_MODULES[cookie.unchecked_get_value(
            _COOKIE_METHOD,
-       )].UserModel.search_by(uid=logged_in_user()).user_name
+       )].user_name()
 
 
 def user_registration(uid):

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -473,9 +473,15 @@ def user_if_logged_in(method):
 
 
 def user_name():
-    return _METHOD_MODULES[cookie.unchecked_get_value(
-        _COOKIE_METHOD,
-    )].user_name()
+    u = getattr(
+        _METHOD_MODULES[cookie.unchecked_get_value(
+            _COOKIE_METHOD,
+        )],
+        'UserModel',
+    )
+    if u:
+        with auth_db.thread_lock:
+            return  u.search_by(uid=logged_in_user()).user_name
 
 
 def user_registration(uid):

--- a/sirepo/auth/basic.py
+++ b/sirepo/auth/basic.py
@@ -25,10 +25,6 @@ def require_user():
     return None
 
 
-def user_name():
-    return 'basic'
-
-
 def _cfg_uid(value):
     from sirepo import simulation_db
     if value and value == 'dev-no-validate' and pkconfig.channel_in_internal_test():

--- a/sirepo/auth/basic.py
+++ b/sirepo/auth/basic.py
@@ -25,6 +25,10 @@ def require_user():
     return None
 
 
+def user_name():
+    return 'basic'
+
+
 def _cfg_uid(value):
     from sirepo import simulation_db
     if value and value == 'dev-no-validate' and pkconfig.channel_in_internal_test():

--- a/sirepo/auth/bluesky.py
+++ b/sirepo/auth/bluesky.py
@@ -127,7 +127,3 @@ def init_apis(*args, **kwargs):
             'Shared secret between Sirepo and BlueSky server',
         ),
     )
-
-
-def user_name():
-    return 'bluesky'

--- a/sirepo/auth/bluesky.py
+++ b/sirepo/auth/bluesky.py
@@ -127,3 +127,7 @@ def init_apis(*args, **kwargs):
             'Shared secret between Sirepo and BlueSky server',
         ),
     )
+
+
+def user_name():
+    return 'bluesky'

--- a/sirepo/auth/email.py
+++ b/sirepo/auth/email.py
@@ -121,11 +121,6 @@ def init_apis(*args, **kwargs):
     auth_db.init_model(_init_model)
 
 
-def user_name():
-    with auth_db.thread_lock:
-        return AuthEmailUser.search_by(uid=auth.logged_in_user()).user_name
-
-
 def _init_model(base):
     """Creates AuthEmailUser bound to dynamic `db` variable"""
     global AuthEmailUser, UserModel

--- a/sirepo/auth/email.py
+++ b/sirepo/auth/email.py
@@ -120,6 +120,12 @@ def avatar_uri(model, size):
 def init_apis(*args, **kwargs):
     auth_db.init_model(_init_model)
 
+
+def user_name():
+    with auth_db.thread_lock:
+        return AuthEmailUser.search_by(uid=auth.logged_in_user()).user_name
+
+
 def _init_model(base):
     """Creates AuthEmailUser bound to dynamic `db` variable"""
     global AuthEmailUser, UserModel

--- a/sirepo/auth/github.py
+++ b/sirepo/auth/github.py
@@ -125,11 +125,6 @@ def init_apis(*args, **kwargs):
     auth_db.init_model(_init_model)
 
 
-def user_name():
-    with auth_db.thread_lock:
-        return AuthGithubUser.search_by(uid=auth.logged_in_user()).user_name
-
-
 class _Client(authlib.integrations.base_client.RemoteApp):
 
     def __init__(self, state):

--- a/sirepo/auth/github.py
+++ b/sirepo/auth/github.py
@@ -123,7 +123,7 @@ def init_apis(*args, **kwargs):
         method_visible=(
             True,
             _cfg_method_visible,
-            'whether or not github auth method is visible to users when enabled',
+            'github auth method is visible to users when it is an enabled method',
         ),
         secret=pkconfig.Required(str, 'Github secret'),
     )
@@ -136,7 +136,7 @@ def _cfg_method_visible(is_visible):
 
     if sirepo.feature_config.cfg().jupyterhub:
         assert not is_visible, \
-            'cannot enable github and jupyterhub'
+            'cannot make github visible and enable jupyterhub'
     return is_visible
 
 

--- a/sirepo/auth/github.py
+++ b/sirepo/auth/github.py
@@ -15,7 +15,6 @@ from sirepo import api_perm
 from sirepo import auth
 from sirepo import auth_db
 from sirepo import cookie
-from sirepo import events
 from sirepo import feature_config
 from sirepo import http_reply
 from sirepo import http_request
@@ -24,6 +23,7 @@ from sirepo import util
 import authlib.integrations.base_client
 import authlib.integrations.requests_client
 import flask
+import sirepo.events
 import sqlalchemy
 
 
@@ -56,7 +56,7 @@ def api_authGithubAuthorized():
         auth.login_fail_redirect(t, this_module, 'oauth-state', reload_js=True)
         raise AssertionError('auth.login_fail_redirect returned unexpectedly')
     d = oc.get('user').json()
-    events.emit('github_authorized', PKDict(user_name=d['login']))
+    sirepo.events.emit('github_authorized', PKDict(user_name=d['login']))
     with auth_db.thread_lock:
         u = AuthGithubUser.search_by(oauth_id=d['id'])
         if u:

--- a/sirepo/auth/github.py
+++ b/sirepo/auth/github.py
@@ -60,7 +60,7 @@ def api_authGithubAuthorized():
         auth.login_fail_redirect(t, this_module, 'oauth-state', reload_js=True)
         raise AssertionError('auth.login_fail_redirect returned unexpectedly')
     d = oc.get('user').json()
-    events.emit(events.GITHUB_AUTHORIZED, kwargs=PKDict(user_name=d['login']))
+    events.emit(events.Type.GITHUB_AUTHORIZED, kwargs=PKDict(user_name=d['login']))
     with auth_db.thread_lock:
         u = AuthGithubUser.search_by(oauth_id=d['id'])
         if u:

--- a/sirepo/auth/github.py
+++ b/sirepo/auth/github.py
@@ -120,22 +120,13 @@ def init_apis(*args, **kwargs):
         key=pkconfig.Required(str, 'Github key'),
         method_visible=(
             True,
-            _cfg_method_visible,
+            bool,
             'github auth method is visible to users when it is an enabled method',
         ),
         secret=pkconfig.Required(str, 'Github secret'),
     )
     AUTH_METHOD_VISIBLE = cfg.method_visible
     auth_db.init_model(_init_model)
-
-
-def _cfg_method_visible(is_visible):
-    import sirepo.feature_config
-
-    if sirepo.feature_config.cfg().jupyterhub:
-        assert not is_visible, \
-            'cannot make github visible and enable jupyterhub'
-    return is_visible
 
 
 class _Client(authlib.integrations.base_client.RemoteApp):

--- a/sirepo/auth/github.py
+++ b/sirepo/auth/github.py
@@ -129,6 +129,11 @@ def init_apis(*args, **kwargs):
     auth_db.init_model(_init_model)
 
 
+def user_name():
+    with auth_db.thread_lock:
+        return AuthGithubUser.search_by(uid=auth.logged_in_user()).user_name
+
+
 class _Client(authlib.integrations.base_client.RemoteApp):
 
     def __init__(self, state):

--- a/sirepo/auth/github.py
+++ b/sirepo/auth/github.py
@@ -30,9 +30,6 @@ import sqlalchemy
 
 AUTH_METHOD = 'github'
 
-#: User can see it
-AUTH_METHOD_VISIBLE = None
-
 #: Used by auth_db
 AuthGithubUser = None
 

--- a/sirepo/auth/github.py
+++ b/sirepo/auth/github.py
@@ -57,7 +57,7 @@ def api_authGithubAuthorized():
         auth.login_fail_redirect(t, this_module, 'oauth-state', reload_js=True)
         raise AssertionError('auth.login_fail_redirect returned unexpectedly')
     d = oc.get('user').json()
-    events.emit(events.Type.GITHUB_AUTHORIZED, kwargs=PKDict(user_name=d['login']))
+    events.emit('github_authorized', PKDict(user_name=d['login']))
     with auth_db.thread_lock:
         u = AuthGithubUser.search_by(oauth_id=d['id'])
         if u:

--- a/sirepo/auth/guest.py
+++ b/sirepo/auth/guest.py
@@ -86,6 +86,10 @@ def is_login_expired(res=None):
     return False
 
 
+def user_name():
+    return 'guest'
+
+
 def validate_login():
     """If expiry is configured, check timestamp
 

--- a/sirepo/auth/guest.py
+++ b/sirepo/auth/guest.py
@@ -86,10 +86,6 @@ def is_login_expired(res=None):
     return False
 
 
-def user_name():
-    return 'guest'
-
-
 def validate_login():
     """If expiry is configured, check timestamp
 

--- a/sirepo/cookie.py
+++ b/sirepo/cookie.py
@@ -63,6 +63,7 @@ def save_to_cookie(resp):
     _state().save_to_cookie(resp)
 
 
+# TODO(e-carlin): merge with set for utils
 def set_cookie_for_jupyterhub(cookie_header):
     """A cookie for authentication with jupyterhub"""
     flask.g = PKDict()

--- a/sirepo/cookie.py
+++ b/sirepo/cookie.py
@@ -29,9 +29,6 @@ _COOKIE_SENTINEL_VALUE = 'z'
 
 _SERIALIZER_SEP = ' '
 
-def delete_jupyterhub(user_name):
-    _state().jupyterhub_user_name = user_name
-
 
 def get_value(key):
     return _state()[key]
@@ -118,7 +115,6 @@ class _State(dict):
     def __init__(self, header):
         super(_State, self).__init__()
         self.crypto = None
-        self.jupyterhub_user_name = None
         self.incoming_serialized = ''
         flask.g.sirepo_cookie = self
         self._from_cookie_header(header)
@@ -144,18 +140,6 @@ class _State(dict):
             #TODO(pjm): enabling this causes self-extracting simulations to break
             #samesite='Strict',
         )
-        if self.jupyterhub_user_name:
-            import sirepo.jupyterhub
-
-            for c in (
-                    ('jupyterhub-hub-login', 'hub'),
-                    (
-                        f'jupyterhub-user-{self.jupyterhub_user_name}',
-                        f'user/{self.jupyterhub_user_name}',
-                    ),
-            ):
-                # Trailing slash is required in paths
-                resp.delete_cookie(c[0], path=f'/{sirepo.jupyterhub.cfg.uri_root}/{c[1]}/')
 
     def _crypto(self):
         if not self.crypto:

--- a/sirepo/cookie.py
+++ b/sirepo/cookie.py
@@ -5,7 +5,6 @@ u"""User state management via an HTTP cookie
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from __future__ import absolute_import, division, print_function
-
 from pykern import pkcompat
 from pykern import pkconfig
 from pykern.pkcollections import PKDict

--- a/sirepo/cookie.py
+++ b/sirepo/cookie.py
@@ -62,6 +62,8 @@ def save_to_cookie(resp):
 def set_cookie_for_utils(cookie_header=''):
     """A mock cookie for utilities"""
     flask.g = PKDict()
+    if cookie_header:
+        cookie_header = f'{cfg.http_name}={cookie_header}'
     _State(cookie_header)
     set_sentinel()
 

--- a/sirepo/cookie.py
+++ b/sirepo/cookie.py
@@ -60,18 +60,10 @@ def save_to_cookie(resp):
     _state().save_to_cookie(resp)
 
 
-# TODO(e-carlin): merge with set for utils
-def set_cookie_for_jupyterhub(cookie_header):
-    """A cookie for authentication with jupyterhub"""
-    flask.g = PKDict()
-    _State(cookie_header)
-    set_sentinel()
-
-
-def set_cookie_for_utils():
+def set_cookie_for_utils(cookie_header=''):
     """A mock cookie for utilities"""
     flask.g = PKDict()
-    _State('')
+    _State(cookie_header)
     set_sentinel()
 
 def set_sentinel(values=None):

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -5,23 +5,35 @@ u"""Sirepo events
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from pykern.pkcollections import PKDict
+import enum
 
-GITHUB_AUTHORIZED = 'github_authorized'
+class _AutoName(enum.Enum):
+    def _generate_next_value_(name, *args):
+        return name
 
-_EVENTS = (GITHUB_AUTHORIZED, )
+
+class Type(_AutoName):
+    AUTH_LOGOUT = enum.auto()
+    END_API_CALL = enum.auto()
+    GITHUB_AUTHORIZED = enum.auto()
+
 
 _HANDLERS = PKDict()
 
 
-def emit(event, kwargs):
+def emit(event, kwargs=None):
     for h in _HANDLERS[event]:
-        h(kwargs)
+        if kwargs:
+            h(kwargs)
+        else:
+            h()
 
 
 def init():
-    for e in _EVENTS:
-        _HANDLERS[e] = []
+    for t in Type:
+        _HANDLERS[t] = []
 
 
-def register(event, handler):
-    _HANDLERS[event].append(handler)
+def register(registrants):
+    for r in registrants:
+        _HANDLERS[r].append(registrants[r])

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -5,22 +5,20 @@ u"""Sirepo events
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from pykern.pkcollections import PKDict
-import enum
+from pykern.pkdebug import pkdp
+import aenum
 
 _HANDLERS = PKDict()
 
 
-def emit(event, kwargs=None):
+def emit(event, kwargs):
     for h in _HANDLERS[event]:
-        if kwargs:
-            h(kwargs)
-        else:
-            h()
+        h(kwargs or PKDict())
 
 
 def init():
-    for t in Type:
-        _HANDLERS[t] = []
+    for k in _Kind:
+        _HANDLERS[k.value] = []
 
 
 def register(registrants):
@@ -28,12 +26,8 @@ def register(registrants):
         _HANDLERS[r].append(registrants[r])
 
 
-class _AutoName(enum.Enum):
-    def _generate_next_value_(name, *args):
-        return name
-
-
-class Type(_AutoName):
-    AUTH_LOGOUT = enum.auto()
-    END_API_CALL = enum.auto()
-    GITHUB_AUTHORIZED = enum.auto()
+@aenum.unique
+class _Kind(aenum.Enum):
+    AUTH_LOGOUT = 'auth_logout'
+    END_API_CALL = 'end_api_call'
+    GITHUB_AUTHORIZED = 'github_authorized'

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -11,6 +11,15 @@ For example, when a user logs out the AUTH_LOGOUT event is emitted. Other
 areas of the code can register a callback for this event (ex to clear jupyterhub
 cookies so the user is logged out of jupyterhub too).
 
+The events:
+- 'auth_logout' emitted when a user logs out, before the cookie is cleared.
+  kwargs contains uid.
+- 'end_api_call' emitted at the end of of an http request to the flask server.
+  kwargs contains resp, the Flask response object.
+- 'github_authorized' emitted once the authorized github user is retrieved and
+  confirmed valid but before that user is logged in or the github db is updated.
+  kwargs contains user_name, the github handle.
+
 :copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
@@ -36,7 +45,7 @@ def emit(event, kwargs):
         kwargs (PKDict): optional arguments to pass to event
     """
     for h in _MAP[event]:
-        h(kwargs or PKDict())
+        h(PKDict() if kwargs is None else kwargs)
 
 
 def register(registrants):

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -18,29 +18,33 @@ from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp
 import aenum
 
-_HANDLERS = PKDict()
+#: Map of events to handlers. Note: this is the list of all possible events.
+_MAP = PKDict(
+     auth_logout=[],
+     end_api_call=[],
+     github_authorized=[],
+)
 
 
 def emit(event, kwargs):
-    for h in _HANDLERS[event]:
+    """Call the handlers for `event` with `kwargs`
+
+    Handlers will be called in registration order (FIFO).
+
+    Args:
+        event (str): one of the names in `_MAP`
+        kwargs (PKDict): optional arguments to pass to event
+    """
+    for h in _MAP[event]:
         h(kwargs or PKDict())
 
 
 def register(registrants):
+    """Register callback(s) for event(s)
+
+    Args:
+        registrants (PKDict): Key is the event and value is the callback
+    """
     for k, v in registrants.items():
-        if v not in _HANDLERS[k]:
-            _HANDLERS[k].append(v)
-
-
-def _init():
-    for k in _Kind:
-        _HANDLERS[k.value] = []
-
-
-@aenum.unique
-class _Kind(aenum.Enum):
-    AUTH_LOGOUT = 'auth_logout'
-    END_API_CALL = 'end_api_call'
-    GITHUB_AUTHORIZED = 'github_authorized'
-
-_init()
+        if v not in _MAP[k]:
+            _MAP[k].append(v)

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
-u"""Sirepo event registration and emittance.
+u"""Reigster callbacks for events and call callbacks when events are emitted.
 
-This module handles registering callbacks for events and calling the callbacks
-when the event occurs.
+Using events allows disparate areas of the code base to perform some task on
+an event without muddling the code that triggered the event. In addition events
+can be registered by configuration. This allows areas of the code to
+register/emit events when they are configured on and doesn't require if
+statements throughout the code.
 
 For example, when a user logs out the AUTH_LOGOUT event is emitted. Other
 areas of the code can register a callback for this event (ex to clear jupyterhub

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+u"""Sirepo events
+
+:copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from pykern.pkcollections import PKDict
+
+GITHUB_AUTHORIZED = 'github_authorized'
+
+_EVENTS = (GITHUB_AUTHORIZED, )
+
+_HANDLERS = PKDict()
+
+
+def emit(event, kwargs):
+    for h in _HANDLERS[event]:
+        h(kwargs)
+
+
+def init():
+    for e in _EVENTS:
+        _HANDLERS[e] = []
+
+
+def register(event, handler):
+    _HANDLERS[event].append(handler)

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -7,17 +7,6 @@ u"""Sirepo events
 from pykern.pkcollections import PKDict
 import enum
 
-class _AutoName(enum.Enum):
-    def _generate_next_value_(name, *args):
-        return name
-
-
-class Type(_AutoName):
-    AUTH_LOGOUT = enum.auto()
-    END_API_CALL = enum.auto()
-    GITHUB_AUTHORIZED = enum.auto()
-
-
 _HANDLERS = PKDict()
 
 
@@ -37,3 +26,14 @@ def init():
 def register(registrants):
     for r in registrants:
         _HANDLERS[r].append(registrants[r])
+
+
+class _AutoName(enum.Enum):
+    def _generate_next_value_(name, *args):
+        return name
+
+
+class Type(_AutoName):
+    AUTH_LOGOUT = enum.auto()
+    END_API_CALL = enum.auto()
+    GITHUB_AUTHORIZED = enum.auto()

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -22,8 +22,9 @@ def init():
 
 
 def register(registrants):
-    for r in registrants:
-        _HANDLERS[r].append(registrants[r])
+    for k, v in registrants.items():
+        if v not in _HANDLERS[k]:
+            _HANDLERS[k].append(v)
 
 
 @aenum.unique

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -16,15 +16,15 @@ def emit(event, kwargs):
         h(kwargs or PKDict())
 
 
-def init():
-    for k in _Kind:
-        _HANDLERS[k.value] = []
-
-
 def register(registrants):
     for k, v in registrants.items():
         if v not in _HANDLERS[k]:
             _HANDLERS[k].append(v)
+
+
+def _init():
+    for k in _Kind:
+        _HANDLERS[k.value] = []
 
 
 @aenum.unique
@@ -32,3 +32,5 @@ class _Kind(aenum.Enum):
     AUTH_LOGOUT = 'auth_logout'
     END_API_CALL = 'end_api_call'
     GITHUB_AUTHORIZED = 'github_authorized'
+
+_init()

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -1,5 +1,12 @@
 # -*- coding: utf-8 -*-
-u"""Sirepo events
+u"""Sirepo event registration and emittance.
+
+This module handles registering callbacks for events and calling the callbacks
+when the event occurs.
+
+For example, when a user logs out the AUTH_LOGOUT event is emitted. Other
+areas of the code can register a callback for this event (ex to clear jupyterhub
+cookies so the user is logged out of jupyterhub too).
 
 :copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -28,7 +28,6 @@ _PROD_FOSS_CODES = frozenset((
 _NON_PROD_FOSS_CODES = frozenset((
     'irad',
     'myapp',
-    'jupyterhublogin',
     'radia',
     'rcscon',
     'rs4pi',
@@ -41,8 +40,11 @@ _FOSS_CODES = _PROD_FOSS_CODES.union(_NON_PROD_FOSS_CODES)
 #: codes for which we require dynamically loaded binaries
 _PROPRIETARY_CODES = frozenset(('flash',))
 
+#: Codes that can be enabled through cfg but aren't "normally" enabled
+_CONFIGURABLE_CODES = frozenset(('jupyterhublogin',))
+
 #: all executable codes
-VALID_CODES = _FOSS_CODES.union(_PROPRIETARY_CODES)
+VALID_CODES = _FOSS_CODES.union(_PROPRIETARY_CODES, _CONFIGURABLE_CODES)
 
 
 #: Configuration

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -96,6 +96,7 @@ def _init():
         proprietary_sim_types=(set(), set, 'codes that require authorization'),
         #TODO(robnagler) make this a sim_type config like srw and warpvnd
         rs4pi_dose_calc=(False, bool, 'run the real dose calculator'),
+        rs_jupyter_migrate=(False, bool, 'give user option to migrate data from jupyter.radiasoft.org'),
         sim_types=(set(), set, 'simulation types (codes) to be imported'),
         srw=dict(
             app_url=('/en/xray-beamlines.html', str, 'URL for SRW link'),

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -93,7 +93,6 @@ def _init():
         jspec=dict(
             derbenevskrinsky_force_formula=b('Include Derbenev-Skrinsky force formula'),
         ),
-        jupyterhub=(False, bool, 'jupyterhub running at /jupyter'),
         proprietary_sim_types=(set(), set, 'codes that require authorization'),
         #TODO(robnagler) make this a sim_type config like srw and warpvnd
         rs4pi_dose_calc=(False, bool, 'run the real dose calculator'),

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -96,7 +96,6 @@ def _init():
         proprietary_sim_types=(set(), set, 'codes that require authorization'),
         #TODO(robnagler) make this a sim_type config like srw and warpvnd
         rs4pi_dose_calc=(False, bool, 'run the real dose calculator'),
-        rs_jupyter_migrate=(False, bool, 'give user option to migrate data from jupyter.radiasoft.org'),
         sim_types=(set(), set, 'simulation types (codes) to be imported'),
         srw=dict(
             app_url=('/en/xray-beamlines.html', str, 'URL for SRW link'),

--- a/sirepo/http_reply.py
+++ b/sirepo/http_reply.py
@@ -106,8 +106,6 @@ def gen_json(value, pretty=False, response_kwargs=None):
         flask.Response: reply object
     """
     app = flask.current_app
-
-
     if not response_kwargs:
         response_kwargs = PKDict()
     return app.response_class(

--- a/sirepo/http_reply.py
+++ b/sirepo/http_reply.py
@@ -105,11 +105,12 @@ def gen_json(value, pretty=False, response_kwargs=None):
     Returns:
         flask.Response: reply object
     """
-    import flask.wrappers
+    app = flask.current_app
+
 
     if not response_kwargs:
         response_kwargs = PKDict()
-    return flask.wrappers.Response(
+    return app.response_class(
         simulation_db.generate_json(value, pretty=pretty),
         mimetype=MIME_TYPE.json,
         **response_kwargs

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -105,6 +105,7 @@ def migrate_rs_data(rs_user_name):
         j = JupyterhubUser.search_by(
             uid=sirepo.auth.logged_in_user()
         )
+        # TODO(e-carlin): u.uid doesn't work _get_or_create_user should return user model
         assert j, f'no JupyterhubUser with uid={u.uid}'
         s = cfg.db_root.join(rs_user_name)
         d = cfg.db_root.join(j.user_name)

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -6,29 +6,14 @@ u"""Jupyterhub login
 """
 from __future__ import absolute_import, division, print_function
 from pykern import pkconfig
-from pykern import pkio
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp, pkdexc, pkdlog
-import importlib
 import jupyterhub.auth
-import os
-import py.error
-import random
-import shutil
 import sirepo.auth
-import sirepo.auth.email
-import sirepo.auth_db
 import sirepo.cookie
 import sirepo.server
-import sirepo.srdb
 import sirepo.util
-import sqlalchemy
-import string
 import tornado.web
-
-cfg = None
-
-JupyterhubUser = None
 
 
 class Authenticator(jupyterhub.auth.Authenticator):
@@ -54,9 +39,14 @@ class Authenticator(jupyterhub.auth.Authenticator):
                 handler.redirect(f'/jupyterhublogin#/{r}')
                 raise tornado.web.Finish()
             raise
-        return _get_or_create_user(check_path=False).user_name
+        u = sirepo.sim_api.jupyterhublogin.logged_in_user_name()
+        if not u:
+            handler.redirect(f'/jupyterhublogin')
+            raise tornado.web.Finish()
+        return u
 
     async def refresh_user(self, user, handler=None):
+        # TODO(e-carlin): this doesn't seem to work, more logging
         assert handler, \
             'Need the handler to get the cookie'
         c = handler.get_cookie(sirepo.cookie.cfg.http_name)
@@ -71,120 +61,3 @@ class Authenticator(jupyterhub.auth.Authenticator):
         except sirepo.util.SRException:
             return False
         return True
-
-def get_user_name():
-    return _get_or_create_user().user_name
-
-def init():
-    global cfg
-
-    if cfg:
-        return
-    cfg = pkconfig.init(
-        db_root=(
-            pkio.py_path(sirepo.srdb.root()).join('jupyterhub'),
-            pkio.py_path,
-            'the path of jupyterhub user db (ex /srv/jupyterhub)',
-        ),
-        uri_root=('jupyter', str, 'the root uri of jupyterhub'),
-    )
-    sirepo.auth_db.init_model(_init_model)
-
-
-def migrate_rs_data(rs_user_name):
-    with sirepo.auth_db.thread_lock:
-        # User may not exist yet because they are created lazily
-        u = _get_or_create_user()
-        s = cfg.db_root.join(rs_user_name)
-        d = cfg.db_root.join(u.user_name)
-        pkio.unchecked_remove(d)
-        try:
-            shutil.move(s, d)
-        except FileNotFoundError:
-            pkdlog(
-                'Tried to migrate existing rs jupyter directory={} but not found. Ignoring.',
-                s,
-            )
-        # TODO(e-carlin): Maybe don't set it to True.
-        # If src dir isn't found they may have given the wrong github creds and
-        # want to try migrating again.
-        u.rs_migration_done = True
-        u.save()
-
-
-def set_rs_migration_prompt_dismissed(dismiss):
-    # TODO(e-carlin): maybe use cookie for this instead?
-    with sirepo.auth_db.thread_lock:
-        # User may not exist yet because they are created lazily
-        u = sirepo.jupyterhub._get_or_create_user()
-        u.rs_migration_prompt_dimsissed = dismiss
-        u.save()
-
-
-def _get_or_create_user(check_path=True):
-    def _make_user_name_safe(s):
-        _SAFE_CHARS = string.ascii_letters + '-' + '_'
-        res = ''
-        for c in s:
-            if c not in _SAFE_CHARS:
-                c = '_'
-            res += c
-        return res
-
-    with sirepo.auth_db.thread_lock:
-        u = JupyterhubUser.search_by(
-            uid=sirepo.auth.logged_in_user(check_path=check_path),
-        )
-        if u:
-            return u
-        # Create new JupyterhubUser
-        u = sirepo.auth.email.AuthEmailUser.search_by(
-            uid=sirepo.auth.logged_in_user(check_path=check_path),
-        )
-        # TODO(e-carlin): if we are logged in but delete the run dir
-        # (happens in dev, maybe in prod if we delete a logged in user)
-        # then this assert will raise.
-        # It would be ideal to log the user out and redirect to / as done
-        # in non-jupyter apps but since we are outside of the flask context
-        # accessing the sirepo cookie and redirecting is challenging.
-        # Return None will display 403 for user which is fine for now.
-        if not u or not u.user_name:
-            return None
-        p = u.user_name.split('@')
-        n = '@'.join(p[:-1])
-        for i in range(5):
-            # TODO(e-carlin): discuss _make_user_name_safe with rn. Username
-            # will be used in paths so things like ../ must be escaped. In
-            # addition they will be used in cookie names so I believe only
-            # ascii_letters, '-' and '_' are valid. Also consider docker volumes.
-            # we use pyisemail in sirepo.auth so maybe that is enough
-            n = _make_user_name_safe(n)
-            try:
-                cfg.db_root.join(n).mkdir()
-                break
-            except py.error.EEXIST:
-                if i == 0:
-                    n += '_' + p[-1].split('.')[0]
-                    continue
-                if i == 1:
-                    n += '_'
-                n += random.choice(string.ascii_lowercase)
-        else:
-            raise RuntimeError(f'unable to generate unique jupyterhub user dir n={n}')
-        u = JupyterhubUser(
-            uid=u.uid,
-            user_name=n,
-        )
-        u.save()
-        return u
-
-
-def _init_model(base):
-    global JupyterhubUser
-
-    class JupyterhubUser(base):
-        __tablename__ = 'jupyterhub_user_t'
-        rs_migration_done = sqlalchemy.Column(sqlalchemy.Boolean())
-        rs_migration_prompt_dimsissed = sqlalchemy.Column(sqlalchemy.Boolean())
-        uid = sqlalchemy.Column(sqlalchemy.String(8), primary_key=True)
-        user_name = sqlalchemy.Column(sqlalchemy.String(100), nullable=False)

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -34,10 +34,10 @@ class Authenticator(jupyterhub.auth.Authenticator):
             sirepo.auth.require_user()
         except sirepo.util.SRException as e:
             r = e.sr_args.get('routeName')
-            if r:
-                handler.redirect(f'/jupyterhublogin#/{r}')
-                raise tornado.web.Finish()
-            raise
+            if r not in ('login', 'loginFail'):
+                raise
+            handler.redirect(f'/jupyterhublogin#/{r}')
+            raise tornado.web.Finish()
         # Do not check path. If not found will result in updates to db
         # which we can not lock.
         u = sirepo.sim_api.jupyterhublogin.logged_in_user_name(check_path=False)

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -7,7 +7,7 @@ u"""Jupyterhub login
 from __future__ import absolute_import, division, print_function
 from pykern import pkconfig
 from pykern.pkcollections import PKDict
-from pykern.pkdebug import pkdp, pkdexc, pkdlog
+from pykern.pkdebug import pkdp
 import jupyterhub.auth
 import sirepo.auth
 import sirepo.cookie
@@ -30,7 +30,7 @@ class Authenticator(jupyterhub.auth.Authenticator):
         c = handler.get_cookie(sirepo.cookie.cfg.http_name)
         if not c:
             c = ''
-        sirepo.cookie.set_cookie_for_jupyterhub(f'{sirepo.cookie.cfg.http_name}={c}')
+        sirepo.cookie.set_cookie_for_utils(f'{sirepo.cookie.cfg.http_name}={c}')
         try:
             sirepo.auth.require_user()
         except sirepo.util.SRException as e:
@@ -52,7 +52,7 @@ class Authenticator(jupyterhub.auth.Authenticator):
         c = handler.get_cookie(sirepo.cookie.cfg.http_name)
         if not c:
             return False
-        sirepo.cookie.set_cookie_for_jupyterhub(
+        sirepo.cookie.set_cookie_for_utils(
             f'{sirepo.cookie.cfg.http_name}={c}'
         )
 

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -15,6 +15,8 @@ import sirepo.server
 import sirepo.util
 import tornado.web
 
+_JUPYTERHUBLOGIN_ROUTE = '/jupyterhublogin'
+
 
 class Authenticator(jupyterhub.auth.Authenticator):
     # Do not prompt with jupyterhub login page. self.authenticate()
@@ -36,13 +38,13 @@ class Authenticator(jupyterhub.auth.Authenticator):
             r = e.sr_args.get('routeName')
             if r not in ('login', 'loginFail'):
                 raise
-            handler.redirect(f'/jupyterhublogin#/{r}')
+            handler.redirect(f'{_JUPYTERHUBLOGIN_ROUTE}#/{r}')
             raise tornado.web.Finish()
         u = sirepo.sim_api.jupyterhublogin.logged_in_user_name(
             have_simulation_db=False,
         )
         if not u:
-            handler.redirect(f'/jupyterhublogin')
+            handler.redirect(f'{_JUPYTERHUBLOGIN_ROUTE}')
             raise tornado.web.Finish()
         return u
 

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -40,7 +40,7 @@ class Authenticator(jupyterhub.auth.Authenticator):
                 raise
             handler.redirect(f'{_JUPYTERHUBLOGIN_ROUTE}#/{r}')
             raise tornado.web.Finish()
-        u = sirepo.sim_api.jupyterhublogin.logged_in_user_name(
+        u = sirepo.sim_api.jupyterhublogin.jupyterhub_user_name(
             have_simulation_db=False,
         )
         if not u:

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -29,10 +29,7 @@ class Authenticator(jupyterhub.auth.Authenticator):
         sirepo.server.init()
 
     async def authenticate(self, handler, data):
-        c = handler.get_cookie(sirepo.cookie.cfg.http_name)
-        if not c:
-            c = ''
-        sirepo.cookie.set_cookie_for_utils(f'{sirepo.cookie.cfg.http_name}={c}')
+        _set_cookie(handler)
         try:
             sirepo.auth.require_user()
         except sirepo.util.SRException as e:
@@ -50,16 +47,15 @@ class Authenticator(jupyterhub.auth.Authenticator):
         return u
 
     async def refresh_user(self, user, handler=None):
-        assert handler, \
-            'Need the handler to get the cookie'
-        c = handler.get_cookie(sirepo.cookie.cfg.http_name)
-        if not c:
-            return False
-        sirepo.cookie.set_cookie_for_utils(
-            f'{sirepo.cookie.cfg.http_name}={c}'
-        )
+        _set_cookie(handler)
         try:
             sirepo.auth.require_user()
         except sirepo.util.SRException:
             return False
         return True
+
+
+def _set_cookie(handler):
+    sirepo.cookie.set_cookie_for_utils(
+        handler.get_cookie(sirepo.cookie.cfg.http_name),
+    )

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -53,6 +53,9 @@ class Authenticator(jupyterhub.auth.Authenticator):
         try:
             sirepo.auth.require_user()
         except sirepo.util.SRException:
+            # Returning False is what the jupyterhub API expects and jupyterhub
+            # will handle re-authenticating the user.
+            # https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.refresh_user
             return False
         return True
 

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -42,6 +42,8 @@ class Authenticator(jupyterhub.auth.Authenticator):
                 handler.redirect(f'/jupyterhublogin#/{r}')
                 raise tornado.web.Finish()
             raise
+        # Do not check path. If not found will result in updates to db
+        # which we can not lock.
         u = sirepo.sim_api.jupyterhublogin.logged_in_user_name(check_path=False)
         if not u:
             handler.redirect(f'/jupyterhublogin')

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -24,9 +24,6 @@ class Authenticator(jupyterhub.auth.Authenticator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # TODO(e-carlin): maybe should set SIREPO_AUTH_LOGGED_IN_USER
-        # if not set user_dir_not_found could do operations to db
-        # that require locking
         sirepo.server.init()
 
     async def authenticate(self, handler, data):

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -19,6 +19,8 @@ import tornado.web
 class Authenticator(jupyterhub.auth.Authenticator):
     # Do not prompt with jupyterhub login page. self.authenticate()
     # will handle login using Sirepo functionality
+    # See the jupyterhub docs for more info:
+    # https://jupyterhub.readthedocs.io/en/stable/api/auth.html
     auto_login = True
     refresh_pre_spawn = True
 

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -48,7 +48,6 @@ class Authenticator(jupyterhub.auth.Authenticator):
         return u
 
     async def refresh_user(self, user, handler=None):
-        # TODO(e-carlin): this doesn't seem to work, more logging
         assert handler, \
             'Need the handler to get the cookie'
         c = handler.get_cookie(sirepo.cookie.cfg.http_name)

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -56,7 +56,6 @@ class Authenticator(jupyterhub.auth.Authenticator):
         sirepo.cookie.set_cookie_for_utils(
             f'{sirepo.cookie.cfg.http_name}={c}'
         )
-
         try:
             sirepo.auth.require_user()
         except sirepo.util.SRException:

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -24,6 +24,9 @@ class Authenticator(jupyterhub.auth.Authenticator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # TODO(e-carlin): maybe should set SIREPO_AUTH_LOGGED_IN_USER
+        # if not set user_dir_not_found could do operations to db
+        # that require locking
         sirepo.server.init()
 
     async def authenticate(self, handler, data):
@@ -39,7 +42,7 @@ class Authenticator(jupyterhub.auth.Authenticator):
                 handler.redirect(f'/jupyterhublogin#/{r}')
                 raise tornado.web.Finish()
             raise
-        u = sirepo.sim_api.jupyterhublogin.logged_in_user_name()
+        u = sirepo.sim_api.jupyterhublogin.logged_in_user_name(check_path=False)
         if not u:
             handler.redirect(f'/jupyterhublogin')
             raise tornado.web.Finish()

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -54,7 +54,7 @@ class Authenticator(jupyterhub.auth.Authenticator):
                 handler.redirect(f'/jupyterhublogin#/{r}')
                 raise tornado.web.Finish()
             raise
-        return _get_or_create_user(check_path=False)
+        return _get_or_create_user(check_path=False).user_name
 
     async def refresh_user(self, user, handler=None):
         assert handler, \
@@ -72,16 +72,8 @@ class Authenticator(jupyterhub.auth.Authenticator):
             return False
         return True
 
-
-def get_user_name(check_path=True):
-    with sirepo.auth_db.thread_lock:
-        u = JupyterhubUser.search_by(
-            uid=sirepo.auth.logged_in_user(check_path=check_path),
-        )
-        if u:
-            return u.user_name
-    return None
-
+def get_user_name():
+    return _get_or_create_user().user_name
 
 def init():
     global cfg
@@ -100,15 +92,11 @@ def init():
 
 
 def migrate_rs_data(rs_user_name):
-    u = _get_or_create_user()
     with sirepo.auth_db.thread_lock:
-        j = JupyterhubUser.search_by(
-            uid=sirepo.auth.logged_in_user()
-        )
-        # TODO(e-carlin): u.uid doesn't work _get_or_create_user should return user model
-        assert j, f'no JupyterhubUser with uid={u.uid}'
+        # User may not exist yet because they are created lazily
+        u = _get_or_create_user()
         s = cfg.db_root.join(rs_user_name)
-        d = cfg.db_root.join(j.user_name)
+        d = cfg.db_root.join(u.user_name)
         pkio.unchecked_remove(d)
         try:
             shutil.move(s, d)
@@ -117,11 +105,21 @@ def migrate_rs_data(rs_user_name):
                 'Tried to migrate existing rs jupyter directory={} but not found. Ignoring.',
                 s,
             )
-        # TODO(e-carlin): Maybe don't set it to True in the case where source
-        # dir wasn't found? They may have given the wrong github creds and want
-        # to try migrating again.
-        j.rs_migration_done = True
-        j.save()
+        # TODO(e-carlin): Maybe don't set it to True.
+        # If src dir isn't found they may have given the wrong github creds and
+        # want to try migrating again.
+        u.rs_migration_done = True
+        u.save()
+
+
+def set_rs_migration_prompt_dismissed(dismiss):
+    # TODO(e-carlin): maybe use cookie for this instead?
+    with sirepo.auth_db.thread_lock:
+        # User may not exist yet because they are created lazily
+        u = sirepo.jupyterhub._get_or_create_user()
+        u.rs_migration_prompt_dimsissed = dismiss
+        u.save()
+
 
 def _get_or_create_user(check_path=True):
     def _make_user_name_safe(s):
@@ -132,51 +130,53 @@ def _get_or_create_user(check_path=True):
                 c = '_'
             res += c
         return res
-    n = get_user_name(check_path=check_path)
-    if n:
-        # Existing JupyterhubUser
-        return n
-    # Create new JupyterhubUser
-    u = sirepo.auth.email.AuthEmailUser.search_by(
-        uid=sirepo.auth.logged_in_user(check_path=check_path),
-    )
-    # TODO(e-carlin): if we are logged in but delete the run dir
-    # (happens in dev, maybe in prod if we delete a logged in user)
-    # then this assert will raise.
-    # It would be ideal to log the user out and redirect to / as done
-    # in non-jupyter apps but since we are outside of the flask context
-    # accessing the sirepo cookie and redirecting is challenging.
-    # Return None will display 403 for user which is fine for now.
-    if not u or not u.user_name:
-        return None
-    p = u.user_name.split('@')
-    n = '@'.join(p[:-1])
-    for i in range(5):
-        # TODO(e-carlin): discuss _make_user_name_safe with rn. Username
-        # will be used in paths so things like ../ must be escaped. In
-        # addition they will be used in cookie names so I believe only
-        # ascii_letters, '-' and '_' are valid. Also consider docker volumes.
-        # we use pyisemail in sirepo.auth so maybe that is enough
-        n = _make_user_name_safe(n)
-        try:
-            cfg.db_root.join(n).mkdir()
-            break
-        except py.error.EEXIST:
-            if i == 0:
-                n += '_' + p[-1].split('.')[0]
-                continue
-            if i == 1:
-                n += '_'
-            n += random.choice(string.ascii_lowercase)
-    else:
-        raise RuntimeError(f'unable to generate unique jupyterhub user dir n={n}')
+
     with sirepo.auth_db.thread_lock:
+        u = JupyterhubUser.search_by(
+            uid=sirepo.auth.logged_in_user(check_path=check_path),
+        )
+        if u:
+            return u
+        # Create new JupyterhubUser
+        u = sirepo.auth.email.AuthEmailUser.search_by(
+            uid=sirepo.auth.logged_in_user(check_path=check_path),
+        )
+        # TODO(e-carlin): if we are logged in but delete the run dir
+        # (happens in dev, maybe in prod if we delete a logged in user)
+        # then this assert will raise.
+        # It would be ideal to log the user out and redirect to / as done
+        # in non-jupyter apps but since we are outside of the flask context
+        # accessing the sirepo cookie and redirecting is challenging.
+        # Return None will display 403 for user which is fine for now.
+        if not u or not u.user_name:
+            return None
+        p = u.user_name.split('@')
+        n = '@'.join(p[:-1])
+        for i in range(5):
+            # TODO(e-carlin): discuss _make_user_name_safe with rn. Username
+            # will be used in paths so things like ../ must be escaped. In
+            # addition they will be used in cookie names so I believe only
+            # ascii_letters, '-' and '_' are valid. Also consider docker volumes.
+            # we use pyisemail in sirepo.auth so maybe that is enough
+            n = _make_user_name_safe(n)
+            try:
+                cfg.db_root.join(n).mkdir()
+                break
+            except py.error.EEXIST:
+                if i == 0:
+                    n += '_' + p[-1].split('.')[0]
+                    continue
+                if i == 1:
+                    n += '_'
+                n += random.choice(string.ascii_lowercase)
+        else:
+            raise RuntimeError(f'unable to generate unique jupyterhub user dir n={n}')
         u = JupyterhubUser(
             uid=u.uid,
             user_name=n,
         )
         u.save()
-        return u.user_name
+        return u
 
 
 def _init_model(base):

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -38,9 +38,9 @@ class Authenticator(jupyterhub.auth.Authenticator):
                 raise
             handler.redirect(f'/jupyterhublogin#/{r}')
             raise tornado.web.Finish()
-        # Do not check path. If not found will result in updates to db
-        # which we can not lock.
-        u = sirepo.sim_api.jupyterhublogin.logged_in_user_name(check_path=False)
+        u = sirepo.sim_api.jupyterhublogin.logged_in_user_name(
+            have_simulation_db=False,
+        )
         if not u:
             handler.redirect(f'/jupyterhublogin')
             raise tornado.web.Finish()

--- a/sirepo/package_data/jupyterhub_conf.py.jinja
+++ b/sirepo/package_data/jupyterhub_conf.py.jinja
@@ -1,12 +1,12 @@
 import jupyterhub.spawner
 import sirepo.jupyterhub
 
-c.Application.log_level = 'DEBUG'
+c.Application.log_level = '{{ "DEBUG" if jupyterhub_debug else "WARN" }}'
 c.ConfigurableHTTPProxy.api_url = 'http://127.0.0.1:8111'
-c.ConfigurableHTTPProxy.debug = True
+c.ConfigurableHTTPProxy.debug = {{ jupyterhub_debug }}
 c.JupyterHub.authenticator_class = sirepo.jupyterhub.Authenticator
 c.JupyterHub.base_url = '/{{ uri_root }}'
 c.JupyterHub.ip = '127.0.0.1'
 c.JupyterHub.port = {{ jupyterhub_port }}
 c.JupyterHub.spawner_class = jupyterhub.spawner.SimpleLocalProcessSpawner
-c.Spawner.debug = True
+c.Spawner.debug = {{ jupyterhub_debug }}

--- a/sirepo/package_data/jupyterhub_conf.py.jinja
+++ b/sirepo/package_data/jupyterhub_conf.py.jinja
@@ -1,7 +1,7 @@
 import jupyterhub.spawner
 import sirepo.jupyterhub
 
-c.Application.log_level = '{{ "DEBUG" if jupyterhub_debug else "WARN" }}'
+c.Application.log_level = '{{ "DEBUG" if jupyterhub_debug else "INFO" }}'
 c.ConfigurableHTTPProxy.api_url = 'http://127.0.0.1:8111'
 c.ConfigurableHTTPProxy.debug = {{ jupyterhub_debug }}
 c.JupyterHub.authenticator_class = sirepo.jupyterhub.Authenticator

--- a/sirepo/package_data/jupyterhub_conf.py.jinja
+++ b/sirepo/package_data/jupyterhub_conf.py.jinja
@@ -3,7 +3,6 @@ import sirepo.jupyterhub
 
 c.Application.log_level = 'DEBUG'
 c.ConfigurableHTTPProxy.api_url = 'http://127.0.0.1:8111'
-c.ConfigurableHTTPProxy.auth_token = 'brucespringsteen'
 c.ConfigurableHTTPProxy.debug = True
 c.JupyterHub.authenticator_class = sirepo.jupyterhub.Authenticator
 c.JupyterHub.base_url = '/{{ uri_root }}'

--- a/sirepo/package_data/nginx_proxy.conf.jinja
+++ b/sirepo/package_data/nginx_proxy.conf.jinja
@@ -10,6 +10,7 @@ events {
 }
 
 http {
+    client_max_body_size 200m;
     client_body_temp_path {{ run_dir }}/client_body_temp;
     proxy_temp_path {{ run_dir }}/proxy_temp;
     fastcgi_temp_path {{ run_dir }}/fastcgi_temp;
@@ -26,6 +27,21 @@ http {
     types_hash_max_size 2048;
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
+    proxy_http_version 1.1;
+    proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+    proxy_read_timeout 600s;
+    proxy_send_timeout 600s;
+    proxy_connect_timeout 600s;
+    proxy_redirect off;
+    proxy_set_header Host $host:$server_port;
+    proxy_set_header Proxy "";
+    proxy_set_header Via $remote_addr;
+    proxy_set_header X-Real-Ip $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_cache_bypass $http_upgrade;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
 
     server {
         listen {{ ip }}:{{ nginx_proxy_port }};
@@ -36,26 +52,10 @@ http {
         }
         location /{{ jupyterhub_root }}/ {
             proxy_pass http://127.0.0.1:{{ jupyterhub_port }};
-            proxy_http_version 1.1;
-            proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
-            proxy_read_timeout 600s;
-            proxy_send_timeout 600s;
-            proxy_connect_timeout 600s;
-            proxy_redirect off;
-            proxy_set_header Host $host:$server_port;
-            proxy_set_header Proxy "";
-            proxy_set_header Via $remote_addr;
-            proxy_set_header X-Real-Ip $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_cache_bypass $http_upgrade;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
         }
         {% endif %}
         location / {
             include /etc/nginx/uwsgi_params;
-            client_max_body_size 50m;
             uwsgi_read_timeout 300s;
             uwsgi_send_timeout 300s;
             uwsgi_pass 127.0.0.1:{{ port }};

--- a/sirepo/package_data/static/html/jupyterhublogin.html
+++ b/sirepo/package_data/static/html/jupyterhublogin.html
@@ -1,4 +1,8 @@
-<div class="container-fluid">
+<div data-ng-if="jupyterhublogin.isLoading" class="sr-page-load" style="display: block">
+    <img class="sr-page-load-image" src="/static/img/sirepo_animated.gif" />
+    <div class="sr-page-load-text">Loading</div>
+</div>
+<div data-ng-if="! jupyterhublogin.isLoading" class="container-fluid">
   <div class="row">
     <div class="row text-center">
       <p>Do you have an existing jupyter.radiasoft.org account that you would like to migrate to Sirepo?</p>

--- a/sirepo/package_data/static/html/jupyterhublogin.html
+++ b/sirepo/package_data/static/html/jupyterhublogin.html
@@ -4,11 +4,6 @@
       <p>Do you have an existing jupyter.radiasoft.org account that you would like to migrate to Sirepo?</p>
       <button data-ng-click="jupyterhublogin.migrate(true)" class="btn btn-large btn-primary">Yes</button>
       <button data-ng-click="jupyterhublogin.migrate(false)" class="btn btn-large btn-default">No</button>
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" data-ng-model="jupyterhublogin.dismissChecked" data-ng-change="jupyterhublogin.dismissRsMigrationPrompt()">Do not ask again.</input>
-        </label>
-      </div>
     </div>
   </div>
 </div>

--- a/sirepo/package_data/static/js/jupyterhublogin.js
+++ b/sirepo/package_data/static/js/jupyterhublogin.js
@@ -12,7 +12,7 @@ SIREPO.app.controller('JupyterhubloginController', function(authState, requestSe
     );
     self.migrate = function(doMigration) {
         requestSender.sendRequest(
-            'migrateRsJupyterhubData',
+            'migrateJupyterhub',
             null,
             {doMigration: doMigration}
         );

--- a/sirepo/package_data/static/js/jupyterhublogin.js
+++ b/sirepo/package_data/static/js/jupyterhublogin.js
@@ -4,31 +4,18 @@ var srlog = SIREPO.srlog;
 var srdbg = SIREPO.srdbg;
 
 SIREPO.app.controller('JupyterhubloginController', function(authState, requestSender, $sce,  $scope) {
-    // TODO(e-carlin): globalRedirect vs sendRequest that returns a redirect
-    if (
-            ! authState.isLoggedIn ||
-            authState.rsMigrationDone ||
-            authState.rsMigrationPromptDimsissed
-    ) {
-        requestSender.sendRequest('redirectJupyterHub');
-        return;
-    }
     const self = this;
-    self.dismissChecked = false;
-
-    self.dismissRsMigrationPrompt = function(v) {
-        requestSender.sendRequest('dismissJupyterhubDataMovePrompt', null, {dismiss: self.dismissChecked});
-    }
-
+    self.isLoading = true;
+    requestSender.sendRequest(
+        'redirectJupyterHub',
+        () => {self.isLoading = false;}
+    );
     self.migrate = function(doMigration) {
-        if (! doMigration) {
-            requestSender.sendRequest('redirectJupyterHub');
-            return;
-        }
-        requestSender.globalRedirect(
+        requestSender.sendRequest(
             'migrateRsJupyterhubData',
-            {'<simulation_type>': SIREPO.APP_SCHEMA.simulationType}
-        );
+            null,
+            {doMigration: doMigration}
+        )
     }
 });
 

--- a/sirepo/package_data/static/js/jupyterhublogin.js
+++ b/sirepo/package_data/static/js/jupyterhublogin.js
@@ -15,8 +15,8 @@ SIREPO.app.controller('JupyterhubloginController', function(authState, requestSe
             'migrateRsJupyterhubData',
             null,
             {doMigration: doMigration}
-        )
-    }
+        );
+    };
 });
 
 SIREPO.app.directive('appHeader', function(jupyterhubloginService) {

--- a/sirepo/package_data/static/js/jupyterhublogin.js
+++ b/sirepo/package_data/static/js/jupyterhublogin.js
@@ -4,6 +4,7 @@ var srlog = SIREPO.srlog;
 var srdbg = SIREPO.srdbg;
 
 SIREPO.app.controller('JupyterhubloginController', function(authState, requestSender, $sce,  $scope) {
+    // TODO(e-carlin): globalRedirect vs sendRequest that returns a redirect
     if (
             ! authState.isLoggedIn ||
             authState.rsMigrationDone ||

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -2078,7 +2078,6 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, $http,
                 1
             );
         }
-        // srdbg('req url/data', url, data);
         var req = data
             ? $http.post(url, data, t)
             : $http.get(url, t);

--- a/sirepo/package_data/static/json/jupyterhublogin-schema.json
+++ b/sirepo/package_data/static/json/jupyterhublogin-schema.json
@@ -7,11 +7,11 @@
         }
     },
     "appDefaults": {
-        "route": "migrate"
+        "route": "migrateJupyter"
     },
     "localRoutes": {
-        "migrate": {
-            "route": "/migrate",
+        "migrateJupyter": {
+            "route": "/migrate-jupyter",
             "config": {
                 "controller": "JupyterhubloginController as jupyterhublogin",
                 "templateUrl": "/static/html/jupyterhublogin.html"

--- a/sirepo/package_data/static/json/jupyterhublogin-schema.json
+++ b/sirepo/package_data/static/json/jupyterhublogin-schema.json
@@ -7,11 +7,11 @@
         }
     },
     "appDefaults": {
-        "route": "jupyterhublogin"
+        "route": "migrate"
     },
     "localRoutes": {
-        "jupyterhublogin": {
-            "route": "/jupyterhublogin",
+        "migrate": {
+            "route": "/migrate",
             "config": {
                 "controller": "JupyterhubloginController as jupyterhublogin",
                 "templateUrl": "/static/html/jupyterhublogin.html"

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -109,7 +109,6 @@
         "copySimulation": "/copy-simulation",
         "deleteFile": "/delete-file",
         "deleteSimulation": "/delete-simulation",
-        "dismissJupyterhubDataMovePrompt": "/dismiss-jupyterhub-data-move-prompt",
         "downloadDataFile": "/download-data-file/<simulation_type>/<simulation_id>/<model>/<frame>/?<suffix>",
         "downloadFile": "/download-file/<simulation_type>/<simulation_id>/<filename>",
         "errorLogging": "/error-logging",

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -126,7 +126,7 @@
         "exportJupyterNotebook": "/export-jupyter-notebook/<simulation_type>/<simulation_id>/?<model>/?<title>",
         "listFiles": "/file-list/<simulation_type>/<simulation_id>/<file_type>",
         "listSimulations": "/simulation-list",
-        "migrateRsJupyterhubData": "/migrate-rs-jupyterhub-data",
+        "migrateJupyterhub": "/migrate-jupyterhub",
         "newSimulation": "/new-simulation",
         "oauthAuthorized": "/oauth-authorized/<oauth_type>",
         "ownJobs": "/own-jobs",

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -126,7 +126,7 @@
         "exportJupyterNotebook": "/export-jupyter-notebook/<simulation_type>/<simulation_id>/?<model>/?<title>",
         "listFiles": "/file-list/<simulation_type>/<simulation_id>/<file_type>",
         "listSimulations": "/simulation-list",
-        "migrateRsJupyterhubData": "/migrate-rs-jupyterhub-data/<simulation_type>",
+        "migrateRsJupyterhubData": "/migrate-rs-jupyterhub-data",
         "newSimulation": "/new-simulation",
         "oauthAuthorized": "/oauth-authorized/<oauth_type>",
         "ownJobs": "/own-jobs",

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -64,9 +64,6 @@ def http():
 
 def jupyterhub():
     assert pkconfig.channel_in('dev')
-    # TODO(e-carlin): setting os.environ doesn't work so manually need to set it here?
-    import sirepo.feature_config
-    sirepo.feature_config.cfg().jupyterhub = True
     try:
         import jupyterhub
     except ImportError:
@@ -89,7 +86,6 @@ def jupyterhub():
            ['jupyterhub', '-f', str(f)],
         ],
         env=PKDict(os.environ).pkupdate(
-            SIREPO_FEATURE_CONFIG_JUPYTERHUB='1',
             SIREPO_AUTH_METHODS='github:email',
             SIREPO_AUTH_GITHUB_METHOD_VISIBLE='',
         ),
@@ -107,12 +103,9 @@ def nginx_proxy(jupyterhub=False):
         f = run_dir.join('default.conf')
         c = PKDict(_cfg()).pkupdate(run_dir=str(d))
         if jupyterhub:
-            import sirepo.feature_config
             import sirepo.sim_api.jupyterhublogin
             import sirepo.server
 
-            # TODO(e-carlin): same hack as jupyterhub() have to set the config.
-            sirepo.feature_config.cfg().jupyterhub = True
             sirepo.server.init()
             c.pkupdate(
                 jupyterhub_root=sirepo.sim_api.jupyterhublogin.cfg.uri_root,

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -111,7 +111,7 @@ def jupyterhub():
     import sirepo.server
 
     sirepo.server.init()
-    with pkio.save_chdir(_run_dir().join('jupyterhub')) as d:
+    with pkio.save_chdir(_run_dir().join('jupyterhub').ensure(dir=True)) as d:
         f = d.join('conf.py')
         pkjinja.render_resource(
             'jupyterhub_conf.py',

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -141,6 +141,11 @@ def _cfg():
         __cfg = pkconfig.init(
             ip=('0.0.0.0', _cfg_ip, 'what IP address to open'),
             jupyterhub_port=(8005, _cfg_port, 'port on which jupyterhub listens'),
+            jupyterhub_debug=(
+                True,
+                bool,
+                'turn on debugging for jupyterhub (hub, spawner, ConfigurableHTTPProxy)',
+            ),
             nginx_proxy_port=(8080, _cfg_port, 'port on which nginx_proxy listens'),
             port=(8000, _cfg_port, 'port on which uwsgi or http listens'),
             processes=(1, _cfg_int(1, 16), 'how many uwsgi processes to start'),

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -170,7 +170,7 @@ def _cfg():
     if not __cfg:
         __cfg = pkconfig.init(
             ip=('0.0.0.0', _cfg_ip, 'what IP address to open'),
-            jupyterhub_port=(8005, _cfg_port, 'port on which jupyterhub listens'),
+            jupyterhub_port=(8002, _cfg_port, 'port on which jupyterhub listens'),
             jupyterhub_debug=(
                 True,
                 bool,

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -67,7 +67,7 @@ def jupyterhub():
     try:
         import jupyterhub
     except ImportError:
-        raise ImportError('jupyterhub not installed. run `pip install jupyterhub`')
+        raise AssertionError('jupyterhub not installed. run `pip install jupyterhub`')
     import sirepo.sim_api.jupyterhublogin
     import sirepo.server
 

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -85,10 +85,7 @@ def jupyterhub():
            ['sirepo', 'job_supervisor'],
            ['jupyterhub', '-f', str(f)],
         ],
-        env=PKDict(os.environ).pkupdate(
-            SIREPO_AUTH_METHODS='github:email',
-            SIREPO_AUTH_GITHUB_METHOD_VISIBLE='',
-        ),
+        env=PKDict(os.environ).pkupdate(SIREPO_AUTH_METHODS='email'),
     )
 
 

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -21,6 +21,7 @@ import flask
 import importlib
 import os
 import re
+import sirepo.events
 import sirepo.jupyterhub
 import sirepo.sim_data
 import sirepo.srdb
@@ -616,6 +617,8 @@ def init(uwsgi=None, use_reloader=False):
         _google_tag_manager = f'''<script>
     (function(w,d,s,l,i){{w[l]=w[l]||[];w[l].push({{'gtm.start':new Date().getTime(),event:'gtm.js'}});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);}})(window,document,'script','dataLayer','{cfg.google_tag_manager_id}');
     </script>'''
+# TODO(e-carlin): should this be done here or elsewhere?
+    sirepo.events.init()
     #: Flask app instance, must be bound globally
     _app = flask.Flask(
         __name__,
@@ -626,8 +629,6 @@ def init(uwsgi=None, use_reloader=False):
     _app.sirepo_uwsgi = uwsgi
     _app.sirepo_use_reloader = use_reloader
     uri_router.init(_app, simulation_db)
-    if feature_config.cfg().jupyterhub:
-        sirepo.jupyterhub.init()
     return _app
 
 

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -616,8 +616,6 @@ def init(uwsgi=None, use_reloader=False):
         _google_tag_manager = f'''<script>
     (function(w,d,s,l,i){{w[l]=w[l]||[];w[l].push({{'gtm.start':new Date().getTime(),event:'gtm.js'}});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);}})(window,document,'script','dataLayer','{cfg.google_tag_manager_id}');
     </script>'''
-# TODO(e-carlin): should this be done here or elsewhere?
-    sirepo.events.init()
     #: Flask app instance, must be bound globally
     _app = flask.Flask(
         __name__,

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -22,7 +22,6 @@ import importlib
 import os
 import re
 import sirepo.events
-import sirepo.jupyterhub
 import sirepo.sim_data
 import sirepo.srdb
 import sirepo.template

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -58,8 +58,6 @@ def jupyterhub_user_name(have_simulation_db=True):
 def init_apis(*args, **kwargs):
     global cfg
 
-    if cfg:
-        return
     cfg = pkconfig.init(
         dst_db_root=(
             pkio.py_path(sirepo.srdb.root()).join('jupyterhub'),

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -87,10 +87,10 @@ def _create_user():
             '_',
             logged_in_user_name.split('@')[0],
         )
-        u = JupyterhubUser.search_by(
-            user_name=n,
-        )
+        u = JupyterhubUser.search_by(user_name=n)
         if u:
+            # The username already exists. Add a random letter to try and create
+            # a unique user name.
             n += random.choice(string.ascii_lowercase)
         return n
 

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -135,8 +135,6 @@ def _event_github_authorized(kwargs):
         try:
             s.rename(d)
         except py.error.ENOTDIR:
-            # TODO(e-carlin): Maybe raise an error letting the user know
-            # They may have given the wrong github creds
             pkdlog(
                 'Tried to migrate existing rs jupyter directory={} but not found. Ignoring.',
                 s,

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -50,8 +50,8 @@ def api_redirectJupyterHub():
     return sirepo.http_reply.gen_json_ok()
 
 
-def logged_in_user_name(check_path=True):
-    return _user_name(sirepo.auth.logged_in_user(check_path=check_path))
+def logged_in_user_name(have_simulation_db=True):
+    return _user_name(sirepo.auth.logged_in_user(check_path=have_simulation_db))
 
 
 def init_apis(*args, **kwargs):

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -51,13 +51,7 @@ def api_redirectJupyterHub():
 
 
 def logged_in_user_name(check_path=True):
-    with sirepo.auth_db.thread_lock:
-        u = JupyterhubUser.search_by(
-            uid=sirepo.auth.logged_in_user(check_path=check_path),
-        )
-        if u:
-            return u.user_name
-        return None
+    return _user_name(sirepo.auth.logged_in_user(check_path=check_path))
 
 
 def init_apis(*args, **kwargs):
@@ -116,8 +110,8 @@ def _create_user():
         return True
 
 
-def _event_auth_logout():
-    flask.g.jupyterhub_logout_user_name = logged_in_user_name()
+def _event_auth_logout(kwargs):
+    flask.g.jupyterhub_logout_user_name = _user_name(kwargs.uid)
 
 
 def _event_end_api_call(kwargs):
@@ -165,3 +159,11 @@ def _init_model(base):
             nullable=False,
             unique=True,
         )
+
+
+def _user_name(uid):
+    with sirepo.auth_db.thread_lock:
+        u = JupyterhubUser.search_by(uid=uid)
+        if u:
+            return u.user_name
+        return None

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -85,6 +85,9 @@ def _create_user():
         n = re.sub(
             '\W+',
             '_',
+            # Get the local part of the email. Or in the case of another auth
+            # method (ex github) it won't have an '@' so it will just be their
+            # user name, handle, etc.
             logged_in_user_name.split('@')[0],
         )
         u = JupyterhubUser.search_by(user_name=n)

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -32,8 +32,8 @@ JupyterhubUser = None
 
 @sirepo.api_perm.require_user
 def api_migrateJupyterhub():
-    assert cfg.rs_jupyter_migrate, \
-        'API forbidden'
+    if not cfg.rs_jupyter_migrate:
+        sirepo.util.raise_forbidden('migrate not enabled')
     d = PKDict(**sirepo.http_request.parse_json())
     if not d.doMigration:
         return sirepo.http_reply.gen_redirect('jupyterHub')

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -75,9 +75,9 @@ def init_apis(*args, **kwargs):
     )
     sirepo.auth_db.init_model(_init_model)
     sirepo.events.register({
-        sirepo.events.Type.AUTH_LOGOUT: _event_auth_logout,
-        sirepo.events.Type.END_API_CALL: _event_end_api_call,
-        sirepo.events.Type.GITHUB_AUTHORIZED: _event_github_authorized,
+        'auth_logout': _event_auth_logout,
+        'end_api_call': _event_end_api_call,
+        'github_authorized': _event_github_authorized,
     })
 
 

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -31,18 +31,22 @@ JupyterhubUser = None
 
 
 @sirepo.api_perm.require_user
-def api_migrateRsJupyterhubData(simulation_type):
+def api_migrateRsJupyterhubData():
     _create_user()
+    d = PKDict(**sirepo.http_request.parse_json())
+    if not d.doMigration:
+        return sirepo.http_reply.gen_redirect('jupyterHub')
     return sirepo.uri_router.call_api(
             'authGithubLogin',
-            kwargs=PKDict(simulation_type=simulation_type),
+            kwargs=PKDict(simulation_type='jupyterhublogin'),
         )
 
 
 @sirepo.api_perm.require_user
 def api_redirectJupyterHub():
-    _create_user()
-    return sirepo.http_reply.gen_redirect('jupyterHub')
+    if logged_in_user_name():
+        return sirepo.http_reply.gen_redirect('jupyterHub')
+    return sirepo.http_reply.gen_json_ok()
 
 
 def logged_in_user_name():

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -5,27 +5,34 @@ u"""API's for jupyterhublogin sim
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from __future__ import absolute_import, division, print_function
+from pykern import pkconfig, pkio
 from pykern.pkcollections import PKDict
-from pykern.pkdebug import pkdp
+from pykern.pkdebug import pkdp, pkdlog
+import py.error
+import re
+import random
 import sirepo.api_perm
 import sirepo.auth
 import sirepo.auth_db
+import sirepo.auth_db
+import sirepo.events
 import sirepo.http_reply
 import sirepo.http_request
 import sirepo.jupyterhub
+import sirepo.srdb
 import sirepo.uri_router
+import sirepo.util
+import string
+import sqlalchemy
 
+cfg = None
 
-@sirepo.api_perm.require_user
-def api_dismissJupyterhubDataMovePrompt():
-    sirepo.jupyterhub.set_rs_migration_prompt_dismissed(
-        sirepo.http_request.parse_json().dismiss
-    )
-    return sirepo.http_reply.gen_json_ok()
+JupyterhubUser = None
 
 
 @sirepo.api_perm.require_user
 def api_migrateRsJupyterhubData(simulation_type):
+    _create_user()
     return sirepo.uri_router.call_api(
             'authGithubLogin',
             kwargs=PKDict(simulation_type=simulation_type),
@@ -34,8 +41,119 @@ def api_migrateRsJupyterhubData(simulation_type):
 
 @sirepo.api_perm.require_user
 def api_redirectJupyterHub():
+    _create_user()
     return sirepo.http_reply.gen_redirect('jupyterHub')
+
+def _event_logout():
+   flask.g.jupyterhub_logout = True
+
+def _event_end_api(resp):
+   # if flask.g.jupyterhub_logout:
+   #     resp.delete_cookie(...jupyterhub)
+    # TODO(e-carlin): remove jupyter cookies
+    pass
+
+def logged_in_user_name():
+    with sirepo.auth_db.thread_lock:
+        u = JupyterhubUser.search_by(
+            uid=sirepo.auth.logged_in_user(check_path=False),
+        )
+        if u:
+            return u.user_name
+        return None
 
 
 def init_apis(*args, **kwargs):
-    pass
+    # TODO(e-carlin): register a logout api with events
+    global cfg
+
+    if cfg:
+        return
+    cfg = pkconfig.init(
+        dst_db_root=(
+            pkio.py_path(sirepo.srdb.root()).join('jupyterhub'),
+            pkio.py_path,
+            'existing jupyter user db (ex /srv/jupyterhub)',
+        ),
+        src_db_root=(
+            pkio.py_path('/dev/null'),
+            pkio.py_path,
+            'new jupyter user db',
+        ),
+        uri_root=('jupyter', str, 'the root uri of jupyterhub'),
+    )
+    sirepo.auth_db.init_model(_init_model)
+    sirepo.events.register(
+        sirepo.events.GITHUB_AUTHORIZED,
+        _handle_github_authorized,
+    )
+
+# TODO(e-carlin): sort
+def _handle_github_authorized(kwargs):
+    with sirepo.auth_db.thread_lock:
+        s = cfg.src_db_root.join(kwargs.user_name)
+        u = logged_in_user_name()
+        assert u, 'need logged in JupyterhubUser'
+        d = cfg.dst_db_root.join(u)
+        try:
+            # TODO(e-carlin): use rename not move since on same partition py_path.rename (maybe os.rename)
+            s.rename(d)
+        except py.error.ENOTDIR:
+            # TODO(e-carlin): Maybe raise an error letting the user know
+            # They may have given the wrong github creds
+            pkdlog(
+                'Tried to migrate existing rs jupyter directory={} but not found. Ignoring.',
+                s,
+            )
+            pkio.mkdir_parent(d)
+    # TODO(e-carlin): /jupyter /juptyerHub ???
+    raise sirepo.util.Redirect('jupyter')
+
+def _create_user():
+    def __user_name(logged_in_user_name):
+        n = re.sub(
+            '\W+',
+            '_',
+            logged_in_user_name.split('@')[0],
+        )
+        u = JupyterhubUser.search_by(
+            user_name=n,
+        )
+        if u:
+            n += random.choice(string.ascii_lowercase)
+        return n
+
+    with sirepo.auth_db.thread_lock:
+        if logged_in_user_name():
+            return
+        # TODO(e-carlin): sirepo.auth.logged_in_user_name()
+        u = sirepo.auth.email.AuthEmailUser.search_by(
+            uid=sirepo.auth.logged_in_user(check_path=False),
+        )
+# TODO(e-carlin): Is below still True ??
+# TODO(e-carlin): if we are logged in but delete the run dir
+# (happens in dev, maybe in prod if we delete a logged in user)
+# then this assert will raise.
+# It would be ideal to log the user out and redirect to / as done
+# in non-jupyter apps but since we are outside of the flask context
+# accessing the sirepo cookie and redirecting is challenging.
+# Return None will display 403 for user which is fine for now.
+        assert u, 'must have existing logged in user to create JupyterhubUser'
+        JupyterhubUser(
+            uid=u.uid,
+            user_name=__user_name(u.user_name),
+        ).save()
+        return
+
+
+def _init_model(base):
+    global JupyterhubUser
+
+    class JupyterhubUser(base):
+        __tablename__ = 'jupyterhub_user_t'
+        uid = sqlalchemy.Column(sqlalchemy.String(8), primary_key=True)
+        user_name = sqlalchemy.Column(
+            sqlalchemy.String(100),
+            nullable=False,
+            unique=True,
+        )

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -18,7 +18,6 @@ import sirepo.auth_db
 import sirepo.events
 import sirepo.http_reply
 import sirepo.http_request
-import sirepo.jupyterhub
 import sirepo.srdb
 import sirepo.uri_router
 import sirepo.util

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -62,13 +62,13 @@ def init_apis(*args, **kwargs):
         dst_db_root=(
             pkio.py_path(sirepo.srdb.root()).join('jupyterhub'),
             pkio.py_path,
-            'existing jupyter user db (ex /srv/jupyterhub)',
+            'new jupyter user db',
         ),
         rs_jupyter_migrate=(False, bool, 'give user option to migrate data from jupyter.radiasoft.org'),
         src_db_root=(
-            pkio.py_path('/dev/null'),
+            pkio.py_path('/var/empty'),
             pkio.py_path,
-            'new jupyter user db',
+            'existing jupyter user db (ex /srv/jupyterhub)',
         ),
         uri_root=('jupyter', str, 'the root uri of jupyterhub'),
     )
@@ -133,7 +133,7 @@ def _event_github_authorized(kwargs):
         d = cfg.dst_db_root.join(u)
         try:
             s.rename(d)
-        except py.error.ENOTDIR:
+        except (py.error.ENOTDIR, py.error.ENOENT):
             pkdlog(
                 'Tried to migrate existing rs jupyter directory={} but not found. Ignoring.',
                 s,

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -34,7 +34,7 @@ JupyterhubUser = None
 def api_migrateJupyterhub():
     if not cfg.rs_jupyter_migrate:
         sirepo.util.raise_forbidden('migrate not enabled')
-    d = PKDict(**sirepo.http_request.parse_json())
+    d = sirepo.http_request.parse_json()
     if not d.doMigration:
         return sirepo.http_reply.gen_redirect('jupyterHub')
     return sirepo.uri_router.call_api(

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -38,9 +38,9 @@ def api_migrateJupyterhub():
     if not d.doMigration:
         return sirepo.http_reply.gen_redirect('jupyterHub')
     return sirepo.uri_router.call_api(
-            'authGithubLogin',
-            kwargs=PKDict(simulation_type='jupyterhublogin'),
-        )
+        'authGithubLogin',
+        kwargs=PKDict(simulation_type='jupyterhublogin'),
+    )
 
 
 @sirepo.api_perm.require_user

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -51,7 +51,7 @@ def api_redirectJupyterHub():
     return sirepo.http_reply.gen_json_ok()
 
 
-def logged_in_user_name(have_simulation_db=True):
+def jupyterhub_user_name(have_simulation_db=True):
     return _user_name(sirepo.auth.logged_in_user(check_path=have_simulation_db))
 
 
@@ -96,7 +96,7 @@ def _create_user():
             n += random.choice(string.ascii_lowercase)
         return n
 
-    if logged_in_user_name():
+    if jupyterhub_user_name():
         return False
     with sirepo.auth_db.thread_lock:
         JupyterhubUser(
@@ -130,7 +130,7 @@ def _event_github_authorized(kwargs):
         return
     with sirepo.auth_db.thread_lock:
         s = cfg.src_db_root.join(kwargs.user_name)
-        u = logged_in_user_name()
+        u = jupyterhub_user_name()
         assert u, 'need logged in JupyterhubUser'
         d = cfg.dst_db_root.join(u)
         try:

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -18,17 +18,9 @@ import sirepo.uri_router
 
 @sirepo.api_perm.require_user
 def api_dismissJupyterhubDataMovePrompt():
-    # TODO(e-carlin): maybe use cookie for this instead?
-    with sirepo.auth_db.thread_lock:
-        # TODO(e-carlin): _get_or_create_user maybe should return the sql model?
-        # TODO(e-carlin): make public if this is what I decide to use
-        # Need to create user because may not exist
-        sirepo.jupyterhub._get_or_create_user()
-        u = sirepo.jupyterhub.JupyterhubUser.search_by(
-            uid=sirepo.auth.logged_in_user(),
-        )
-        u.rs_migration_prompt_dimsissed = sirepo.http_request.parse_json().dismiss
-        u.save()
+    sirepo.jupyterhub.set_rs_migration_prompt_dismissed(
+        sirepo.http_request.parse_json().dismiss
+    )
     return sirepo.http_reply.gen_json_ok()
 
 

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -158,7 +158,6 @@ def _event_github_authorized(kwargs):
                 s,
             )
             pkio.mkdir_parent(d)
-    # TODO(e-carlin): /jupyter /juptyerHub ???
     raise sirepo.util.Redirect('jupyter')
 
 

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -26,6 +26,7 @@ import string
 
 cfg = None
 
+#: Used by auth_db. Sirepo record of each jupyterhub user.
 JupyterhubUser = None
 
 

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -30,7 +30,7 @@ JupyterhubUser = None
 
 
 @sirepo.api_perm.require_user
-def api_migrateRsJupyterhubData():
+def api_migrateJupyterhub():
     assert cfg.rs_jupyter_migrate, \
         'API forbidden'
     d = PKDict(**sirepo.http_request.parse_json())

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -29,6 +29,8 @@ cfg = None
 #: Used by auth_db. Sirepo record of each jupyterhub user.
 JupyterhubUser = None
 
+_HUB_USER_SEP = '_'
+
 
 @sirepo.api_perm.require_user
 def api_migrateJupyterhub():
@@ -85,7 +87,7 @@ def _create_user():
         assert logged_in_user_name, 'must supply a name'
         n = re.sub(
             '\W+',
-            '_',
+            _HUB_USER_SEP,
             # Get the local part of the email. Or in the case of another auth
             # method (ex github) it won't have an '@' so it will just be their
             # user name, handle, etc.
@@ -95,7 +97,7 @@ def _create_user():
         if u:
             # The username already exists. Add a random letter to try and create
             # a unique user name.
-            n += random.choice(string.ascii_lowercase)
+            n += _HUB_USER_SEP + random.choice(string.ascii_lowercase)
         return n
 
     if jupyterhub_user_name():

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -82,6 +82,7 @@ def init_apis(*args, **kwargs):
 
 def _create_user():
     def __user_name(logged_in_user_name):
+        assert logged_in_user_name, 'must supply a name'
         n = re.sub(
             '\W+',
             '_',

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -55,7 +55,6 @@ def logged_in_user_name(check_path=True):
 
 
 def init_apis(*args, **kwargs):
-    # TODO(e-carlin): register a logout api with events
     global cfg
 
     if cfg:
@@ -98,14 +97,13 @@ def _create_user():
     with sirepo.auth_db.thread_lock:
         if logged_in_user_name():
             return False
-        # TODO(e-carlin): sirepo.auth.logged_in_user_name()
-        u = sirepo.auth.email.AuthEmailUser.search_by(
-            uid=sirepo.auth.logged_in_user(),
-        )
-        assert u, 'must have existing logged in user to create JupyterhubUser'
+        i = sirepo.auth.logged_in_user()
+        u = sirepo.auth.logged_in_user_name()
+        assert i and u, \
+            f'Must have logged in user with user_name. uid={i} user_name={u}'
         JupyterhubUser(
-            uid=u.uid,
-            user_name=__user_name(u.user_name),
+            uid=i,
+            user_name=__user_name(u),
         ).save()
         return True
 

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -8,12 +8,12 @@ from __future__ import absolute_import, division, print_function
 from pykern import pkconfig, pkio
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp, pkdlog
+import flask
 import py.error
-import re
 import random
+import re
 import sirepo.api_perm
 import sirepo.auth
-import sirepo.auth_db
 import sirepo.auth_db
 import sirepo.events
 import sirepo.http_reply
@@ -22,8 +22,8 @@ import sirepo.jupyterhub
 import sirepo.srdb
 import sirepo.uri_router
 import sirepo.util
-import string
 import sqlalchemy
+import string
 
 cfg = None
 
@@ -44,14 +44,6 @@ def api_redirectJupyterHub():
     _create_user()
     return sirepo.http_reply.gen_redirect('jupyterHub')
 
-def _event_logout():
-   flask.g.jupyterhub_logout = True
-
-def _event_end_api(resp):
-   # if flask.g.jupyterhub_logout:
-   #     resp.delete_cookie(...jupyterhub)
-    # TODO(e-carlin): remove jupyter cookies
-    pass
 
 def logged_in_user_name():
     with sirepo.auth_db.thread_lock:
@@ -83,31 +75,12 @@ def init_apis(*args, **kwargs):
         uri_root=('jupyter', str, 'the root uri of jupyterhub'),
     )
     sirepo.auth_db.init_model(_init_model)
-    sirepo.events.register(
-        sirepo.events.GITHUB_AUTHORIZED,
-        _handle_github_authorized,
-    )
+    sirepo.events.register({
+        sirepo.events.Type.AUTH_LOGOUT: _event_auth_logout,
+        sirepo.events.Type.END_API_CALL: _event_end_api_call,
+        sirepo.events.Type.GITHUB_AUTHORIZED: _event_github_authorized,
+    })
 
-# TODO(e-carlin): sort
-def _handle_github_authorized(kwargs):
-    with sirepo.auth_db.thread_lock:
-        s = cfg.src_db_root.join(kwargs.user_name)
-        u = logged_in_user_name()
-        assert u, 'need logged in JupyterhubUser'
-        d = cfg.dst_db_root.join(u)
-        try:
-            # TODO(e-carlin): use rename not move since on same partition py_path.rename (maybe os.rename)
-            s.rename(d)
-        except py.error.ENOTDIR:
-            # TODO(e-carlin): Maybe raise an error letting the user know
-            # They may have given the wrong github creds
-            pkdlog(
-                'Tried to migrate existing rs jupyter directory={} but not found. Ignoring.',
-                s,
-            )
-            pkio.mkdir_parent(d)
-    # TODO(e-carlin): /jupyter /juptyerHub ???
-    raise sirepo.util.Redirect('jupyter')
 
 def _create_user():
     def __user_name(logged_in_user_name):
@@ -144,6 +117,45 @@ def _create_user():
             user_name=__user_name(u.user_name),
         ).save()
         return
+
+
+def _event_auth_logout():
+    flask.g.jupyterhub_logout_user_name = logged_in_user_name()
+
+
+def _event_end_api_call(kwargs):
+    u = flask.g.get('jupyterhub_logout_user_name', None)
+    if not u:
+       return
+    for c in (
+            ('jupyterhub-hub-login', 'hub'),
+            (f'jupyterhub-user-{u}', f'user/{u}'),
+    ):
+        kwargs.resp.delete_cookie(
+            c[0],
+            # Trailing slash is required in paths
+            path=f'/{cfg.uri_root}/{c[1]}/',
+        )
+
+
+def _event_github_authorized(kwargs):
+    with sirepo.auth_db.thread_lock:
+        s = cfg.src_db_root.join(kwargs.user_name)
+        u = logged_in_user_name()
+        assert u, 'need logged in JupyterhubUser'
+        d = cfg.dst_db_root.join(u)
+        try:
+            s.rename(d)
+        except py.error.ENOTDIR:
+            # TODO(e-carlin): Maybe raise an error letting the user know
+            # They may have given the wrong github creds
+            pkdlog(
+                'Tried to migrate existing rs jupyter directory={} but not found. Ignoring.',
+                s,
+            )
+            pkio.mkdir_parent(d)
+    # TODO(e-carlin): /jupyter /juptyerHub ???
+    raise sirepo.util.Redirect('jupyter')
 
 
 def _init_model(base):

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -95,16 +95,12 @@ def _create_user():
             n += random.choice(string.ascii_lowercase)
         return n
 
+    if logged_in_user_name():
+        return False
     with sirepo.auth_db.thread_lock:
-        if logged_in_user_name():
-            return False
-        i = sirepo.auth.logged_in_user()
-        u = sirepo.auth.logged_in_user_name()
-        assert i and u, \
-            f'Must have logged in user with user_name. uid={i} user_name={u}'
         JupyterhubUser(
-            uid=i,
-            user_name=__user_name(u),
+            uid=sirepo.auth.logged_in_user(),
+            user_name=__user_name(sirepo.auth.user_name()),
         ).save()
         return True
 

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -50,10 +50,10 @@ def api_redirectJupyterHub():
     return sirepo.http_reply.gen_json_ok()
 
 
-def logged_in_user_name():
+def logged_in_user_name(check_path=True):
     with sirepo.auth_db.thread_lock:
         u = JupyterhubUser.search_by(
-            uid=sirepo.auth.logged_in_user(check_path=False),
+            uid=sirepo.auth.logged_in_user(check_path=check_path),
         )
         if u:
             return u.user_name
@@ -106,16 +106,8 @@ def _create_user():
             return False
         # TODO(e-carlin): sirepo.auth.logged_in_user_name()
         u = sirepo.auth.email.AuthEmailUser.search_by(
-            uid=sirepo.auth.logged_in_user(check_path=False),
+            uid=sirepo.auth.logged_in_user(),
         )
-# TODO(e-carlin): Is below still True ??
-# TODO(e-carlin): if we are logged in but delete the run dir
-# (happens in dev, maybe in prod if we delete a logged in user)
-# then this assert will raise.
-# It would be ideal to log the user out and redirect to / as done
-# in non-jupyter apps but since we are outside of the flask context
-# accessing the sirepo cookie and redirecting is challenging.
-# Return None will display 403 for user which is fine for now.
         assert u, 'must have existing logged in user to create JupyterhubUser'
         JupyterhubUser(
             uid=u.uid,

--- a/sirepo/sim_data/jupyterhublogin.py
+++ b/sirepo/sim_data/jupyterhublogin.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+u"""simulation data operations
+
+:copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from __future__ import absolute_import, division, print_function
 import sirepo.sim_data
 
 

--- a/sirepo/srunit.py
+++ b/sirepo/srunit.py
@@ -135,14 +135,20 @@ def test_in_request(op, cfg=None, before_request=None, headers=None, want_cookie
 
 class UwsgiClient(PKDict):
 
+    def __init__(self, env, *args, **kwargs):
+        import sirepo.pkcli.service
+
+        c = sirepo.pkcli.service._cfg()
+        for k in ('nginx_proxy_port', 'ip'):
+            self[f'_{k}'] = env.get(f'SIREPO_PKCLI_SERVICE_{k.upper()}') or c[k]
+
     def sr_post(self, route_or_uri, data, headers=None):
         from pykern import pkjson
-        from sirepo.pkcli import service
         import requests
 
         r = requests.post(
             (
-                f'http://{service._cfg().ip}:{service._cfg().nginx_proxy_port}'
+                f'http://{self._ip}:{self._nginx_proxy_port}'
                     + f'{self._server_route(route_or_uri)}'
             ),
             json=data,

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -5,8 +5,8 @@ u"""Handles dispatching of uris to server.api_* functions
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from __future__ import absolute_import, division, print_function
-from pykern.pkcollections import PKDict
 from pykern import pkinspect
+from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdc, pkdexc, pkdlog, pkdp
 import flask
 import importlib

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -94,6 +94,8 @@ def call_api(func_or_name, kwargs=None, data=None):
         # this is ok to call (even if s is None)
         sirepo.http_request.set_sim_type(s)
     sirepo.cookie.save_to_cookie(r)
+    # TODO(e-carlin): cookie will register with it
+    # events.emit(events.END_API_CALL, r)
     return r
 
 

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -95,7 +95,7 @@ def call_api(func_or_name, kwargs=None, data=None):
         # this is ok to call (even if s is None)
         sirepo.http_request.set_sim_type(s)
     sirepo.cookie.save_to_cookie(r)
-    sirepo.events.emit(sirepo.events.Type.END_API_CALL, kwargs=PKDict(resp=r))
+    sirepo.events.emit('end_api_call', PKDict(resp=r))
     return r
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,7 +312,7 @@ def _subprocess_setup(request, cfg=None, uwsgi=False):
     from pykern import pkunit
     from pykern import pkio
     # different port than default so can run tests when supervisor running
-    p = '8002'
+    p = '8101'
     cfg.pkupdate(
         PYKERN_PKDEBUG_WANT_PID_TIME='1',
         SIREPO_PKCLI_JOB_SUPERVISOR_IP=i,
@@ -320,7 +320,8 @@ def _subprocess_setup(request, cfg=None, uwsgi=False):
         SIREPO_SRDB_ROOT=str(pkio.mkdir_parent(pkunit.work_dir().join('db'))),
     )
     if uwsgi:
-        cfg.SIREPO_PKCLI_SERVICE_PORT = '8003'
+        cfg.SIREPO_PKCLI_SERVICE_PORT = '8102'
+        cfg.SIREPO_PKCLI_SERVICE_NGINX_PROXY_PORT = '8180'
     for x in 'DRIVER_LOCAL', 'DRIVER_DOCKER', 'API', 'DRIVER_SBATCH':
         cfg['SIREPO_JOB_{}_SUPERVISOR_URI'.format(x)] = 'http://{}:{}'.format(i, p)
     if sbatch_module:
@@ -330,7 +331,7 @@ def _subprocess_setup(request, cfg=None, uwsgi=False):
     import sirepo.srunit
     c = None
     if uwsgi:
-        c = sirepo.srunit.UwsgiClient()
+        c = sirepo.srunit.UwsgiClient(env)
     else:
         c = sirepo.srunit.flask_client(
             cfg=cfg,


### PR DESCRIPTION
Fix #2979.

Add support in Sirepo for running jupyterhub at sirepo.com/jupyter

To test:
`sirepo service jupyterhub`
To test with migration of data using GitHub handle:
In `sirepo.pkcli.service.jupyterhub` comment out the line setting `env=`
`SIREPO_AUTH_METHODS='github:email' SIREPO_SIM_API_JUPYTERHUBLOGIN_RS_JUPYTER_MIGRATE='1' SIREPO_AUTH_GITHUB_METHOD_VISIBLE='' SIREPO_AUTH_GITHUB_KEY='<dev_key>' SIREPO_AUTH_GITHUB_SECRET='<dev_secret>' sirepo service jupyterhub`