### PR TITLE
Fix #3145. Do not evaluate RPN's that are shell commands.

### DIFF
--- a/sirepo/template/code_variable.py
+++ b/sirepo/template/code_variable.py
@@ -67,7 +67,10 @@ class CodeVar():
     def eval_var_with_assert(self, expr):
         (v, err) = self.eval_var(expr)
         assert not err, f'expr={expr} err={err}'
-        return float(v)
+        try:
+            return float(v)
+        except ValueError:
+            return v
 
     def get_application_data(self, args, schema, ignore_array_values=False):
         from sirepo import simulation_db

--- a/sirepo/template/elegant_lattice_importer.py
+++ b/sirepo/template/elegant_lattice_importer.py
@@ -51,6 +51,9 @@ class ElegantRPNEval(object):
         # sleep                       sleep for number of seconds
         # @                       push command input file
         pkdc('rpn variables={} expr="{}"', var_list, expr)
+        if re.match(r'^\{.+\}$', expr):
+            # It is a shell command
+            return expr, None
         out = elegant_common.subprocess_output(['rpnl', '{} {}'.format(var_list, expr)])
         if out is None:
             return None, 'invalid'

--- a/tests/lib_data/elegant_1/first.ele
+++ b/tests/lib_data/elegant_1/first.ele
@@ -92,7 +92,7 @@
       ! alpha_y = -5.4,
 	!	reference_file = twiss.input,
 	!Twiss Parameters from twiss.input (from S.Shin\..\Method_SShin)
-	beta_x = 4.034896311524342,
+	beta_x = "{sddsanalyzebeam whruby.sdds -pipe=out | sdds2stream -pipe -column=betax}",
 	beta_y = 4.199343696609461,
 	alpha_x = -1.609709872915761,
 	alpha_y = -1.653138844198896

--- a/tests/lib_data/elegant_1/first.ele.out
+++ b/tests/lib_data/elegant_1/first.ele.out
@@ -107,7 +107,7 @@
 &twiss_output
   alpha_x = -1.609709872915761,
   alpha_y = -1.653138844198896,
-  beta_x = 4.034896311524342,
+  beta_x = "({sddsanalyzebeam whruby.sdds -pipe=out | sdds2stream -pipe -column=betax})",
   beta_y = 4.199343696609461,
   filename = "%s.twi",
   matched = 0,

--- a/tests/lib_data/elegant_1/out.json
+++ b/tests/lib_data/elegant_1/out.json
@@ -2931,7 +2931,7 @@
                 "_type": "twiss_output",
                 "alpha_x": -1.609709872915761,
                 "alpha_y": -1.653138844198896,
-                "beta_x": 4.034896311524342,
+                "beta_x": "{sddsanalyzebeam whruby.sdds -pipe=out | sdds2stream -pipe -column=betax}",
                 "beta_y": 4.199343696609461,
                 "cavities_are_drifts_if_matched": "1",
                 "chromatic_tune_spread_half_range": 0.0,


### PR DESCRIPTION
RPN namelist fields in elegant can also be strings containing shell commands
that will be evaluated by elegant. In this case just pass the string through
and do not try to evaluate it.

In the sirepo.lib case this is fine and will always work. In the Sirepo GUI
case it may not always work.

There are many possible failure points for these types of commands. For example,
when converting from elegant to madx some RPN fields we must evaluate. If the
field contains shell commands then we will get the string of the commands and
may try to do math operations on it. We will fail at that point. Another example,
is that we mangle filenames but don't mangle them in the shell commands. So, if
a user has shell commands with filenames in them the filenames will not be found
when elegant evaluates the command.