### PR TITLE
Fix #3091 incorrect item lists

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -274,6 +274,7 @@ SIREPO.app.controller('RadiaSourceController', function (appState, geometry, pan
     self.copyObject = function(o) {
         var copy = appState.clone(o);
         copy.name = newObjectName(copy);
+        copy.groupId = '';
         addObject(copy);
         self.editObject(copy);
     };

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -293,8 +293,8 @@ SIREPO.app.controller('RadiaSourceController', function (appState, geometry, pan
         }
         deleteShapesForObject(o);
         // if object was a group, ungroup its members
-        for (let m of (o.members || [])) {
-            self.getObject(m).groupId = '';
+        for (let mId of (o.members || [])) {
+            self.getObject(mId).groupId = '';
         }
         // if object was in a group, remove from that group
         removeFromGroup(o);

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -309,6 +309,8 @@ SIREPO.app.controller('RadiaSourceController', function (appState, geometry, pan
         }
         let g = self.getObject(gId);
         g.members.splice(g.members.indexOf(o.id), 1);
+        appState.models.geomGroup = g;
+        appState.saveQuietly('geomGroup');
     }
 
     self.editItem = function(o) {


### PR DESCRIPTION
Notes:

- Missing items was due to copied objects having the same ```groupId``` as the original, so the code thought the copy was already in a group and omitted it
- Removed the possibility of adding a parent group to one of its children
- Ensure deleted objects are removed from groups