### PR TITLE
Fix #3123. Read csv with quoted values

### DIFF
--- a/sirepo/numpy.py
+++ b/sirepo/numpy.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+u"""Wrappers for numpy
+
+:copyright: Copyright (c) 2021 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from __future__ import absolute_import, division, print_function
+import numpy as np
+
+def ndarray_from_csv(path, skip_header, **kwargs):
+    def _read():
+        import csv
+        import re
+
+        with open(path) as f:
+            for r in csv.reader(f):
+                yield ','.join(map(lambda v: re.sub(r'"|\n|\r|,', '', v), r))
+    return np.genfromtxt(
+        _read(),
+        comments=None,
+        delimiter=',',
+        skip_header=skip_header,
+        **kwargs
+    )

--- a/sirepo/numpy.py
+++ b/sirepo/numpy.py
@@ -14,7 +14,7 @@ def ndarray_from_csv(path, skip_header, **kwargs):
 
         with open(path) as f:
             for r in csv.reader(f):
-                yield ','.join(map(lambda v: re.sub(r'"|\n|\r|,', '', v), r))
+                yield ','.join(map(lambda v: re.sub(r'["\n\r,]', '', v), r))
     return np.genfromtxt(
         _read(),
         comments=None,

--- a/sirepo/numpy.py
+++ b/sirepo/numpy.py
@@ -12,7 +12,7 @@ def ndarray_from_csv(path, skip_header, **kwargs):
         import csv
         import re
 
-        with open(path) as f:
+        with open(path, "rt") as f:
             for r in csv.reader(f):
                 yield ','.join(map(lambda v: re.sub(r'["\n\r,]', '', v), r))
     return np.genfromtxt(

--- a/sirepo/package_data/template/ml/scale.py.jinja
+++ b/sirepo/package_data/template/ml/scale.py.jinja
@@ -12,7 +12,7 @@ from sklearn.preprocessing import {{ dataFile_outputsScaler }}
 def read_data(path, **kwargs):
     return sirepo.numpy.ndarray_from_csv(
         path,
-        {{ 1 if columnInfo_hasHeaderRow else 0 }},
+        {{ columnInfo_hasHeaderRow }},
         **kwargs,
     )
 

--- a/sirepo/package_data/template/ml/scale.py.jinja
+++ b/sirepo/package_data/template/ml/scale.py.jinja
@@ -12,7 +12,7 @@ from sklearn.preprocessing import {{ dataFile_outputsScaler }}
 def read_data(path, **kwargs):
     return sirepo.numpy.ndarray_from_csv(
         path,
-        {{ columnInfo_hasHeaderRow }},
+        {{ 1 if columnInfo_hasHeaderRow else 0 }},
         **kwargs,
     )
 

--- a/sirepo/package_data/template/ml/scale.py.jinja
+++ b/sirepo/package_data/template/ml/scale.py.jinja
@@ -1,5 +1,6 @@
 import numpy as np
 import os
+import sirepo.numpy
 
 {% if dataFile_inputsScaler != 'None' %}
 from sklearn.preprocessing import {{ dataFile_inputsScaler }}
@@ -9,11 +10,10 @@ from sklearn.preprocessing import {{ dataFile_outputsScaler }}
 {% endif %}
 
 def read_data(path, **kwargs):
-    return np.genfromtxt(
+    return sirepo.numpy.ndarray_from_csv(
         path,
-        delimiter=',',
-        skip_header={{ 1 if columnInfo_hasHeaderRow else 0 }},
-        **kwargs
+        {{ 1 if columnInfo_hasHeaderRow else 0 }},
+        **kwargs,
     )
 
 

--- a/sirepo/template/ml.py
+++ b/sirepo/template/ml.py
@@ -16,7 +16,9 @@ import csv
 import numpy as np
 import re
 import sirepo.analysis
+import sirepo.numpy
 import sirepo.sim_data
+import sirepo.util
 
 _SIM_DATA, SIM_TYPE, _SCHEMA = sirepo.sim_data.template_globals()
 
@@ -198,7 +200,8 @@ def sim_frame_epochAnimation(frame_args):
     #TODO(pjm): improve heading text
     header = ['epoch', 'loss', 'val_loss']
     path = str(frame_args.run_dir.join(_OUTPUT_FILE.fitCSVFile))
-    v = np.genfromtxt(path, delimiter=',', skip_header=1)
+
+    v = sirepo.numpy.ndarray_from_csv(path, True)
     if len(v.shape) == 1:
         v.shape = (v.shape[0], 1)
     return _report_info(
@@ -357,11 +360,7 @@ def _cols_with_non_unique_values(filename, has_header_row, header):
     # TODO(e-carlin): support npy
     assert not re.search(r'\.npy$', str(filename)), \
         f'numpy files are not supported path={filename}'
-    v = np.genfromtxt(
-        str(_filepath(filename)),
-        delimiter=',',
-        skip_header=True,
-    )
+    v = sirepo.numpy.ndarray_from_csv(_filepath(filename), has_header_row)
     res = PKDict()
     for i, c in enumerate(np.all(v == v[0,:], axis = 0)):
         if not c:


### PR DESCRIPTION
I added parsing in get_application_data as well as scale.py.jinja. Also, now the comments arg in numpy.genfromtxt is set to None which means the default (`#`) won't be parsed as a comment. This seems to probably be the right default for us when parsing csv's. 