### PR TITLE
Fix #3129. Enable particle reflection from emitter and collector plates.

### DIFF
--- a/sirepo/package_data/static/css/warpvnd.css
+++ b/sirepo/package_data/static/css/warpvnd.css
@@ -11,8 +11,8 @@
   cursor: pointer;
 }
 .warpvnd-plate-no-voltage {
-  stroke: rgb(228, 176, 95);
   fill: rgba(255, 146, 105, 0.3);
+  stroke: rgb(228, 176, 95);
 }
 .warpvnd-plate-voltage {
   fill: rgba(105, 146, 255, 0.3);

--- a/sirepo/package_data/static/html/conductor-grid.html
+++ b/sirepo/package_data/static/html/conductor-grid.html
@@ -23,12 +23,10 @@
               <svg class="plot-viewport" data-ng-attr-width="{{ width }}" data-ng-attr-height="{{ height }}" data-ng-drop="true" data-ng-drag-move="dragMove($data, $event)" data-ng-drop-success="dropSuccess($data, $event)">
                   <defs>
                       <pattern id="reflectionPattern-anode" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
-                          <path d="M0,0 l20,20" stroke="{{  source.conductorColors.nonZero }}" stroke-width="1.5" stroke-opacity="{{ source.getReflectOpacity('anode', 'd') }}"></path>
-                          <!--<circle cx="2" cy="12" r="2" fill="{{  source.conductorColors.nonZero }}" fill-opacity="{{ source.getReflectOpacity('anode', 'd') }}"></circle>-->
+                          <path d="M0,0 l20,20" stroke="{{  source.conductorColors.nonZero }}" stroke-width="1.5" stroke-opacity="{{ source.getReflectOpacity('anode') }}"></path>
                       </pattern>
                       <pattern data-ng-repeat="conductorType in source.conductorTypes() track by conductorType.id" id="reflectionPattern-{{ conductorType.id }}" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
-                          <path d="M0,0 l20,20" stroke="{{ conductorType.color }}" stroke-width="1.5" stroke-opacity="{{ source.getReflectOpacity(conductorType.id, 'd') }}"></path>
-                          <!--<circle cx="2" cy="12" r="2" fill="{{ conductorType.color }}" fill-opacity="{{ source.getReflectOpacity(conductorType.id, 'd') }}"></circle>-->
+                          <path d="M0,0 l20,20" stroke="{{ conductorType.color }}" stroke-width="1.5" stroke-opacity="{{ source.getReflectOpacity(conductorType.id) }}"></path>
                       </pattern>
                   </defs>
                   <rect class="overlay mouse-zoom" data-ng-attr-width="{{ width }}" data-ng-attr-height="{{ height }}"></rect>

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -2973,7 +2973,7 @@ SIREPO.app.directive('optimizeFloat', function(appState, panelState) {
         },
         template: [
             // keep the field the same dimensions as regular float, but offset width by button size
-            '<div class="input-group input-group-sm" style="margin-right: -30px">',
+            '<div class="input-group input-group-sm">',
               '<input data-string-to-number="" data-ng-model="model[field]" data-min="min" data-max="max" class="form-control" style="text-align: right" data-lpignore="true" required />',
               '<div class="input-group-btn">',
                 '<button data-ng-attr-class="btn btn-{{ buttonName() }} dropdown-toggle" data-toggle="dropdown" type="button" title="Optimization Settings"><span class="glyphicon glyphicon-cog"></span></button>',

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -603,7 +603,8 @@ SIREPO.app.controller('SourceController', function (appState, frameCache, panelS
         models.forEach((m) => {
             f(m);
             probFields.forEach(function (f) {
-                panelState.showField(m, f, showProbs);
+                panelState.showRow(m, f, showProbs)
+                panelState.showField(m, f, showProbs)
             });
         })
     }

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -59,6 +59,11 @@
         "ObjectiveFunction": [
             ["efficiency", "Efficiency"]
         ],
+        "ParticleReflection": [
+            ["none", "None"],
+            ["diffuse", "Diffuse"],
+            ["specular", "Specular"]
+        ],
         "ParticleRenderCount": [
             ["100", "100"],
             ["80", "80"],
@@ -139,11 +144,8 @@
     },
     "model": {
         "anode": {
-            "isReflector": ["Particle Reflector", "Boolean", "0"],
-            "isSpecular": ["Specular Reflector", "Boolean", "0"],
-            "specProb": ["Specular Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
-            "diffProb": ["Diffuse Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
-            "refScheme": ["Reflection Scheme", "ReflectionScheme", "rand_angle"]
+            "reflectorType": ["Particle Reflection", "ParticleReflection", "none"],
+            "reflectorProbability": ["Reflection Probability", "Float", "0.0", "", "0.0", "1.0"]
         },
         "beam": {
             "currentMode": ["Current Mode", "CurrentMode"],
@@ -159,11 +161,8 @@
             "_super": ["_", "model", "conductor"]
         },
         "cathode": {
-            "isReflector": ["Particle Reflector", "Boolean", "0"],
-            "isSpecular": ["Specular Reflector", "Boolean", "0"],
-            "specProb": ["Specular Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
-            "diffProb": ["Diffuse Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
-            "refScheme": ["Reflection Scheme", "ReflectionScheme", "rand_angle"]
+            "reflectorType": ["Particle Reflection", "ParticleReflection", "none"],
+            "reflectorProbability": ["Reflection Probability", "Float", "0.0", "", "0.0", "1.0"]
         },
         "conductor": {
             "name": ["Name", "String"],
@@ -173,13 +172,10 @@
             "voltage": ["Voltage [eV]", "OptFloat"],
             "permittivity": ["Relative Permittivity", "Float", 7.0],
             "isConductor": ["Conductor", "Boolean", "1"],
-            "isReflector": ["Particle Reflector", "Boolean", "0"],
-            "isSpecular": ["Specular Reflector", "Boolean", "0"],
+            "reflectorType": ["Particle Reflection", "ParticleReflection", "none"],
+            "reflectorProbability": ["Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
             "color": ["Color", "Color", "#6992ff"],
-            "type": ["Type", "ConductorType", "box"],
-            "specProb": ["Specular Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
-            "diffProb": ["Diffuse Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
-            "refScheme": ["Reflection Scheme", "ReflectionScheme", "uniform"]
+            "type": ["Type", "ConductorType", "box"]
         },
         "conductorGridReport": {
             "tileDomain": ["Show tiled domain", "Boolean", "0"]
@@ -297,10 +293,8 @@
             "advanced": [
                 "beam.anode_voltage",
                 "beam.anode_work_function",
-                "isReflector",
-                "isSpecular",
-                "specProb",
-                "diffProb"
+                "reflectorType",
+                "reflectorProbability"
             ]
         },
         "beam": {
@@ -309,33 +303,23 @@
                 "currentMode",
                 "beam_current",
                 "species",
+                "cathode_temperature",
+                "anode_voltage",
                 [
                     ["Cathode", [
-                        "cathode_temperature",
                         "cathode_work_function",
-                        "cathode.isReflector"
+                        "cathode.reflectorType",
+                        "cathode.reflectorProbability"
                     ]],
                     ["Anode", [
-                        "anode_voltage",
                         "anode_work_function",
-                        "anode.isReflector"
+                        "anode.reflectorType",
+                        "anode.reflectorProbability"
                     ]]
                 ]
             ],
             "advanced": [
-                "x_radius",
-                [
-                    ["Cathode", [
-                        "cathode.isSpecular",
-                        "cathode.specProb",
-                        "cathode.diffProb"
-                    ]],
-                    ["Anode", [
-                        "anode.isSpecular",
-                        "anode.specProb",
-                        "anode.diffProb"
-                    ]]
-                ]
+                "x_radius"
             ]
         },
         "box": {
@@ -348,10 +332,8 @@
                 "yLength",
                 "isConductor",
                 "permittivity",
-                "isReflector",
-                "isSpecular",
-                "specProb",
-                "diffProb",
+                "reflectorType",
+                "reflectorProbability",
                 "color"
             ]
         },
@@ -371,10 +353,8 @@
             "advanced": [
                 "beam.cathode_temperature",
                 "beam.cathode_work_function",
-                "isReflector",
-                "isSpecular",
-                "specProb",
-                "diffProb"
+                "reflectorType",
+                "reflectorProbability"
             ]
         },
         "conductorGridReport": {

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -135,7 +135,7 @@
     },
     "model": {
         "anode": {
-            "isReflector": ["Add Reflector", "Boolean", "0"],
+            "isReflector": ["Particle Reflector", "Boolean", "0"],
             "specProb": ["Specular Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
             "diffProb": ["Diffuse Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
             "refScheme": ["Reflection Scheme", "ReflectionScheme", "rand_angle"]
@@ -154,7 +154,7 @@
             "_super": ["_", "model", "conductor"]
         },
         "cathode": {
-            "isReflector": ["Add Reflector", "Boolean", "0"],
+            "isReflector": ["Particle Reflector", "Boolean", "0"],
             "specProb": ["Specular Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
             "diffProb": ["Diffuse Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
             "refScheme": ["Reflection Scheme", "ReflectionScheme", "rand_angle"]
@@ -167,7 +167,7 @@
             "voltage": ["Voltage [eV]", "OptFloat"],
             "permittivity": ["Relative Permittivity", "Float", 7.0],
             "isConductor": ["Conductor", "Boolean", "1"],
-            "isReflector": ["Add Reflector", "Boolean", "0"],
+            "isReflector": ["Particle Reflector", "Boolean", "0"],
             "color": ["Color", "Color", "#6992ff"],
             "type": ["Type", "ConductorType", "box"],
             "specProb": ["Specular Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
@@ -296,18 +296,36 @@
             ]
         },
         "beam": {
-            "title": "Emitter and Reflector Properties",
+            "title": "Emitter and Collector Properties",
             "basic": [
                 "currentMode",
                 "beam_current",
                 "species",
-                "x_radius",
-                "cathode_temperature",
-                "cathode_work_function",
-                "anode_voltage",
-                "anode_work_function"
+                [
+                    ["Cathode", [
+                        "cathode_temperature",
+                        "cathode_work_function",
+                        "cathode.isReflector"
+                    ]],
+                    ["Anode", [
+                        "anode_voltage",
+                        "anode_work_function",
+                        "anode.isReflector"
+                    ]]
+                ]
             ],
             "advanced": [
+                "x_radius",
+                [
+                    ["Cathode", [
+                        "cathode.diffProb",
+                        "cathode.specProb"
+                    ]],
+                    ["Anode", [
+                        "anode.diffProb",
+                        "anode.specProb"
+                    ]]
+                ]
             ]
         },
         "box": {
@@ -322,6 +340,7 @@
                 "permittivity",
                 "isReflector",
                 "diffProb",
+                "specProb",
                 "color"
             ]
         },

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -140,6 +140,7 @@
     "model": {
         "anode": {
             "isReflector": ["Particle Reflector", "Boolean", "0"],
+            "isSpecular": ["Specular Reflector", "Boolean", "0"],
             "specProb": ["Specular Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
             "diffProb": ["Diffuse Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
             "refScheme": ["Reflection Scheme", "ReflectionScheme", "rand_angle"]
@@ -159,6 +160,7 @@
         },
         "cathode": {
             "isReflector": ["Particle Reflector", "Boolean", "0"],
+            "isSpecular": ["Specular Reflector", "Boolean", "0"],
             "specProb": ["Specular Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
             "diffProb": ["Diffuse Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
             "refScheme": ["Reflection Scheme", "ReflectionScheme", "rand_angle"]
@@ -172,6 +174,7 @@
             "permittivity": ["Relative Permittivity", "Float", 7.0],
             "isConductor": ["Conductor", "Boolean", "1"],
             "isReflector": ["Particle Reflector", "Boolean", "0"],
+            "isSpecular": ["Specular Reflector", "Boolean", "0"],
             "color": ["Color", "Color", "#6992ff"],
             "type": ["Type", "ConductorType", "box"],
             "specProb": ["Specular Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
@@ -295,8 +298,9 @@
                 "beam.anode_voltage",
                 "beam.anode_work_function",
                 "isReflector",
-                "diffProb",
-                "specProb"
+                "isSpecular",
+                "specProb",
+                "diffProb"
             ]
         },
         "beam": {
@@ -322,12 +326,14 @@
                 "x_radius",
                 [
                     ["Cathode", [
-                        "cathode.diffProb",
-                        "cathode.specProb"
+                        "cathode.isSpecular",
+                        "cathode.specProb",
+                        "cathode.diffProb"
                     ]],
                     ["Anode", [
-                        "anode.diffProb",
-                        "anode.specProb"
+                        "anode.isSpecular",
+                        "anode.specProb",
+                        "anode.diffProb"
                     ]]
                 ]
             ]
@@ -343,8 +349,9 @@
                 "isConductor",
                 "permittivity",
                 "isReflector",
-                "diffProb",
+                "isSpecular",
                 "specProb",
+                "diffProb",
                 "color"
             ]
         },
@@ -365,8 +372,9 @@
                 "beam.cathode_temperature",
                 "beam.cathode_work_function",
                 "isReflector",
-                "diffProb",
-                "specProb"
+                "isSpecular",
+                "specProb",
+                "diffProb"
             ]
         },
         "conductorGridReport": {

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -153,6 +153,12 @@
         "box": {
             "_super": ["_", "model", "conductor"]
         },
+        "cathode": {
+            "isReflector": ["Add Reflector", "Boolean", "0"],
+            "specProb": ["Specular Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
+            "diffProb": ["Diffuse Reflection Probability", "Float", "0.0", "", "0.0", "1.0"],
+            "refScheme": ["Reflection Scheme", "ReflectionScheme", "rand_angle"]
+        },
         "conductor": {
             "name": ["Name", "String"],
             "xLength": ["Width (X) [µm]", "OptFloat"],
@@ -285,17 +291,13 @@
                 "beam.anode_voltage",
                 "beam.anode_work_function",
                 "isReflector",
-                "diffProb"
+                "diffProb",
+                "specProb"
             ]
         },
         "beam": {
-            "title": "Beam",
+            "title": "Emitter and Reflector Properties",
             "basic": [
-                "currentMode",
-                "beam_current",
-                "species"
-            ],
-            "advanced": [
                 "currentMode",
                 "beam_current",
                 "species",
@@ -304,6 +306,8 @@
                 "cathode_work_function",
                 "anode_voltage",
                 "anode_work_function"
+            ],
+            "advanced": [
             ]
         },
         "box": {
@@ -336,7 +340,10 @@
             "title": "Cathode",
             "advanced": [
                 "beam.cathode_temperature",
-                "beam.cathode_work_function"
+                "beam.cathode_work_function",
+                "isReflector",
+                "diffProb",
+                "specProb"
             ]
         },
         "conductorGridReport": {

--- a/sirepo/package_data/static/json/warpvnd-schema.json
+++ b/sirepo/package_data/static/json/warpvnd-schema.json
@@ -2,6 +2,10 @@
     "constants": {
         "cellColors": ["#ff0000", "#008000", "#0000ff"],
         "nonZeroVoltsColor": "#6992ff",
+        "elementStroke": {
+            "cathode": "#FF9269",
+            "anode": "#6992ff"
+        },
         "particleTrackColor": "#4682b4",
         "planeCaudal":  "caudal",
         "planeDexter": "dexter",

--- a/sirepo/package_data/template/warpvnd/base.py.jinja
+++ b/sirepo/package_data/template/warpvnd/base.py.jinja
@@ -387,8 +387,24 @@ wp.installconductor(plate, dfill=wp.largepos)
 scraper = wp.ParticleScraper([source, plate] + conductors, lcollectlpdata=True, lsaveintercept={{ saveIntercept }})
 
 {% if anode.isReflector %}
-reflector = particlereflector.ParticleReflector(scraper=scraper, conductor=plate, spref=wp.Species(type=wp.Electron, name='Electron'), srefprob={{ anode.specProb }}, drefprob={{ anode.diffProb }})
-particlereflector.installparticlereflector(reflector)
+particlereflector.installparticlereflector(
+    particlereflector.ParticleReflector(
+        scraper=scraper,
+        conductor=plate,
+        spref=wp.Species(type=wp.Electron, name='Electron'),
+        srefprob={{ anode.specProb }}, drefprob={{ anode.diffProb }}),
+)
+{% endif %}
+
+{% if cathode.isReflector %}
+particlereflector.installparticlereflector(
+    particlereflector.ParticleReflector(
+        scraper=scraper,
+        conductor=plate,
+        spref=wp.Species(type=wp.Electron, name='Electron'),
+        srefprob={{ cathode.specProb }}, drefprob={{ cathode.diffProb }},
+    )
+)
 {% endif %}
 
 # Ignore specular probability and reflection scheme for now

--- a/sirepo/package_data/template/warpvnd/base.py.jinja
+++ b/sirepo/package_data/template/warpvnd/base.py.jinja
@@ -1,3 +1,4 @@
+# -*- python -*-
 from __future__ import absolute_import, division, print_function
 import warpoptions
 warpoptions.ignoreUnknownArgs = True
@@ -358,10 +359,8 @@ stl_conductors = {
 reflectors = [
 {% for c in conductors %}
     {
-        'isReflector': {{ c.conductor_type.isReflector }},
-        'specProb': {{ c.conductor_type.specProb }},
-        'diffProb': {{ c.conductor_type.diffProb }},
-        'refScheme': '{{ c.conductor_type.refScheme }}'
+        'reflectorType': '{{ c.conductor_type.reflectorType }}',
+        'reflectorProbability': {{ c.conductor_type.reflectorProbability }},
     },
 {% endfor %}
 ]
@@ -369,7 +368,7 @@ reflectors = [
 # Install reflecting conductors regardless of voltage
 for c_idx, c in enumerate(conductors):
     r = reflectors[c_idx]
-    if c.voltage != 0 or r['isReflector']:
+    if c.voltage != 0 or r['reflectorType'] != 'none':
         wp.installconductor(c, dfill=wp.largepos)
 
 max_c_id = max([c.condid for c in conductors]) if len(conductors) > 0 else 0
@@ -386,33 +385,45 @@ wp.installconductor(plate, dfill=wp.largepos)
 
 scraper = wp.ParticleScraper([source, plate] + conductors, lcollectlpdata=True, lsaveintercept={{ saveIntercept }})
 
-{% if anode.isReflector %}
+{% if anode_reflectorType != 'none' %}
 particlereflector.installparticlereflector(
     particlereflector.ParticleReflector(
         scraper=scraper,
         conductor=plate,
         spref=wp.Species(type=wp.Electron, name='Electron'),
-        srefprob={{ anode.specProb }}, drefprob={{ anode.diffProb }}),
+        srefprob={{ anode_reflectorProbability if anode_reflectorType == 'specular' else 0 }},
+        drefprob={{ anode_reflectorProbability if anode_reflectorType == 'diffuse' else 0 }},
+        refscheme='uniform',
+    ),
 )
 {% endif %}
 
-{% if cathode.isReflector %}
+{% if cathode_reflectorType != 'none' %}
 particlereflector.installparticlereflector(
     particlereflector.ParticleReflector(
         scraper=scraper,
-        conductor=plate,
+        conductor=source,
         spref=wp.Species(type=wp.Electron, name='Electron'),
-        srefprob={{ cathode.specProb }}, drefprob={{ cathode.diffProb }},
+        srefprob={{ cathode_reflectorProbability if cathode_reflectorType == 'specular' else 0 }},
+        drefprob={{ cathode_reflectorProbability if cathode_reflectorType == 'diffuse' else 0 }},
+        refscheme='uniform',
     )
 )
 {% endif %}
 
-# Ignore specular probability and reflection scheme for now
 for r_idx, r in enumerate(reflectors):
     c = conductors[r_idx]
-    if r['isReflector']:
-        reflector = particlereflector.ParticleReflector(scraper=scraper, conductor=c, spref=wp.Species(type=wp.Electron, name='Electron'), srefprob=0., drefprob=r['diffProb'], refscheme='uniform')
-        particlereflector.installparticlereflector(reflector)
+    if r['reflectorType'] != 'none':
+        particlereflector.installparticlereflector(
+            particlereflector.ParticleReflector(
+                scraper=scraper,
+                conductor=c,
+                spref=wp.Species(type=wp.Electron, name='Electron'),
+                srefprob=r['reflectorProbability'] if r['reflectorType'] == 'specular' else 0,
+                drefprob=r['reflectorProbability'] if r['reflectorType'] == 'diffuse' else 0,
+                refscheme='uniform',
+            )
+        )
 
 #------
 

--- a/sirepo/package_data/template/warpvnd/optimizer.py.jinja
+++ b/sirepo/package_data/template/warpvnd/optimizer.py.jinja
@@ -44,6 +44,8 @@ def wrapper(parameters, bounds, constraints, cache):
         #TODO(pjm): put sr-opt somewhere common
         # read warp output, parse out lines beginning with sr-opt
         for line in iter(run_warp.stdout.readline, b''):
+            if not line:
+                break
             if re.search(r'^sr-opt:\s*', line):
                 line = re.sub(r'^sr-opt:\s*|\n$', '', line)
                 print(' {}'.format(line))

--- a/sirepo/sim_data/warpvnd.py
+++ b/sirepo/sim_data/warpvnd.py
@@ -70,6 +70,7 @@ class SimData(sirepo.sim_data.SimDataBase):
                 'particle3d',
                 'particleAnimation',
                 'simulation',
+                'cathode'
             ),
             dynamic=lambda m: cls.__dynamic_defaults(data, m),
         )

--- a/sirepo/sim_data/warpvnd.py
+++ b/sirepo/sim_data/warpvnd.py
@@ -70,7 +70,8 @@ class SimData(sirepo.sim_data.SimDataBase):
                 'particle3d',
                 'particleAnimation',
                 'simulation',
-                'cathode'
+                'cathode',
+                'conductor',
             ),
             dynamic=lambda m: cls.__dynamic_defaults(data, m),
         )

--- a/sirepo/sim_data/warpvnd.py
+++ b/sirepo/sim_data/warpvnd.py
@@ -43,6 +43,20 @@ class SimData(sirepo.sim_data.SimDataBase):
 
     @classmethod
     def fixup_old_data(cls, data):
+
+        def _fixup_reflector(m):
+            if 'isReflector' not in m:
+                return
+            if m.isReflector == '1':
+                if m.specProb > 0:
+                    m.reflectorType = 'specular'
+                    m.reflectorProbability = m.specProb
+                elif m.diffProb > 0:
+                    m.reflectorType = 'diffuse'
+                    m.reflectorProbability = m.diffProb
+            for f in ('isReflector', 'specProb', 'diffProb', 'refScheme'):
+                del m[f]
+
         dm = data.models
         dm.pksetdefault(optimizer=PKDict)
         dm.optimizer.pksetdefault(
@@ -71,24 +85,20 @@ class SimData(sirepo.sim_data.SimDataBase):
                 'particleAnimation',
                 'simulation',
                 'cathode',
-                'conductor',
             ),
             dynamic=lambda m: cls.__dynamic_defaults(data, m),
         )
         pkcollections.unchecked_del(dm.particle3d, 'joinEvery')
-#TODO(robnagler) is this a denormalization of conductors?
+        for m in ('anode', 'cathode'):
+            _fixup_reflector(dm[m])
         s = cls.schema()
-        for c in dm.get('conductorTypes', []):
-#TODO(robnagler) can a conductor type be none?
-            if c is None:
-                continue
-#TODO(robnagler) why is this not a bool?
+        for c in dm.conductorTypes:
             x = c.setdefault('isConductor', '1' if c.voltage > 0 else '0')
-            c.pksetdefault(
-                color=s.get('zeroVoltsColor' if x == '0' else 'nonZeroVoltsColor'),
-            )
-#TODO(robnagler) how does this work? bc names are on schema, not conductor
-            cls.update_model_defaults(c, c.get('type', 'box'))
+            # conductor.color is null is examples
+            if not c.get('color', 0):
+                c.color = s.constants['zeroVoltsColor' if x == '0' else 'nonZeroVoltsColor']
+            cls.update_model_defaults(c, c.type)
+            _fixup_reflector(c)
         for c in dm.conductors:
             cls.update_model_defaults(c, 'conductorPosition')
         cls._organize_example(data)

--- a/sirepo/sim_data/warpvnd.py
+++ b/sirepo/sim_data/warpvnd.py
@@ -48,6 +48,8 @@ class SimData(sirepo.sim_data.SimDataBase):
             if 'isReflector' not in m:
                 return
             if m.isReflector == '1':
+                for f in 'specProb', 'diffProb':
+                    m[f] = float(m[f])
                 if m.specProb > 0:
                     m.reflectorType = 'specular'
                     m.reflectorProbability = m.specProb

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -782,9 +782,7 @@ def _generate_parameters_file(data):
     v['conductors'] = _prepare_conductors(data)
     v['maxConductorVoltage'] = _max_conductor_voltage(data)
     v['is3D'] = _SIM_DATA.warpvnd_is_3d(data)
-    for e in 'anode', 'cathode':
-        v[e] = _prepare_electrode(e, data)
-    v['saveIntercept'] = v['anode']['isReflector']
+    v['saveIntercept'] = v['anode_reflectorType'] != 'none' or v['cathode_reflectorType'] != 'none'
     for c in data.models.conductors:
         if c.conductor_type.type == 'stl':
             # if any conductor is STL then don't save the intercept
@@ -793,7 +791,7 @@ def _generate_parameters_file(data):
                 _stl_polygon_file(c.conductor_type.name),
             )
             break
-        if c.conductor_type.isReflector:
+        if c.conductor_type.reflectorType != 'none':
             v['saveIntercept'] = True
     if not v['is3D']:
         v['simulationGrid_num_y'] = v['simulationGrid_num_x']
@@ -939,7 +937,6 @@ def _prepare_conductors(data):
             ct.yLength = 1
         ct.permittivity = ct.permittivity if ct.isConductor == '0' else 'None'
         ct.file = _SIM_DATA.lib_file_abspath(_stl_file(ct)) if 'file' in ct else 'None'
-        ct.isReflector = ct.isReflector == '1' if 'isReflector' in ct else False
     for c in data.models.conductors:
         if c.conductorTypeId not in type_by_id:
             continue
@@ -949,14 +946,6 @@ def _prepare_conductors(data):
         if not _SIM_DATA.warpvnd_is_3d(data):
             c.yCenter = 0
     return data.models.conductors
-
-
-def _prepare_electrode(electrode, data):
-    return {
-        'isReflector': data.models[electrode].isReflector == '1',
-        'specProb': data.models[electrode].specProb,
-        'diffProb': data.models[electrode].diffProb,
-    }
 
 
 def _read_optimizer_output(run_dir):

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -955,7 +955,7 @@ def _read_optimizer_output(run_dir):
         return None, None
     try:
         values = np.loadtxt(str(opt_file))
-        if values:
+        if values.any():
             if len(values.shape) == 1:
                 values = np.array([values])
         else:

--- a/sirepo/template/warpvnd.py
+++ b/sirepo/template/warpvnd.py
@@ -782,7 +782,8 @@ def _generate_parameters_file(data):
     v['conductors'] = _prepare_conductors(data)
     v['maxConductorVoltage'] = _max_conductor_voltage(data)
     v['is3D'] = _SIM_DATA.warpvnd_is_3d(data)
-    v['anode'] = _prepare_anode(data)
+    for e in 'anode', 'cathode':
+        v[e] = _prepare_electrode(e, data)
     v['saveIntercept'] = v['anode']['isReflector']
     for c in data.models.conductors:
         if c.conductor_type.type == 'stl':
@@ -950,11 +951,11 @@ def _prepare_conductors(data):
     return data.models.conductors
 
 
-def _prepare_anode(data):
+def _prepare_electrode(electrode, data):
     return {
-        'isReflector': data.models.anode['isReflector'] == '1',
-        'specProb': data.models.anode['specProb'],
-        'diffProb': data.models.anode['diffProb'],
+        'isReflector': data.models[electrode].isReflector == '1',
+        'specProb': data.models[electrode].specProb,
+        'diffProb': data.models[electrode].diffProb,
     }
 
 


### PR DESCRIPTION
I believe this covers everything outlined in #3129. @moellep and @ncook882 I don't know how to verify that these changes are working right. The simulation runs with them but I don't know if it is correct. Lmk if there is something I can do (ex demo, send python sources) to help verify the changes are correct.

@ncook882 this is the new "Emitter and Reflector Properties
<img width="835" alt="Screen Shot 2020-11-13 at 2 41 01 PM" src="https://user-images.githubusercontent.com/10264515/99123916-66953300-25be-11eb-9e66-e35608c47cf8.png">
" panel:

When the user double clicks on the cathode or anode on the Conductor Grid they will now be able to adjust the properties of the conductor. Ex for the cathode:
<img width="1054" alt="Screen Shot 2020-11-13 at 2 41 12 PM" src="https://user-images.githubusercontent.com/10264515/99123992-87f61f00-25be-11eb-8754-5bf505eaa320.png">

