### PR TITLE
Fix #1351. Add role for jupyterhublogin.

### DIFF
--- a/etc/run-jupyterhub.sh
+++ b/etc/run-jupyterhub.sh
@@ -2,7 +2,7 @@
 set -eou pipefail
 
 export SIREPO_AUTH_METHODS=email
-export SIREPO_FEATURE_CONFIG_OTHER_SIM_TYPES=jupyterhublogin
+export SIREPO_FEATURE_CONFIG_PROPRIETARY_SIM_TYPES=jupyterhublogin
 
 if [[ ${SIREPO_AUTH_GITHUB_KEY:-} || ${SIREPO_AUTH_GITHUB_SECRET:-} ]]; then
     export SIREPO_AUTH_GITHUB_METHOD_VISIBLE=0

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -612,10 +612,13 @@ def _auth_state():
     return v
 
 def _create_roles_for_user(uid, method):
+    r = []
     if not (pkconfig.channel_in('dev') and method == METHOD_GUEST):
-        return
-
-    auth_db.UserRole.add_roles(uid, get_all_roles())
+        if not sirepo.template.is_sim_type('jupyterhublogin'):
+            return
+        # Every user gets the jupyterhub role initially
+        r.append(role_for_sim_type('jupyterhublogin'))
+    auth_db.UserRole.add_roles(uid, r or get_all_roles())
 
 
 def _get_user():

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -613,12 +613,10 @@ def _auth_state():
 
 def _create_roles_for_user(uid, method):
     r = []
-    if not (pkconfig.channel_in('dev') and method == METHOD_GUEST):
-        if not sirepo.template.is_sim_type('jupyterhublogin'):
-            return
-        # Every user gets the jupyterhub role initially
-        r.append(role_for_sim_type('jupyterhublogin'))
-    auth_db.UserRole.add_roles(uid, r or get_all_roles())
+    if pkconfig.channel_in('dev') and method == METHOD_GUEST:
+        auth_db.UserRole.add_roles(uid, get_all_roles())
+    elif sirepo.template.is_sim_type('jupyterhublogin'):
+        auth_db.UserRole.add_roles(uid, [role_for_sim_type('jupyterhublogin')])
 
 
 def _get_user():

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -53,19 +53,23 @@ def audit_proprietary_lib_files(uid):
     import pykern.pkio
     import sirepo.auth
     import sirepo.feature_config
+    import sirepo.sim_data
     import sirepo.simulation_db
 
     x = sirepo.feature_config.cfg().proprietary_sim_types
     if not x:
         return
     for t in x:
+        if not sirepo.sim_data.get_class(t).proprietary_code_rpm():
+            return
+        d = sirepo.srdb.proprietary_code_dir(t)
+        assert d.exists(), \
+            f'{d} proprietary_code_dir must exist' \
+            + ('; run: sirepo setup_dev' if pykern.pkconfig.channel_in('dev') else '')
         r = UserRole.has_role(
             uid,
             sirepo.auth.role_for_sim_type(t),
         )
-        d = sirepo.srdb.proprietary_code_dir(t)
-        if not d.exists():
-            return
         for f in pykern.pkio.sorted_glob(d.join('*')):
 #TODO(robnagler) ensure no collision on names with uploaded files
 # (restrict suffixes in user uploads)

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -64,12 +64,9 @@ def audit_proprietary_lib_files(uid):
             sirepo.auth.role_for_sim_type(t),
         )
         d = sirepo.srdb.proprietary_code_dir(t)
-        assert d.exists(), \
-            f'{d} proprietary_code_dir must exist' \
-            + ('; run: sirepo setup_dev' if pykern.pkconfig.channel_in('dev') else '')
-
+        if not d.exists():
+            return
         for f in pykern.pkio.sorted_glob(d.join('*')):
-
 #TODO(robnagler) ensure no collision on names with uploaded files
 # (restrict suffixes in user uploads)
             p = sirepo.simulation_db.simulation_lib_dir(t, uid=uid).join(f.basename)

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -45,13 +45,10 @@ _FOSS_CODES = _PROD_FOSS_CODES.union(_NON_PROD_FOSS_CODES)
 
 
 #: codes for which we require dynamically loaded binaries
