### PR TITLE
Fix 3267. Case issue with jupyterhub migration.

### DIFF
--- a/sirepo/package_data/static/html/jupyter-name-conflict.html
+++ b/sirepo/package_data/static/html/jupyter-name-conflict.html
@@ -1,10 +1,6 @@
 <div class="container-fluid">
   <div class="row">
-    <div class="col-sm-6 col-sm-offset-2" data-ng-if="! nameConflict.isMigration">
-      <h1>Error</h1>
-      <p>We are unable to create your account. Please send a message to our support team <a href="mailto:support@radiasoft.net">support@radiasoft.net</a>.</p>
-    </div>
-    <div class="col-sm-6 col-sm-offset-2" data-ng-if="nameConflict.isMigration">
+    <div class="col-sm-6 col-sm-offset-2">
       <h1>Could not merge your account</h1>
       <p>We are unable to merge your account. This may be becaue you have merged the Jupyter account before under a different Sirepo account. If you believe this is in error, please send a message to our support team <a href="mailto:support@radiasoft.net">support@radiasoft.net</a>.</p>
 

--- a/sirepo/package_data/static/js/jupyterhublogin.js
+++ b/sirepo/package_data/static/js/jupyterhublogin.js
@@ -17,7 +17,6 @@ SIREPO.app.controller('JupyterhubMigrateController', function(authState, jupyter
 
 SIREPO.app.controller('NameConflictController', function(requestSender, jupyterhubloginService, $route, $scope) {
     const self = this;
-    self.isMigration = $route.current.params.isMigration;
 
     self.noMigration = function() {
         jupyterhubloginService.doMigration(false);

--- a/sirepo/package_data/static/json/jupyterhublogin-schema.json
+++ b/sirepo/package_data/static/json/jupyterhublogin-schema.json
@@ -18,7 +18,7 @@
             }
         },
         "jupyterNameConflict": {
-            "route": "/jupyter-name-conflict/:isMigration",
+            "route": "/jupyter-name-conflict",
             "config": {
                 "controller": "NameConflictController as nameConflict",
                 "templateUrl": "/static/html/jupyter-name-conflict.html"

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -10,7 +10,6 @@ from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp, pkdlog
 import flask
 import py.error
-import random
 import re
 import sirepo.api_perm
 import sirepo.auth
@@ -29,7 +28,7 @@ cfg = None
 #: Used by auth_db. Sirepo record of each jupyterhub user.
 JupyterhubUser = None
 
-_HUB_USER_SEP = '_'
+_HUB_USER_SEP = '-'
 
 
 @sirepo.api_perm.require_user
@@ -95,7 +94,7 @@ def _create_user(github_handle=None):
     A few interesting cases to keep in mind:
       1. User selects to migrate and they have old data. We should never
          uniquify the user's github handle because the user dir is identified
-         and exists.
+         and exists. But, we may uniquify their user_name.
       2. User signs into sirepo under one@any.com. They migrate their data using
          GitHub handle y. They sign into sirepo under two@any.com. They choose
          to migrate GitHub handle y again. We should let them know that they
@@ -108,34 +107,32 @@ def _create_user(github_handle=None):
          migrate. There is an existing foo migration user which has not registered
          yet. We should uniquify the new user (foo_xyz) to ensure the name
          doesn't collide with the existing (yet to register) user.
+      5. User selects to migrate and they have old data. They migrate github
+         hanlde xYz (capitlization is important) They get the username xyz
+         (maybe with randomness). We rename xYz dir to xyz.
+      6. The db has en existing jupyter dir XYZ. xyz@foo.com signs in and
+         doesn't migrate.  They get username xyz. The db now has XYZ and
+         xyz. User two@bar.com registers and they migrate github handle
+         XYZ. They get the username xyz_qrs. The db now has xyz_qrs and xyz.
+         The same user (two@bar.com) signs in as three@bar.com. They migrate the
+         github handle XYZ. We need to let them know that they have already
+         migrated.
 
     Args:
         github_handle (str): The user's github handle
 
     """
-    def __existing_migration_user_new_jupyter_user():
-        return github_handle and _user_dir(user_name=github_handle).exists() \
-            and not JupyterhubUser.search_by(user_name=github_handle)
-
     def __user_name():
         n = github_handle or sirepo.auth.user_name()
-        assert n, 'must supply a name'
-        if __existing_migration_user_new_jupyter_user():
-            # TODO(e-carlin): If the new jupyter user changes their handle to be
-            # the handle of an existing but unmigrated migration user then the
-            # new jupyter user will get the data of the existing migration user.
-            # No way to protect against this.
-            return n
-        if not github_handle:
-            n = re.sub(
-                r'\W+',
-                _HUB_USER_SEP,
-                # Get the local part of the email. Or in the case of another auth
-                # method (ex github) it won't have an '@' so it will just be their
-                # user name, handle, etc.
-                n.split('@')[0],
-            )
-        if __user_name_exists(n) and not github_handle:
+        n = re.sub(
+            r'\W+',
+            _HUB_USER_SEP,
+            # Get the local part of the email. Or in the case of another auth
+            # method (ex github) it won't have an '@' so it will just be their
+            # user name, handle, etc.
+            n.split('@')[0],
+        ).lower()
+        if __user_name_exists(n):
             # The username already exists. Add some randomness to try and create
             # a unique user name.
             n += _HUB_USER_SEP + sirepo.util.random_base62(3).lower()
@@ -145,9 +142,20 @@ def _create_user(github_handle=None):
                 'jupyterNameConflict',
                 PKDict(
                     sim_type='jupyterhublogin',
-                    isMigration=bool(github_handle),
+                    isMigration=False,
                 ),
             )
+        if github_handle and (
+            not _user_dir(user_name=github_handle).exists()
+            or JupyterhubUser.search_by(user_name=github_handle)
+        ):
+                raise sirepo.util.SRException(
+                    'jupyterNameConflict',
+                    PKDict(
+                        sim_type='jupyterhublogin',
+                        isMigration=True,
+                    ),
+                )
         return n
 
     def __user_name_exists(user_name):
@@ -155,10 +163,15 @@ def _create_user(github_handle=None):
             or _user_dir(user_name=user_name).exists()
 
     with sirepo.auth_db.thread_lock:
+        n = __user_name()
         JupyterhubUser(
             uid=sirepo.auth.logged_in_user(),
-            user_name=__user_name(),
+            user_name=n,
         ).save()
+        if github_handle and _user_dir(user_name=github_handle).exists() \
+           and github_handle != n:
+            _user_dir(user_name=github_handle).rename(_user_dir())
+            return
         pkio.mkdir_parent(_user_dir())
 
 


### PR DESCRIPTION
I've spent a fair bit of time thinking through this but I have trouble reasoning about this code so please take a close look.

We now format github handles (make lowercase and make all non-word
characters -). This means we now must rename directories (github
handles that are different after formatting).

This solves two bugs:
1. GitHub handles may have uppercase letters in them. This was causing
a bug where users were registering with github handles with
capitalized letters and a system downstream was making the names
lowercase.
2. Underscores were possibly being encoded/decoded wrong in
usernames. We had two directories (foo_8f2 and foo_5F8f2). This made
it look like we sometimes had an randomness of 5 characters added. We
believe that 5F (hex for ascii _) was a possible encoding/decoding
issue in a downstream system.

These changes lead to a behavior change in the app:
If a user registers, selects migrate, and they have no existing data previously they would no be alerted. Now they will be alerted that we could not migrate. They will have to select to proceed without migrating or to sign into a different account.