### PR TITLE
Issue/3099 Check for sdds_beam input during write

### DIFF
--- a/sirepo/template/lattice.py
+++ b/sirepo/template/lattice.py
@@ -83,7 +83,7 @@ class InputFileIterator(ModelIterator):
         self.sim_data = sim_data
 
     def field(self, model, field_schema, field):
-        if model[field] and field_schema[1].startswith('InputFile'):
+        if model[field] and (field_schema[1].startswith('InputFile') or field_schema[1].startswith('BeamInputFile')):
             self.result.append(self.sim_data.lib_file_name_with_model_field(
                 LatticeUtil.model_name_for_data(model), field, model[field]))
 

--- a/sirepo/template/lattice.py
+++ b/sirepo/template/lattice.py
@@ -83,7 +83,7 @@ class InputFileIterator(ModelIterator):
         self.sim_data = sim_data
 
     def field(self, model, field_schema, field):
-        if model[field] and (field_schema[1].startswith('InputFile') or field_schema[1].startswith('BeamInputFile')):
+        if model[field] and field_schema[1].startswith(('InputFile', 'BeamInputFile')):
             self.result.append(self.sim_data.lib_file_name_with_model_field(
                 LatticeUtil.model_name_for_data(model), field, model[field]))
 


### PR DESCRIPTION
This fixes #3099
Looks like the issue is that `BeamInputFile` is used as the description for sdds_beam.input in the elegant schema instead of just `InputFile`. I wasn't sure of the significance of `BeamInputFile` so I just added it into `InputFileIterator` as a fix.