-_PROPRIETARY_CODES = frozenset(('flash',))
-
-#: Codes that can be enabled but are not the "normal" set of codes
-_OTHER_CODES = frozenset(('jupyterhublogin',))
+_PROPRIETARY_CODES = frozenset(('flash', 'jupyterhublogin'))
 
 #: all executable codes
-VALID_CODES = _FOSS_CODES.union(_PROPRIETARY_CODES, _OTHER_CODES)
+VALID_CODES = _FOSS_CODES.union(_PROPRIETARY_CODES)
 
 
 #: Configuration
@@ -102,7 +99,6 @@ def _init():
         jspec=dict(
             derbenevskrinsky_force_formula=b('Include Derbenev-Skrinsky force formula'),
         ),
-        other_sim_types=(set(), set, 'other sim types to enable'),
         proprietary_sim_types=(set(), set, 'codes that require authorization'),
         #TODO(robnagler) make this a sim_type config like srw and warpvnd
         rs4pi_dose_calc=(False, bool, 'run the real dose calculator'),
@@ -124,7 +120,7 @@ def _init():
             _PROD_FOSS_CODES if pkconfig.channel_in('prod') else _FOSS_CODES
         )
     )
-    s.update(_cfg.proprietary_sim_types, _cfg.other_sim_types)
+    s.update(_cfg.proprietary_sim_types)
     for v in _DEPENDENT_CODES:
         if v[0] in s:
             s.add(v[1])

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -14,6 +14,7 @@ import sirepo.cookie
 import sirepo.server
 import sirepo.util
 import tornado.web
+import werkzeug.exceptions
 
 _JUPYTERHUBLOGIN_ROUTE = '/jupyterhublogin'
 
@@ -34,6 +35,9 @@ class Authenticator(jupyterhub.auth.Authenticator):
         _set_cookie(handler)
         try:
             sirepo.auth.require_user()
+            sirepo.auth.require_sim_type('jupyterhublogin')
+        except werkzeug.exceptions.Forbidden:
+            return None
         except sirepo.util.SRException as e:
             r = e.sr_args.get('routeName')
             if r not in ('login', 'loginFail'):

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -40,7 +40,7 @@ class Authenticator(jupyterhub.auth.Authenticator):
             return None
         except sirepo.util.SRException as e:
             r = e.sr_args.get('routeName')
-            if r not in ('login', 'loginFail'):
+            if r not in ('completeRegistration', 'login', 'loginFail'):
                 raise
             handler.redirect(f'{_JUPYTERHUBLOGIN_ROUTE}#/{r}')
             raise tornado.web.Finish()

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -37,6 +37,8 @@ class Authenticator(jupyterhub.auth.Authenticator):
             sirepo.auth.require_user()
             sirepo.auth.require_sim_type('jupyterhublogin')
         except werkzeug.exceptions.Forbidden:
+            # returning None means the user is forbidden (403)
+            # https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.authenticate
             return None
         except sirepo.util.SRException as e:
             r = e.sr_args.get('routeName')

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -24,6 +24,27 @@ import re
 import shutil
 
 
