### PR TITLE
Fix #3159. src and dst jupyterhub db root may be the same.

### DIFF
--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -95,13 +95,13 @@ def _create_user():
             logged_in_user_name.split('@')[0],
         )
         u = JupyterhubUser.search_by(user_name=n)
-        if u or pkio.sorted_glob(_user_dir(n)):
+        if u or _user_dir(n).exists():
             # The username already exists. Add a random letter to try and create
             # a unique user name.
-            n += _HUB_USER_SEP + random.choice(string.ascii_lowercase)
+            n += _HUB_USER_SEP + sirepo.util.random_base62(3).lower()
 
-        assert not pkio.sorted_glob(_user_dir(n)), \
-            f'conflict with existing username={n}'
+        assert not _user_dir(n).exists(), \
+            f'conflict with existing user_dir={n}'
         return n
 
     if jupyterhub_user_name():


### PR DESCRIPTION
In the case of the src and dst db root being the same we need to add another
check of the directories to make sure a new username doesn't conflict.