### PR TITLE
Fix #3086. Make the layout of editors 4 across.

### DIFF
--- a/sirepo/package_data/static/html/controls-controls.html
+++ b/sirepo/package_data/static/html/controls-controls.html
@@ -12,15 +12,14 @@
         <div data-sim-status-panel="controls.simState"></div>
       </div>
     </div>
-    <div class="clearfix"></div>
+  </div>
+  <div class="row">
     <div data-ng-repeat="col in controls.editorColumns track by $index">
-      <div class="col-sm-6 col-md-3">
-        <div class="row">
-          <div class="col-sm-12" data-ng-repeat="item in col track by $index">
-            <div data-basic-editor-panel="" data-view-name="{{ item.viewName }}" data-model-data="item" data-panel-title="{{ item.title }}"></div>
-          </div>
+      <div class="row" ng-show="$index % 4 == 0"></div>
+        <div class="col-sm-6 col-md-3">
+          <div data-basic-editor-panel="" data-view-name="{{ col.viewName }}" data-model-data="col" data-panel-title="{{ col.title }}"></div>
         </div>
-      </div>
+      </div ng-show="$index % 4 == 0">
     </div>
   </div>
 </div>

--- a/sirepo/package_data/static/html/controls-controls.html
+++ b/sirepo/package_data/static/html/controls-controls.html
@@ -15,11 +15,10 @@
   </div>
   <div class="row">
     <div data-ng-repeat="col in controls.editorColumns track by $index">
-      <div class="row" ng-show="$index % 4 == 0"></div>
+      <div class="clearfix" ng-if="$index % 4 == 0"></div>
         <div class="col-sm-6 col-md-3">
           <div data-basic-editor-panel="" data-view-name="{{ col.viewName }}" data-model-data="col" data-panel-title="{{ col.title }}"></div>
         </div>
-      </div ng-show="$index % 4 == 0">
     </div>
   </div>
 </div>

--- a/sirepo/package_data/static/js/controls.js
+++ b/sirepo/package_data/static/js/controls.js
@@ -109,7 +109,7 @@ SIREPO.app.controller('ControlsController', function(appState, controlsService, 
         var beamlineId = appState.models.externalLattice.models.simulation.visualizationBeamlineId;
         getBeamlineElements(beamlineId, []).forEach(function(element) {
             if (schema[element.type]) {
-                self.editorColumns.push([modelForElement(element)]);
+                self.editorColumns.push(modelForElement(element));
             }
         });
     });


### PR DESCRIPTION
In addition, make it so when the "Save Changes" button appears other
editors don't shift into rows below causing awkward spacing.