+def add_jupyterhub_role():
+    """Adds jupyterhub role to all users"""
+    import sirepo.server
+
+    sirepo.server.init()
+    import sirepo.auth
+    import sirepo.auth_db
+    import sirepo.pkcli.roles
+    import sirepo.template
+    import sqlalchemy.exc
+
+    sirepo.template.assert_sim_type('jupyterhublogin')
+    r = sirepo.auth.role_for_sim_type('jupyterhublogin')
+    # TODO(e-carlin): locking
+    for u in sirepo.auth_db.all_uids():
+        try:
+            sirepo.pkcli.roles.add(u, r)
+        except sqlalchemy.exc.IntegrityError:
+            pass
+
+
 def audit_proprietary_lib_files(*uid):
     """Add/removes proprietary files based on a user's roles
 
@@ -39,7 +60,7 @@ def audit_proprietary_lib_files(*uid):
     import sirepo.auth
 
     #TODO(robnagler) locking
-    for u in uid or all_uids():
+    for u in uid or sirepo.auth_db.all_uids():
         sirepo.auth_db.audit_proprietary_lib_files(u)
 
 

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -24,27 +24,6 @@ import re
 import shutil
 
 
-def add_jupyterhub_role():
-    """Adds jupyterhub role to all users"""
-    import sirepo.server
-
-    sirepo.server.init()
-    import sirepo.auth
-    import sirepo.auth_db
-    import sirepo.pkcli.roles
-    import sirepo.template
-    import sqlalchemy.exc
-
-    sirepo.template.assert_sim_type('jupyterhublogin')
-    r = sirepo.auth.role_for_sim_type('jupyterhublogin')
-    # TODO(e-carlin): locking
-    for u in sirepo.auth_db.all_uids():
-        try:
-            sirepo.pkcli.roles.add(u, r)
-        except sqlalchemy.exc.IntegrityError:
-            pass
-
-
 def audit_proprietary_lib_files(*uid):
     """Add/removes proprietary files based on a user's roles
 

--- a/sirepo/pkcli/setup_dev.py
+++ b/sirepo/pkcli/setup_dev.py
@@ -41,8 +41,8 @@ def _proprietary_codes():
 
     for s in sirepo.feature_config.cfg().proprietary_sim_types:
         f = sirepo.sim_data.get_class(s).proprietary_code_rpm()
-        assert f, \
-            f'sim_type={s} has no proprietary rpm'
+        if not f:
+            return
         r = pkio.mkdir_parent(
             sirepo.srdb.proprietary_code_dir(s),
         ).join(f)

--- a/sirepo/pkcli/setup_dev.py
+++ b/sirepo/pkcli/setup_dev.py
@@ -40,11 +40,12 @@ def _proprietary_codes():
     import urllib.request
 
     for s in sirepo.feature_config.cfg().proprietary_sim_types:
+        f = sirepo.sim_data.get_class(s).proprietary_code_rpm()
+        assert f, \
+            f'sim_type={s} has no proprietary rpm'
         r = pkio.mkdir_parent(
             sirepo.srdb.proprietary_code_dir(s),
-        ).join(
-            sirepo.sim_data.get_class(s).proprietary_code_rpm(),
-        )
+        ).join(f)
         # POSIT: download/installers/rpm-code/dev-build.sh
         u = f'{cfg.proprietary_code_uri}/rscode-{s}-dev.rpm'
         try:

--- a/sirepo/sim_data/__init__.py
+++ b/sirepo/sim_data/__init__.py
@@ -463,7 +463,7 @@ class SimDataBase(object):
 
     @classmethod
     def proprietary_code_rpm(cls):
-        return f'{cls.sim_type()}.rpm'
+        return None
 
     @classmethod
     def resource_dir(cls):
@@ -653,6 +653,11 @@ class SimDataBase(object):
         dm = data.models
         if dm.simulation.get('isExample') and dm.simulation.folder == '/':
             dm.simulation.folder = '/Examples'
+
+    @classmethod
+    def _proprietary_code_rpm(cls):
+        return f'{cls.sim_type()}.rpm'
+
 
 
 def split_jid(jid):

--- a/sirepo/sim_data/flash.py
+++ b/sirepo/sim_data/flash.py
@@ -127,6 +127,10 @@ class SimData(sirepo.sim_data.SimDataBase):
         )
 
     @classmethod
+    def proprietary_code_rpm(cls):
+        return cls._proprietary_code_rpm()
+
+    @classmethod
     def _compute_job_fields(cls, data, r, compute_model):
         return [r]
 


### PR DESCRIPTION
jupyterhublogin is now a "proprietary" code. All new users get the
role for it. This will allow us to revoke the role later which will
prevent the user from logging in.