### PR TITLE
Fix #3003 Radia dump file import

### DIFF
--- a/sirepo/exporter.py
+++ b/sirepo/exporter.py
@@ -31,6 +31,10 @@ def create_archive(sim):
     Returns:
         py.path.Local: zip file name
     """
+    if hasattr(sim.template, 'create_archive'):
+        res = sim.template.create_archive(sim)
+        if res:
+            return res
     if not pkio.has_file_extension(sim.filename, ('zip', 'html')):
         raise sirepo.util.NotFound(
             'unknown file type={}; expecting html or zip'.format(sim.filename)

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -970,7 +970,6 @@ SIREPO.app.directive('appHeader', function(appState, requestSender) {
         ].join(''),
         controller: function($scope) {
             $scope.exportDmp = function() {
-                srdbg('DMP');
                 requestSender.newWindow('exportArchive', {
                     '<simulation_id>': appState.models.simulation.simulationId,
                     '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -954,7 +954,7 @@ SIREPO.app.directive('appHeader', function(appState, requestSender) {
             '<div data-app-header-right="nav">',
               '<app-header-right-sim-loaded>',
                 '<div data-sim-sections="">',
-                  '<li data-ng-if="! isExampleLoaded()" class="sim-section" data-ng-class="{active: nav.isActive(\'source\')}"><a href data-ng-click="nav.openSection(\'source\')"><span class="glyphicon glyphicon-magnet"></span> Design</a></li>',
+                  '<li data-ng-if="! isImported()" class="sim-section" data-ng-class="{active: nav.isActive(\'source\')}"><a href data-ng-click="nav.openSection(\'source\')"><span class="glyphicon glyphicon-magnet"></span> Design</a></li>',
                   '<li class="sim-section" data-ng-class="{active: nav.isActive(\'visualization\')}"><a href data-ng-click="nav.openSection(\'visualization\')"><span class="glyphicon glyphicon-picture"></span> Visualization</a></li>',
                 '</div>',
               '</app-header-right-sim-loaded>',
@@ -980,8 +980,9 @@ SIREPO.app.directive('appHeader', function(appState, requestSender) {
             $scope.showImportModal = function() {
                 $('#simulation-import').modal('show');
             };
-            $scope.isExampleLoaded = function() {
-                return (appState.models.simulation || {}).isExample;
+            $scope.isImported = function() {
+                return (appState.models.simulation || {}).isExample ||
+                    (appState.models.simulation || {}).dmpImportFile;
             };
         }
     };
@@ -2076,8 +2077,8 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
             });
 
             // stash the actor and associated info to avoid recalculation
-            function addActor(id, group, actor, type, pickable) {
-                //srdbg('addActor', 'id', id, 'grp', group, 'type', type, 'pick', pickable);
+            function addActor(id, group, actor, geomType, pickable) {
+                //srdbg('addActor', 'id', id, 'grp', group, 'geomType', type, 'pick', pickable);
                 var pData = actor.getMapper().getInputData();
                 var info = {
                     actor: actor,
@@ -2086,11 +2087,11 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
                     id: id,
                     pData: pData,
                     scalars: pData.getCellData().getScalars(),
-                    type: type,
+                    type: geomType,
                 };
 
                 if (info.scalars) {
-                    info.colorIndices = utilities.indexArray(numColors(pData, type))
+                    info.colorIndices = utilities.indexArray(numColors(pData, geomType))
                         .map(function (i) {
                             return 4 * i;
                         });
@@ -2581,7 +2582,8 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
                             getData: function () {
                                 return selectedObj;
                             },
-                            modelKey: 'geomObject',
+                            // just color etc here?
+                            modelKey: 'radiaObject',
                         } : null,
                     };
                 }

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -942,7 +942,7 @@ SIREPO.app.directive('appFooter', function() {
     };
 });
 
-SIREPO.app.directive('appHeader', function(appState, panelState) {
+SIREPO.app.directive('appHeader', function(appState, requestSender) {
     return {
         restrict: 'A',
         scope: {
@@ -959,7 +959,7 @@ SIREPO.app.directive('appHeader', function(appState, panelState) {
                 '</div>',
               '</app-header-right-sim-loaded>',
               '<app-settings>',
-                //  '<div>App-specific setting item</div>',
+                    '<li><a href data-ng-click="exportDmp()"><span class="glyphicon glyphicon-cloud-download"></span> Export Radia Dump</a></li>',
               '</app-settings>',
               '<app-header-right-sim-list>',
                 '<ul class="nav navbar-nav sr-navbar-right">',
@@ -969,6 +969,14 @@ SIREPO.app.directive('appHeader', function(appState, panelState) {
             '</div>',
         ].join(''),
         controller: function($scope) {
+            $scope.exportDmp = function() {
+                srdbg('DMP');
+                requestSender.newWindow('exportArchive', {
+                    '<simulation_id>': appState.models.simulation.simulationId,
+                    '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
+                    '<filename>':  $scope.nav.simulationName() + '.dat',
+                });
+            };
             $scope.showImportModal = function() {
                 $('#simulation-import').modal('show');
             };

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -6,9 +6,6 @@
     },
     "constants": {
         "defaultGeomColor": "#ffffff",
-        "inProgressText": "Solving",
-        "objectScale": 0.001,
-        "pathPtsFileType": "path-pts",
         "detailFields": {
             "fieldPath": {
                 "circlePath": ["ctrX", "ctrY", "ctrZ", "radius", "theta", "phi"],
@@ -27,6 +24,13 @@
                 "rotateClone": ["name", "angle", "axis", "center"]
             }
         },
+        "geomTypeLines": "lines",
+        "geomTypePolys": "polygons",
+        "geomTypeVectors": "vectors",
+        "inProgressText": "Solving",
+        "objectScale": 0.001,
+        "pathPtsFileType": "path-pts",
+        "radiaDmpFileType": "radia-dmp",
         "toolbarItems": [
             {
                 "canDrag": true,
@@ -123,7 +127,9 @@
                 ],
                 "name": "Transforms (clone)"
             }
-        ]
+        ],
+        "viewTypeFields": "fields",
+        "viewTypeObjects": "objects"
     },
     "dynamicFiles": {
         "externalLibs": {
@@ -567,6 +573,22 @@
                 "numSegments",
                 "currentDensity",
                 "fieldCalc",
+                "color"
+            ]],
+                ["Transforms", [
+                    "transforms"
+                ]]
+            ]
+        },
+        "radiaObject": {
+            "title": "Object",
+            "basic": [
+                "name",
+                "color"
+            ],
+            "advanced": [
+                ["Main", [
+                "name",
                 "color"
             ]],
                 ["Transforms", [

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -587,13 +587,8 @@
                 "color"
             ],
             "advanced": [
-                ["Main", [
                 "name",
                 "color"
-            ]],
-                ["Transforms", [
-                    "transforms"
-                ]]
             ]
         },
         "rotate": {

--- a/sirepo/package_data/template/radia/geom.py.jinja
+++ b/sirepo/package_data/template/radia/geom.py.jinja
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import h5py
+import os
 import re
 from pykern.pkcollections import PKDict
 from sirepo.template import radia_tk
@@ -64,6 +65,11 @@ def _add_object(o):
 id_map = PKDict()
 {% if isExample %}
 g_id = radia_examples.build('{{ geomName }}')
+{% elif dmpImportFile %}
+if not os.path.isfile('{{ dmpFile }}'):
+    with open('{{ dmpImportFile }}', 'rb') as f:
+        b = f.read()
+        g_id = radia_tk.load_bin(b)
 {% else %}
 for obj in {{ objects }}:
     o = PKDict(obj)

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -156,6 +156,7 @@ def api_errorLogging():
 @api_perm.require_user
 def api_exportArchive(simulation_type, simulation_id, filename):
     req = http_request.parse_params(
+        template=True,
         filename=filename,
         id=simulation_id,
         type=simulation_type,

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -75,6 +75,7 @@ def create_archive(sim):
             content_type='application/octet-stream',
             filename=sim.filename,
         )
+    return False
 
 
 def extract_report_data(run_dir, sim_in):

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -174,6 +174,9 @@ def get_application_data(data, **kwargs):
 def new_simulation(data, new_simulation_data):
     data.models.simulation.beamAxis = new_simulation_data.beamAxis
     data.models.geometry.name = new_simulation_data.name
+    if new_simulation_data.dmpImportFile:
+        data.models.simulation.dmpImportFile = new_simulation_data.dmpImportFile
+
 
 def python_source_for_model(data, model):
     return _generate_parameters_file(data)
@@ -360,6 +363,10 @@ def _generate_parameters_file(data):
     g = data.models.geometry
 
     v['dmpFile'] = _dmp_file(sim_id)
+    if 'dmpImportFile' in data.models.simulation:
+        v['dmpImportFile'] = simulation_db.simulation_lib_dir(SIM_TYPE).join(
+            f'radia-dmp.{data.models.simulation.dmpImportFile}'
+        )
     v['isExample'] = data.models.simulation.get('isExample', False)
     v['objects'] = g.get('objects', [])
     v['geomName'] = g.name

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -369,7 +369,7 @@ def _generate_obj_data(g_id, name):
 def _generate_parameters_file(data):
     report = data.get('report', '')
     res, v = template_common.generate_parameters_file(data)
-    sim_id = data.simulationId
+    sim_id = data.get('simulationId', data.models.simulation.simulationId)
     g = data.models.geometry
 
     v['dmpFile'] = _dmp_file(sim_id)

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -45,9 +45,7 @@ _SDDS_INDEX = 0
 
 GEOM_PYTHON_FILE = 'geom.py'
 MPI_SUMMARY_FILE = 'mpi-info.json'
-VIEW_TYPE_OBJ = 'objects'
-VIEW_TYPE_FIELD = 'fields'
-VIEW_TYPES = [VIEW_TYPE_OBJ, VIEW_TYPE_FIELD]
+VIEW_TYPES = [_SCHEMA.constants.viewTypeObjects, _SCHEMA.constants.viewTypeFields]
 
 # cfg contains sdds instance
 _cfg = PKDict(sdds=None)
@@ -76,8 +74,8 @@ def extract_report_data(run_dir, sim_in):
         template_common.write_sequential_result({}, run_dir=run_dir)
     if 'geometry' in sim_in.report:
         v_type = sim_in.models.magnetDisplay.viewType
-        f_type = sim_in.models.magnetDisplay.fieldType if v_type == VIEW_TYPE_FIELD\
-            else None
+        f_type = sim_in.models.magnetDisplay.fieldType if v_type ==\
+            _SCHEMA.constants.viewTypeFields else None
         template_common.write_sequential_result(
             _read_data(sim_in.simulationId, v_type, f_type),
             run_dir=run_dir,
@@ -114,7 +112,7 @@ def get_application_data(data, **kwargs):
             #except KeyError:
             #    res = None
             #if res:
-            #    v = [d.vectors.vertices for d in res.data if 'vectors' in d]
+            #    v = [d.vectors.vertices for d in res.data if _SCHEMA.constants.geomTypeVectors in d]
             #    old_pts = [p for a in v for p in a]
             #    new_pts = _build_field_points(data.fieldPaths)
             #    if len(old_pts) == len(new_pts) and numpy.allclose(new_pts, old_pts):
@@ -128,9 +126,9 @@ def get_application_data(data, **kwargs):
         # moved addition of lines from client
         tmp_f_type = data.fieldType
         data.fieldType = None
-        data.geomTypes = ['lines']
+        data.geomTypes = [_SCHEMA.constants.geomTypeLines]
         data.method = 'get_geom'
-        data.viewType = VIEW_TYPE_OBJ
+        data.viewType = _SCHEMA.constants.viewTypeObjects
         new_res = get_application_data(data)
         res.data += new_res.data
         data.fieldType = tmp_f_type
@@ -139,8 +137,11 @@ def get_application_data(data, **kwargs):
     if data.method == 'get_field_integrals':
         return _generate_field_integrals(g_id, data.fieldPaths)
     if data.method == 'get_geom':
-        g_types = data.get('geomTypes', ['lines', 'polygons'])
-        g_types.extend(['center', 'size'])
+        g_types = data.get(
+            'geomTypes',
+            [_SCHEMA.constants.geomTypeLines, _SCHEMA.constants.geomTypePolys]
+        )
+        g_types.extend(['center', 'name', 'size'])
         res = _read_or_generate(g_id, data)
         rd = res.data if 'data' in res else []
         res.data = [{k: d[k] for k in d.keys() if k in g_types} for d in rd]
@@ -338,9 +339,9 @@ def _generate_field_integrals(g_id, f_paths):
 def _generate_data(g_id, in_data, add_lines=True):
     try:
         o = _generate_obj_data(g_id, in_data.name)
-        if in_data.viewType == VIEW_TYPE_OBJ:
+        if in_data.viewType == _SCHEMA.constants.viewTypeObjects:
             return o
-        elif in_data.viewType == VIEW_TYPE_FIELD:
+        elif in_data.viewType == _SCHEMA.constants.viewTypeFields:
             g = _generate_field_data(
                 g_id, in_data.name, in_data.fieldType, in_data.get('fieldPaths', None)
             )
@@ -353,7 +354,7 @@ def _generate_data(g_id, in_data, add_lines=True):
 
 
 def _generate_obj_data(g_id, name):
-    return radia_tk.geom_to_data(g_id, name=name)
+    return radia_tk.geom_to_data(g_id, name=name, g_type=_SCHEMA.constants.viewTypeObjects)
 
 
 def _generate_parameters_file(data):
@@ -365,7 +366,7 @@ def _generate_parameters_file(data):
     v['dmpFile'] = _dmp_file(sim_id)
     if 'dmpImportFile' in data.models.simulation:
         v['dmpImportFile'] = simulation_db.simulation_lib_dir(SIM_TYPE).join(
-            f'radia-dmp.{data.models.simulation.dmpImportFile}'
+            f'{_SCHEMA.constants.radiaDmpFileType}.{data.models.simulation.dmpImportFile}'
         )
     v['isExample'] = data.models.simulation.get('isExample', False)
     v['objects'] = g.get('objects', [])
@@ -377,7 +378,7 @@ def _generate_parameters_file(data):
         raise ValueError('Invalid view {} ({})'.format(v_type, VIEW_TYPES))
     v['viewType'] = v_type
     v['dataFile'] = _geom_file(sim_id)
-    if v_type == VIEW_TYPE_FIELD:
+    if v_type == _SCHEMA.constants.viewTypeFields:
         f_type = disp.fieldType
         if f_type not in radia_tk.FIELD_TYPES:
             raise ValueError(
@@ -395,8 +396,8 @@ def _generate_parameters_file(data):
         radia_tk.reset()
         data.report = 'geometry'
         return _generate_parameters_file(data)
-    v['h5ObjPath'] = _geom_h5_path(VIEW_TYPE_OBJ)
-    v['h5FieldPath'] = _geom_h5_path(VIEW_TYPE_FIELD, f_type)
+    v['h5ObjPath'] = _geom_h5_path(_SCHEMA.constants.viewTypeObjects)
+    v['h5FieldPath'] = _geom_h5_path(_SCHEMA.constants.viewTypeFields, f_type)
 
     return template_common.render_jinja(
         SIM_TYPE,

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -68,6 +68,15 @@ def background_percent_complete(report, run_dir, is_running):
     )
 
 
+def create_archive(sim):
+    if sim.filename.endswith('dat'):
+        return sirepo.http_reply.gen_file_as_attachment(
+            _dmp_file(sim.id),
+            content_type='application/octet-stream',
+            filename=sim.filename,
+        )
+
+
 def extract_report_data(run_dir, sim_in):
     assert sim_in.report in _REPORTS, 'unknown report: {}'.format(sim_in.report)
     if 'reset' in sim_in.report:


### PR DESCRIPTION
Adds the ability to import binary Radia dump files. Notes:

- simulations created this way cannot be "designed" so that tab is unavailable (similar to examples)
- also added is the ability to export to a dump file. This is done by letting the template do the export if the method is defined, but maybe an ```Exporter``` class is more appropriate
