### PR TITLE
radiasoft/sirepoflash#16: allow user to upload FLASH problem files

### DIFF
--- a/sirepo/package_data/static/html/flash-visualization.html
+++ b/sirepo/package_data/static/html/flash-visualization.html
@@ -11,6 +11,9 @@
       </div>
     </div>
     <div class="col-md-6">
+      <div data-basic-editor-panel="" data-view-name="problemFiles"></div>
+    </div>
+    <div class="col-md-6">
       <div data-basic-editor-panel="" data-view-name="Driver"></div>
     </div>
     <div class="col-md-6" data-ng-hide="visualization.panelState.isHidden('simulationStatus')">

--- a/sirepo/package_data/static/html/flash-visualization.html
+++ b/sirepo/package_data/static/html/flash-visualization.html
@@ -1,22 +1,25 @@
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-6 col-xl-4">
-      <div class="row">
+    <div class="col-sm-6">
+      <div data-basic-editor-panel="" data-view-name="setupArguments"></div>
+    </div>
+    <div class="col-sm-6">
+      <div data-simple-panel="withUnitArguments">
         <div class="col-md-12">
-          <div class="panel panel-info">
-            <div class="panel-heading clearfix" data-panel-heading="Simulation Status" data-model-key="'simulationStatus'"></div>
-            <div class="panel-body" data-ng-hide="visualization.panelState.isHidden('simulationStatus')">
-              <div data-sim-status-panel="visualization.simState"></div>
-            </div>
-          </div>
+          <div data-with-unit-arguments=""></div>
         </div>
-        <div class="col-md-12">
-          <div data-basic-editor-panel="" data-view-name="Driver"></div>
-        </div>
-        <div class="col-md-12" data-ng-if="visualization.flashService.isCapLaser() && visualization.simState.hasFrames()">
-          <div data-report-panel="parameter" data-model-name="gridEvolutionAnimation"></div>
-       </div>
       </div>
+    </div>
+    <div class="col-md-6">
+      <div data-basic-editor-panel="" data-view-name="Driver"></div>
+    </div>
+    <div class="col-md-6" data-ng-hide="visualization.panelState.isHidden('simulationStatus')">
+      <div data-simple-panel="simulationStatus">
+        <div data-sim-status-panel="visualization.simState"></div>
+      </div>
+    </div>
+    <div class="col-md-6" data-ng-if="visualization.flashService.isCapLaser() && visualization.simState.hasFrames()">
+      <div data-report-panel="parameter" data-model-name="gridEvolutionAnimation"></div>
     </div>
     <div class="col-md-6 col-xl-4" data-ng-if="visualization.flashService.isFlashType('RTFlame') && visualization.simState.hasFrames()">
       <div data-report-panel="parameter" data-model-name="gridEvolutionAnimation"></div>

--- a/sirepo/package_data/static/js/flash.js
+++ b/sirepo/package_data/static/js/flash.js
@@ -11,6 +11,9 @@ SIREPO.app.config(function() {
           '<input data-string-to-number="integer" data-ng-model="model[field]" data-min="info[4]" data-max="info[5]" class="form-control" style="text-align: right" data-lpignore="true" required />',
         '</div>'
     ].join('');
+    SIREPO.FILE_UPLOAD_TYPE = {
+        'problemFiles-archive': '.zip',
+    };
     SIREPO.PLOTTING_HEATPLOT_FULL_PIXEL = true;
     SIREPO.SINGLE_FRAME_ANIMATION = ['gridEvolutionAnimation'];
 });

--- a/sirepo/package_data/static/json/flash-schema.json
+++ b/sirepo/package_data/static/json/flash-schema.json
@@ -2182,38 +2182,55 @@
         "setupArguments": {
             "title": "Setup Arguments",
             "basic": [
-                "auto",
-                "cartesian",
-                "cylindrical",
-                "d",
-                "maxblocks",
-                "nofbs",
-                "noio",
-                "nxb",
-                "nyb",
-                "nzb",
-                "opt",
-                "pm2",
-                "pm40",
-                "pm4dev",
-                "polar",
-                "spherical",
-                "splithydro",
-                "ug",
-                "uhd",
-                "usm"
+                ["Common", [
+                    "auto",
+                    "opt",
+                    "cartesian",
+                    "cylindrical",
+                    "polar",
+                    "spherical",
+                    "d",
+                    "species"
+                ]],
+                ["Laser", [
+                    "laser",
+                    "ed_maxBeams",
+                    "ed_maxPulseSections",
+                    "ed_maxPulses"
+
+                ]],
+                ["Blocks", [
+                    "nofbs",
+                    "ug",
+                    "maxblocks",
+                    "nxb",
+                    "nyb",
+                    "nzb"
+                ]],
+                ["Paramesh", [
+                    "pm2",
+                    "pm40",
+                    "pm4dev"
+                ]]
             ],
             "advanced": [
-                "ed_maxBeams",
-                "ed_maxPulseSections",
-                "ed_maxPulses",
-                "hdf5typeio",
-                "laser",
-                "mgd",
-                "mgd_meshgroups",
-                "mtmmmt",
-                "species",
-                "usm3t"
+                ["IO", [
+                    "noio",
+                    "hdf5typeio"
+                ]],
+                ["Magneto Gas Dynamics", [
+                    "mgd",
+                    "mgd_meshgroups"
+                ]],
+                ["Equation Of State", [
+                    "mtmmmt",
+                    "usm3t"
+                ]],
+                ["Solver", [
+                    "splithydro",
+                    "uhd",
+                    "usm"
+                ]]
             ]
         },
         "simulation": {

--- a/sirepo/package_data/static/json/flash-schema.json
+++ b/sirepo/package_data/static/json/flash-schema.json
@@ -3,197 +3,6 @@
         "canDownloadInputFile": false
     },
     "enum": {
-        "flashType": [
-            ["CapLaserBELLA", "CapLaserBELLA"],
-            ["CapLaser3D", "CapLaser3D"],
-            ["RTFlame", "RTFlame"]
-        ],
-        "physicsGravityConstantgdirec": [
-            ["x", "x"],
-            ["y", "y"],
-            ["z", "z"]
-        ],
-        "physicsGravitygrav_boundary_type": [
-            ["isolated", "isolated"],
-            ["periodic", "periodic"],
-            ["dirichlet", "dirichlet"]
-        ],
-        "physicsRadTransMGDrt_mgdBoundEntry": [
-            ["grbd_manual", "grbd_manual"]
-        ],
-        "physicsRadTransMGDrt_mgdFlMode": [
-            ["fl_none", "fl_none"],
-            ["fl_harmonic", "fl_harmonic"],
-            ["fl_minmax", "fl_minmax"],
-            ["fl_larsen", "fl_larsen"],
-            ["fl_levermorepomraning1981", "fl_levermorepomraning1981"]
-        ],
-        "physicsRadTransMGDrt_mgdXlBoundaryType": [
-            ["reflecting", "reflecting"],
-            ["vacuum", "vacuum"],
-            ["dirichlet", "dirichlet"],
-            ["neumann", "neumann"],
-            ["outflow", "outflow"],
-            ["outstream", "outstream"]
-        ],
-        "physicsRadTransMGDrt_mgdXrBoundaryType": [
-            ["reflecting", "reflecting"],
-            ["vacuum", "vacuum"],
-            ["dirichlet", "dirichlet"],
-            ["neumann", "neumann"],
-            ["outflow", "outflow"],
-            ["outstream", "outstream"]
-        ],
-        "physicsRadTransMGDrt_mgdYlBoundaryType": [
-            ["reflecting", "reflecting"],
-            ["vacuum", "vacuum"],
-            ["dirichlet", "dirichlet"],
-            ["neumann", "neumann"],
-            ["outflow", "outflow"],
-            ["outstream", "outstream"]
-        ],
-        "physicsRadTransMGDrt_mgdYrBoundaryType": [
-            ["reflecting", "reflecting"],
-            ["vacuum", "vacuum"],
-            ["dirichlet", "dirichlet"],
-            ["neumann", "neumann"],
-            ["outflow", "outflow"],
-            ["outstream", "outstream"]
-        ],
-        "physicsRadTransMGDrt_mgdZlBoundaryType": [
-            ["reflecting", "reflecting"],
-            ["vacuum", "vacuum"],
-            ["dirichlet", "dirichlet"],
-            ["neumann", "neumann"],
-            ["outflow", "outflow"],
-            ["outstream", "outstream"]
-        ],
-        "physicsRadTransMGDrt_mgdZrBoundaryType": [
-            ["reflecting", "reflecting"],
-            ["vacuum", "vacuum"],
-            ["dirichlet", "dirichlet"],
-            ["neumann", "neumann"],
-            ["outflow", "outflow"],
-            ["outstream", "outstream"]
-        ],
-        "GridEvolutionColumn": [
-            ["mass", "mass"],
-            ["x-momentum", "x-momentum"],
-            ["y-momentum", "y-momentum"],
-            ["z-momentum", "z-momentum"],
-            ["E_total", "E_total"],
-            ["E_kinetic", "E_kinetic"],
-            ["E_turbulent", "E_turbulent"],
-            ["E_internal", "E_internal"],
-            ["Burned Mass", "Burned Mass"],
-            ["dens_burning_ave", "dens_burning_ave"],
-            ["db_ave samplevol", "db_ave samplevol"],
-            ["Burning rate", "Burning rate"],
-            ["fspd to input_fspd ratio", "fspd to input_fspd ratio"],
-            ["surface area flam=0.1", "surface area flam=0.1"],
-            ["surface area flam=0.5", "surface area flam=0.5"],
-            ["surface area flam=0.9", "surface area flam=0.9"]
-        ],
-        "FillSpecies": [
-            ["hydrogen", "Hyrdogen Gas"],
-            ["helium", "Helium Gas"],
-            ["argon", "Argon Gas"]
-        ],
-        "FramesPerSecond": [
-            ["1", "1"],
-            ["2", "2"],
-            ["5", "5"],
-            ["10", "10"],
-            ["15", "15"],
-            ["20", "20"]
-        ],
-        "Multispecieseos_fillEosType": [
-            ["-none-", "-none-"],
-            ["eos_gam", "eos_gam"],
-            ["eos_tab", "eos_tab"]
-        ],
-        "Multispecieseos_wallEosType": [
-            ["-none-", "-none-"],
-            ["eos_gam", "eos_gam"],
-            ["eos_tab", "eos_tab"]
-        ],
-        "RiemannSolver": [
-            ["HHLD", "HLLD"],
-            ["HLL", "HLL"],
-            ["HLLC", "HLLC"],
-            ["HYBR", "Hybrid"],
-            ["LLF", "LLF"],
-            ["MARQ", "Marquina"],
-            ["MARM", "Marquina Modified"],
-            ["ROE", "Roe"]
-        ],
-        "SlopeLimiter": [
-            ["mc", "mc"],
-            ["vanLeer", "vanLeer"],
-            ["minmod", "minmod"],
-            ["hybrid", "hybrid"],
-            ["limited", "limited"]
-        ],
-        "SimulationCapLasersim_currType": [
-            ["0", "Linear ramp"],
-            ["1", "Exponential ramp"],
-            ["2", "From external file"]
-        ],
-        "SimulationCapLasersim_eosFill": [
-            ["eos_tab", "eos_tab"],
-            ["eos_gam", "eos_gam"]
-        ],
-        "SimulationCapLasersim_eosWall": [
-            ["eos_tab", "eos_tab"],
-            ["eos_gam", "eos_gam"]
-        ],
-        "physicsDiffusediff_eleFlMode": [
-            ["fl_none", "fl_none"],
-            ["fl_harmonic", "fl_harmonic"],
-            ["fl_minmax", "fl_minmax"],
-            ["fl_larsen", "fl_larsen"],
-            ["fl_levermorepomraning1981", "fl_levermorepomraning1981"]
-        ],
-        "physicsDiffusediff_ionFlMode": [
-            ["fl_none", "fl_none"],
-            ["fl_harmonic", "fl_harmonic"],
-            ["fl_minmax", "fl_minmax"],
-            ["fl_larsen", "fl_larsen"]
-        ],
-        "VariableName": [
-            ["dens", "dens"],
-            ["depo", "depo"],
-            ["tele", "tele"],
-            ["tion", "tion"],
-            ["trad", "trad"],
-            ["ye", "ye"],
-            ["sumy", "sumy"],
-            ["fill", "fill"],
-            ["wall", "wall"],
-            ["magz", "magz"],
-            ["velx", "velx"],
-            ["kapa", "kapa"],
-            ["flam", "flam"]
-        ],
-        "VariableNameOptional": [
-            ["none", "none"],
-            ["dens", "dens"],
-            ["depo", "depo"],
-            ["tele", "tele"],
-            ["tion", "tion"],
-            ["trad", "trad"],
-            ["ye", "ye"],
-            ["sumy", "sumy"],
-            ["fill", "fill"],
-            ["wall", "wall"],
-            ["magz", "magz"],
-            ["velx", "velx"],
-            ["kapa", "kapa"],
-            ["flam", "flam"]
-        ],
-        "WallSpecies": [
-            ["alumina", "Alumina"]
-        ],
         "DiffuseBoundaryType": [
             ["dirichlet", "dirichlet"],
             ["neumann", "neumann"],
@@ -201,15 +10,6 @@
             ["outstream", "outstream"],
             ["reflecting", "reflecting"],
             ["vacuum", "vacuum"]
-         ],
-        "GridBoundaryType": [
-            ["periodic", "periodic"],
-            ["reflect", "reflect"],
-            ["outflow", "outflow"],
-            ["diode", "diode"],
-            ["axisymmetric", "axisymmetric"],
-            ["eqtsymmetric", "eqtsymmetric"],
-            ["user", "user"]
         ],
         "Driverdr_dtMinBelowAction": [
             ["0", "0"],
@@ -222,6 +22,33 @@
             ["231", "231"],
             ["312", "312"],
             ["321", "321"]
+        ],
+        "FillSpecies": [
+            ["hydrogen", "Hyrdogen Gas"],
+            ["helium", "Helium Gas"],
+            ["argon", "Argon Gas"]
+        ],
+        "flashType": [
+            ["CapLaserBELLA", "CapLaserBELLA"],
+            ["CapLaser3D", "CapLaser3D"],
+            ["RTFlame", "RTFlame"]
+        ],
+        "FramesPerSecond": [
+            ["1", "1"],
+            ["2", "2"],
+            ["5", "5"],
+            ["10", "10"],
+            ["15", "15"],
+            ["20", "20"]
+        ],
+        "GridBoundaryType": [
+            ["periodic", "periodic"],
+            ["reflect", "reflect"],
+            ["outflow", "outflow"],
+            ["diode", "diode"],
+            ["axisymmetric", "axisymmetric"],
+            ["eqtsymmetric", "eqtsymmetric"],
+            ["user", "user"]
         ],
         "GridbndPriorityOne": [
             ["1", "1"],
@@ -264,6 +91,24 @@
             ["dens_temp_gather", "dens_temp_gather"],
             ["eos_nop", "eos_nop"]
         ],
+        "GridEvolutionColumn": [
+            ["mass", "mass"],
+            ["x-momentum", "x-momentum"],
+            ["y-momentum", "y-momentum"],
+            ["z-momentum", "z-momentum"],
+            ["E_total", "E_total"],
+            ["E_kinetic", "E_kinetic"],
+            ["E_turbulent", "E_turbulent"],
+            ["E_internal", "E_internal"],
+            ["Burned Mass", "Burned Mass"],
+            ["dens_burning_ave", "dens_burning_ave"],
+            ["db_ave samplevol", "db_ave samplevol"],
+            ["Burning rate", "Burning rate"],
+            ["fspd to input_fspd ratio", "fspd to input_fspd ratio"],
+            ["surface area flam=0.1", "surface area flam=0.1"],
+            ["surface area flam=0.5", "surface area flam=0.5"],
+            ["surface area flam=0.9", "surface area flam=0.9"]
+        ],
         "Gridgeometry": [
             ["cartesian", "cartesian"],
             ["polar", "polar"],
@@ -298,67 +143,38 @@
             ["4", "4"],
             ["5", "5"]
         ],
-        "physicsmaterialPropertiesOpacityMultispeciesop_fillAbsorb": [
-            ["op_undefined", "op_undefined"],
-            ["op_constant", "op_constant"],
-            ["op_constcm2g", "op_constcm2g"],
-            ["op_tabpa", "op_tabpa"],
-            ["op_tabpe", "op_tabpe"],
-            ["op_tabro", "op_tabro"]
+        "Multispecieseos_fillEosType": [
+            ["-none-", "-none-"],
+            ["eos_gam", "eos_gam"],
+            ["eos_tab", "eos_tab"]
         ],
-        "physicsmaterialPropertiesOpacityMultispeciesop_fillEmiss": [
-            ["op_undefined", "op_undefined"],
-            ["op_constant", "op_constant"],
-            ["op_constcm2g", "op_constcm2g"],
-            ["op_tabpa", "op_tabpa"],
-            ["op_tabpe", "op_tabpe"],
-            ["op_tabro", "op_tabro"]
+        "Multispecieseos_wallEosType": [
+            ["-none-", "-none-"],
+            ["eos_gam", "eos_gam"],
+            ["eos_tab", "eos_tab"]
         ],
-        "physicsmaterialPropertiesOpacityMultispeciesop_fillTrans": [
-            ["op_undefined", "op_undefined"],
-            ["op_constant", "op_constant"],
-            ["op_constcm2g", "op_constcm2g"],
-            ["op_tabpa", "op_tabpa"],
-            ["op_tabpe", "op_tabpe"],
-            ["op_tabro", "op_tabro"]
+        "physicsDiffusediff_eleFlMode": [
+            ["fl_none", "fl_none"],
+            ["fl_harmonic", "fl_harmonic"],
+            ["fl_minmax", "fl_minmax"],
+            ["fl_larsen", "fl_larsen"],
+            ["fl_levermorepomraning1981", "fl_levermorepomraning1981"]
         ],
-        "physicsmaterialPropertiesOpacityMultispeciesop_wallAbsorb": [
-            ["op_undefined", "op_undefined"],
-            ["op_constant", "op_constant"],
-            ["op_constcm2g", "op_constcm2g"],
-            ["op_tabpa", "op_tabpa"],
-            ["op_tabpe", "op_tabpe"],
-            ["op_tabro", "op_tabro"]
+        "physicsDiffusediff_ionFlMode": [
+            ["fl_none", "fl_none"],
+            ["fl_harmonic", "fl_harmonic"],
+            ["fl_minmax", "fl_minmax"],
+            ["fl_larsen", "fl_larsen"]
         ],
-        "physicsmaterialPropertiesOpacityMultispeciesop_wallEmiss": [
-            ["op_undefined", "op_undefined"],
-            ["op_constant", "op_constant"],
-            ["op_constcm2g", "op_constcm2g"],
-            ["op_tabpa", "op_tabpa"],
-            ["op_tabpe", "op_tabpe"],
-            ["op_tabro", "op_tabro"]
+        "physicsGravityConstantgdirec": [
+            ["x", "x"],
+            ["y", "y"],
+            ["z", "z"]
         ],
-        "physicsmaterialPropertiesOpacityMultispeciesop_wallTrans": [
-            ["op_undefined", "op_undefined"],
-            ["op_constant", "op_constant"],
-            ["op_constcm2g", "op_constcm2g"],
-            ["op_tabpa", "op_tabpa"],
-            ["op_tabpe", "op_tabpe"],
-            ["op_tabro", "op_tabro"]
-        ],
-        "physicssourceTermsEnergyDepositionLasered_gradOrder": [
-            ["1", "1"],
-            ["2", "2"]
-        ],
-        "physicssourceTermsEnergyDepositionLasered_gridType_1": [
-            ["rectangular2D", "rectangular2D"],
-            ["square2D", "square2D"],
-            ["delta2D", "delta2D"],
-            ["radial2D", "radial2D"],
-            ["statistical2D", "statistical2D"],
-            ["regular1D", "regular1D"],
-            ["statistical1D", "statistical1D"],
-            [" ", " "]
+        "physicsGravitygrav_boundary_type": [
+            ["isolated", "isolated"],
+            ["periodic", "periodic"],
+            ["dirichlet", "dirichlet"]
         ],
         "physicsHydrounsplithy_3Torder": [
             ["-1", "-1"],
@@ -445,6 +261,754 @@
             ["2", "2"],
             ["3", "3"],
             ["4", "4"]
+        ],
+        "physicsmaterialPropertiesOpacityMultispeciesop_fillAbsorb": [
+            ["op_undefined", "op_undefined"],
+            ["op_constant", "op_constant"],
+            ["op_constcm2g", "op_constcm2g"],
+            ["op_tabpa", "op_tabpa"],
+            ["op_tabpe", "op_tabpe"],
+            ["op_tabro", "op_tabro"]
+        ],
+        "physicsmaterialPropertiesOpacityMultispeciesop_fillEmiss": [
+            ["op_undefined", "op_undefined"],
+            ["op_constant", "op_constant"],
+            ["op_constcm2g", "op_constcm2g"],
+            ["op_tabpa", "op_tabpa"],
+            ["op_tabpe", "op_tabpe"],
+            ["op_tabro", "op_tabro"]
+        ],
+        "physicsmaterialPropertiesOpacityMultispeciesop_fillTrans": [
+            ["op_undefined", "op_undefined"],
+            ["op_constant", "op_constant"],
+            ["op_constcm2g", "op_constcm2g"],
+            ["op_tabpa", "op_tabpa"],
+            ["op_tabpe", "op_tabpe"],
+            ["op_tabro", "op_tabro"]
+        ],
+        "physicsmaterialPropertiesOpacityMultispeciesop_wallAbsorb": [
+            ["op_undefined", "op_undefined"],
+            ["op_constant", "op_constant"],
+            ["op_constcm2g", "op_constcm2g"],
+            ["op_tabpa", "op_tabpa"],
+            ["op_tabpe", "op_tabpe"],
+            ["op_tabro", "op_tabro"]
+        ],
+        "physicsmaterialPropertiesOpacityMultispeciesop_wallEmiss": [
+            ["op_undefined", "op_undefined"],
+            ["op_constant", "op_constant"],
+            ["op_constcm2g", "op_constcm2g"],
+            ["op_tabpa", "op_tabpa"],
+            ["op_tabpe", "op_tabpe"],
+            ["op_tabro", "op_tabro"]
+        ],
+        "physicsmaterialPropertiesOpacityMultispeciesop_wallTrans": [
+            ["op_undefined", "op_undefined"],
+            ["op_constant", "op_constant"],
+            ["op_constcm2g", "op_constcm2g"],
+            ["op_tabpa", "op_tabpa"],
+            ["op_tabpe", "op_tabpe"],
+            ["op_tabro", "op_tabro"]
+        ],
+        "physicsRadTransMGDrt_mgdBoundEntry": [
+            ["grbd_manual", "grbd_manual"]
+        ],
+        "physicsRadTransMGDrt_mgdFlMode": [
+            ["fl_none", "fl_none"],
+            ["fl_harmonic", "fl_harmonic"],
+            ["fl_minmax", "fl_minmax"],
+            ["fl_larsen", "fl_larsen"],
+            ["fl_levermorepomraning1981", "fl_levermorepomraning1981"]
+        ],
+        "physicsRadTransMGDrt_mgdXlBoundaryType": [
+            ["reflecting", "reflecting"],
+            ["vacuum", "vacuum"],
+            ["dirichlet", "dirichlet"],
+            ["neumann", "neumann"],
+            ["outflow", "outflow"],
+            ["outstream", "outstream"]
+        ],
+        "physicsRadTransMGDrt_mgdXrBoundaryType": [
+            ["reflecting", "reflecting"],
+            ["vacuum", "vacuum"],
+            ["dirichlet", "dirichlet"],
+            ["neumann", "neumann"],
+            ["outflow", "outflow"],
+            ["outstream", "outstream"]
+        ],
+        "physicsRadTransMGDrt_mgdYlBoundaryType": [
+            ["reflecting", "reflecting"],
+            ["vacuum", "vacuum"],
+            ["dirichlet", "dirichlet"],
+            ["neumann", "neumann"],
+            ["outflow", "outflow"],
+            ["outstream", "outstream"]
+        ],
+        "physicsRadTransMGDrt_mgdYrBoundaryType": [
+            ["reflecting", "reflecting"],
+            ["vacuum", "vacuum"],
+            ["dirichlet", "dirichlet"],
+            ["neumann", "neumann"],
+            ["outflow", "outflow"],
+            ["outstream", "outstream"]
+        ],
+        "physicsRadTransMGDrt_mgdZlBoundaryType": [
+            ["reflecting", "reflecting"],
+            ["vacuum", "vacuum"],
+            ["dirichlet", "dirichlet"],
+            ["neumann", "neumann"],
+            ["outflow", "outflow"],
+            ["outstream", "outstream"]
+        ],
+        "physicsRadTransMGDrt_mgdZrBoundaryType": [
+            ["reflecting", "reflecting"],
+            ["vacuum", "vacuum"],
+            ["dirichlet", "dirichlet"],
+            ["neumann", "neumann"],
+            ["outflow", "outflow"],
+            ["outstream", "outstream"]
+        ],
+        "physicssourceTermsEnergyDepositionLasered_gradOrder": [
+            ["1", "1"],
+            ["2", "2"]
+        ],
+        "physicssourceTermsEnergyDepositionLasered_gridType_1": [
+            ["rectangular2D", "rectangular2D"],
+            ["square2D", "square2D"],
+            ["delta2D", "delta2D"],
+            ["radial2D", "radial2D"],
+            ["statistical2D", "statistical2D"],
+            ["regular1D", "regular1D"],
+            ["statistical1D", "statistical1D"],
+            [" ", " "]
+        ],
+        "RiemannSolver": [
+            ["HHLD", "HLLD"],
+            ["HLL", "HLL"],
+            ["HLLC", "HLLC"],
+            ["HYBR", "Hybrid"],
+            ["LLF", "LLF"],
+            ["MARQ", "Marquina"],
+            ["MARM", "Marquina Modified"],
+            ["ROE", "Roe"]
+        ],
+        "SetupArgumentDimension": [
+            ["1", "1"],
+            ["2", "2"],
+            ["3", "3"]
+        ],
+        "SetupArgumentUnitPath": [
+            ["Driver", "Driver"],
+            ["Driver/DriverMain", "Driver/DriverMain"],
+            ["Driver/DriverMain/INSfracstep", "Driver/DriverMain/INSfracstep"],
+            ["Driver/DriverMain/Split", "Driver/DriverMain/Split"],
+            ["Driver/DriverMain/Unsplit", "Driver/DriverMain/Unsplit"],
+            ["Grid", "Grid"],
+            ["Grid/GridAllocatableScratches", "Grid/GridAllocatableScratches"],
+            ["Grid/GridBoundaryConditions", "Grid/GridBoundaryConditions"],
+            ["Grid/GridBoundaryConditions/Chombo", "Grid/GridBoundaryConditions/Chombo"],
+            ["Grid/GridBoundaryConditions/Flash2HSE", "Grid/GridBoundaryConditions/Flash2HSE"],
+            ["Grid/GridBoundaryConditions/Flash3HSE", "Grid/GridBoundaryConditions/Flash3HSE"],
+            ["Grid/GridBoundaryConditions/OneRow", "Grid/GridBoundaryConditions/OneRow"],
+            ["Grid/GridBoundaryConditions/OneRow/Flash2HSE", "Grid/GridBoundaryConditions/OneRow/Flash2HSE"],
+            ["Grid/GridBoundaryConditions/OneRow/Flash3HSE", "Grid/GridBoundaryConditions/OneRow/Flash3HSE"],
+            ["Grid/GridMain", "Grid/GridMain"],
+            ["Grid/GridMain/Chombo", "Grid/GridMain/Chombo"],
+            ["Grid/GridMain/Chombo/AMR", "Grid/GridMain/Chombo/AMR"],
+            ["Grid/GridMain/Chombo/UG", "Grid/GridMain/Chombo/UG"],
+            ["Grid/GridMain/UG", "Grid/GridMain/UG"],
+            ["Grid/GridMain/UG/UGReordered", "Grid/GridMain/UG/UGReordered"],
+            ["Grid/GridMain/paramesh/Paramesh2", "Grid/GridMain/paramesh/Paramesh2"],
+            ["Grid/GridMain/paramesh/interpolation/Paramesh4", "Grid/GridMain/paramesh/interpolation/Paramesh4"],
+            ["Grid/GridMain/paramesh/paramesh4/Incomp", "Grid/GridMain/paramesh/paramesh4/Incomp"],
+            ["Grid/GridMain/paramesh/paramesh4/Paramesh4.0", "Grid/GridMain/paramesh/paramesh4/Paramesh4.0"],
+            ["Grid/GridMain/paramesh/paramesh4/Paramesh4.0/PM4_package", "Grid/GridMain/paramesh/paramesh4/Paramesh4.0/PM4_package"],
+            ["Grid/GridMain/paramesh/paramesh4/Paramesh4.0/PM4_package/Tests", "Grid/GridMain/paramesh/paramesh4/Paramesh4.0/PM4_package/Tests"],
+            ["Grid/GridMain/paramesh/paramesh4/Paramesh4.0/PM4_package/Tests/Poisson", "Grid/GridMain/paramesh/paramesh4/Paramesh4.0/PM4_package/Tests/Poisson"],
+            ["Grid/GridMain/paramesh/paramesh4/Paramesh4dev", "Grid/GridMain/paramesh/paramesh4/Paramesh4dev"],
+            ["Grid/GridMain/paramesh/paramesh4/Paramesh4dev/PM4_package", "Grid/GridMain/paramesh/paramesh4/Paramesh4dev/PM4_package"],
+            ["Grid/GridMain/paramesh/paramesh4/Paramesh4dev/PM4_package/Ex_Makefiles", "Grid/GridMain/paramesh/paramesh4/Paramesh4dev/PM4_package/Ex_Makefiles"],
+            ["Grid/GridMain/paramesh/paramesh4/Paramesh4dev/PM4_package/Tests", "Grid/GridMain/paramesh/paramesh4/Paramesh4dev/PM4_package/Tests"],
+            ["Grid/GridMain/paramesh/paramesh4/Paramesh4dev/PM4_package/Tests/Poisson", "Grid/GridMain/paramesh/paramesh4/Paramesh4dev/PM4_package/Tests/Poisson"],
+            ["Grid/GridParticles", "Grid/GridParticles"],
+            ["Grid/GridParticles/GridParticlesMapFromMesh", "Grid/GridParticles/GridParticlesMapFromMesh"],
+            ["Grid/GridParticles/GridParticlesMapToMesh", "Grid/GridParticles/GridParticlesMapToMesh"],
+            ["Grid/GridParticles/GridParticlesMapToMesh/Paramesh", "Grid/GridParticles/GridParticlesMapToMesh/Paramesh"],
+            ["Grid/GridParticles/GridParticlesMapToMesh/Paramesh/MoveSieve", "Grid/GridParticles/GridParticlesMapToMesh/Paramesh/MoveSieve"],
+            ["Grid/GridParticles/GridParticlesMapToMesh/Paramesh/PttoPt", "Grid/GridParticles/GridParticlesMapToMesh/Paramesh/PttoPt"],
+            ["Grid/GridParticles/GridParticlesMapToMesh/UG", "Grid/GridParticles/GridParticlesMapToMesh/UG"],
+            ["Grid/GridParticles/GridParticlesMove", "Grid/GridParticles/GridParticlesMove"],
+            ["Grid/GridParticles/GridParticlesMove/Sieve", "Grid/GridParticles/GridParticlesMove/Sieve"],
+            ["Grid/GridParticles/GridParticlesMove/Sieve/BlockMatch", "Grid/GridParticles/GridParticlesMove/Sieve/BlockMatch"],
+            ["Grid/GridParticles/GridParticlesMove/UG", "Grid/GridParticles/GridParticlesMove/UG"],
+            ["Grid/GridParticles/GridParticlesMove/UG/Directional", "Grid/GridParticles/GridParticlesMove/UG/Directional"],
+            ["Grid/GridParticles/GridParticlesMove/paramesh/VirtualParticles", "Grid/GridParticles/GridParticlesMove/paramesh/VirtualParticles"],
+            ["Grid/GridSolvers", "Grid/GridSolvers"],
+            ["Grid/GridSolvers/BHTree", "Grid/GridSolvers/BHTree"],
+            ["Grid/GridSolvers/BHTree/Wunsch", "Grid/GridSolvers/BHTree/Wunsch"],
+            ["Grid/GridSolvers/BiPCGStab", "Grid/GridSolvers/BiPCGStab"],
+            ["Grid/GridSolvers/BiPCGStab/poisson/PrecondHYPRE", "Grid/GridSolvers/BiPCGStab/poisson/PrecondHYPRE"],
+            ["Grid/GridSolvers/BiPCGStab/poisson/PrecondMultigrid", "Grid/GridSolvers/BiPCGStab/poisson/PrecondMultigrid"],
+            ["Grid/GridSolvers/BiPCGStab/poisson/PrecondMultigridMC", "Grid/GridSolvers/BiPCGStab/poisson/PrecondMultigridMC"],
+            ["Grid/GridSolvers/HYPRE", "Grid/GridSolvers/HYPRE"],
+            ["Grid/GridSolvers/HYPRE/UG", "Grid/GridSolvers/HYPRE/UG"],
+            ["Grid/GridSolvers/HYPRE/multiScalar/coupled/UG", "Grid/GridSolvers/HYPRE/multiScalar/coupled/UG"],
+            ["Grid/GridSolvers/IsoBndMultipole", "Grid/GridSolvers/IsoBndMultipole"],
+            ["Grid/GridSolvers/Multigrid", "Grid/GridSolvers/Multigrid"],
+            ["Grid/GridSolvers/Multigrid/Paramesh2", "Grid/GridSolvers/Multigrid/Paramesh2"],
+            ["Grid/GridSolvers/Multigrid/PfftTopLevelSolve", "Grid/GridSolvers/Multigrid/PfftTopLevelSolve"],
+            ["Grid/GridSolvers/Multigrid/PfftTopLevelSolve/HomBcTrig", "Grid/GridSolvers/Multigrid/PfftTopLevelSolve/HomBcTrig"],
+            ["Grid/GridSolvers/Multigrid/PfftTopLevelSolve/SimplePeriodic", "Grid/GridSolvers/Multigrid/PfftTopLevelSolve/SimplePeriodic"],
+            ["Grid/GridSolvers/MultigridMC", "Grid/GridSolvers/MultigridMC"],
+            ["Grid/GridSolvers/MultigridMC/poisson/PfftTopLevelSolve", "Grid/GridSolvers/MultigridMC/poisson/PfftTopLevelSolve"],
+            ["Grid/GridSolvers/MultigridMC/poisson/PfftTopLevelSolve/HomBcTrig", "Grid/GridSolvers/MultigridMC/poisson/PfftTopLevelSolve/HomBcTrig"],
+            ["Grid/GridSolvers/Multipole", "Grid/GridSolvers/Multipole"],
+            ["Grid/GridSolvers/Multipole_new", "Grid/GridSolvers/Multipole_new"],
+            ["Grid/GridSolvers/Pfft", "Grid/GridSolvers/Pfft"],
+            ["Grid/GridSolvers/Pfft/DirectSolver", "Grid/GridSolvers/Pfft/DirectSolver"],
+            ["Grid/GridSolvers/Pfft/DirectSolver/Generic_Direct", "Grid/GridSolvers/Pfft/DirectSolver/Generic_Direct"],
+            ["Grid/GridSolvers/Pfft/DirectSolver/PlaneSolver_blktri", "Grid/GridSolvers/Pfft/DirectSolver/PlaneSolver_blktri"],
+            ["Grid/GridSolvers/Pfft/DirectSolver/SecondOrder_FD3p", "Grid/GridSolvers/Pfft/DirectSolver/SecondOrder_FD3p"],
+            ["Grid/GridSolvers/Pfft/HomBcTrigSolver", "Grid/GridSolvers/Pfft/HomBcTrigSolver"],
+            ["Grid/GridSolvers/Pfft/ImplicitDiffusionSolver", "Grid/GridSolvers/Pfft/ImplicitDiffusionSolver"],
+            ["Grid/GridSolvers/Pfft/MeshReconfiguration", "Grid/GridSolvers/Pfft/MeshReconfiguration"],
+            ["Grid/GridSolvers/Pfft/MeshReconfiguration/Collective", "Grid/GridSolvers/Pfft/MeshReconfiguration/Collective"],
+            ["Grid/GridSolvers/Pfft/MeshReconfiguration/PtToPt", "Grid/GridSolvers/Pfft/MeshReconfiguration/PtToPt"],
+            ["Grid/GridSolvers/Pfft/ProcessGrid", "Grid/GridSolvers/Pfft/ProcessGrid"],
+            ["Grid/GridSolvers/Pfft/SimplePeriodicSolver", "Grid/GridSolvers/Pfft/SimplePeriodicSolver"],
+            ["IO", "IO"],
+            ["IO/IOMain", "IO/IOMain"],
+            ["IO/IOMain/direct/PM", "IO/IOMain/direct/PM"],
+            ["IO/IOMain/direct/UG", "IO/IOMain/direct/UG"],
+            ["IO/IOMain/hdf5/parallel/NoFbs", "IO/IOMain/hdf5/parallel/NoFbs"],
+            ["IO/IOMain/hdf5/parallel/PM", "IO/IOMain/hdf5/parallel/PM"],
+            ["IO/IOMain/hdf5/parallel/PM_argonne", "IO/IOMain/hdf5/parallel/PM_argonne"],
+            ["IO/IOMain/hdf5/parallel/PM_argonne/UnitTest", "IO/IOMain/hdf5/parallel/PM_argonne/UnitTest"],
+            ["IO/IOMain/hdf5/parallel/PM_argonne/UnitTest/TestParallelWriteC", "IO/IOMain/hdf5/parallel/PM_argonne/UnitTest/TestParallelWriteC"],
+            ["IO/IOMain/hdf5/parallel/PM_argonne/UnitTest/TestSerialWriteFortran", "IO/IOMain/hdf5/parallel/PM_argonne/UnitTest/TestSerialWriteFortran"],
+            ["IO/IOMain/hdf5/parallel/UG", "IO/IOMain/hdf5/parallel/UG"],
+            ["IO/IOMain/hdf5/serial/PM", "IO/IOMain/hdf5/serial/PM"],
+            ["IO/IOMain/hdf5/serial/UG", "IO/IOMain/hdf5/serial/UG"],
+            ["IO/IOMain/pnetcdf/typeSelection/UnitTest", "IO/IOMain/pnetcdf/typeSelection/UnitTest"],
+            ["IO/IOMain/pnetcdf/typeSelection/UnitTest/TestParallelWriteC", "IO/IOMain/pnetcdf/typeSelection/UnitTest/TestParallelWriteC"],
+            ["IO/IOParticles", "IO/IOParticles"],
+            ["IO/IOParticles/direct/UG", "IO/IOParticles/direct/UG"],
+            ["IO/IOSingleCell", "IO/IOSingleCell"],
+            ["IO/IOTypes", "IO/IOTypes"],
+            ["Multispecies", "Multispecies"],
+            ["Multispecies/MultispeciesMain", "Multispecies/MultispeciesMain"],
+            ["Particles", "Particles"],
+            ["Particles/ParticlesForces", "Particles/ParticlesForces"],
+            ["Particles/ParticlesForces/longRange/gravity/ParticleMesh", "Particles/ParticlesForces/longRange/gravity/ParticleMesh"],
+            ["Particles/ParticlesInitialization", "Particles/ParticlesInitialization"],
+            ["Particles/ParticlesInitialization/Lattice", "Particles/ParticlesInitialization/Lattice"],
+            ["Particles/ParticlesInitialization/WithDensity", "Particles/ParticlesInitialization/WithDensity"],
+            ["Particles/ParticlesInitialization/WithDensity/CellMassBins", "Particles/ParticlesInitialization/WithDensity/CellMassBins"],
+            ["Particles/ParticlesInitialization/WithDensity/RejectionMethod", "Particles/ParticlesInitialization/WithDensity/RejectionMethod"],
+            ["Particles/ParticlesMain", "Particles/ParticlesMain"],
+            ["Particles/ParticlesMain/active/DPD", "Particles/ParticlesMain/active/DPD"],
+            ["Particles/ParticlesMain/active/Sink", "Particles/ParticlesMain/active/Sink"],
+            ["Particles/ParticlesMain/active/charged/HybridPIC", "Particles/ParticlesMain/active/charged/HybridPIC"],
+            ["Particles/ParticlesMain/active/massive/Euler", "Particles/ParticlesMain/active/massive/Euler"],
+            ["Particles/ParticlesMain/active/massive/Leapfrog", "Particles/ParticlesMain/active/massive/Leapfrog"],
+            ["Particles/ParticlesMain/active/massive/LeapfrogCosmo", "Particles/ParticlesMain/active/massive/LeapfrogCosmo"],
+            ["Particles/ParticlesMain/passive/EstiMidpoint2", "Particles/ParticlesMain/passive/EstiMidpoint2"],
+            ["Particles/ParticlesMain/passive/Euler", "Particles/ParticlesMain/passive/Euler"],
+            ["Particles/ParticlesMain/passive/Midpoint", "Particles/ParticlesMain/passive/Midpoint"],
+            ["Particles/ParticlesMain/passive/RungeKutta", "Particles/ParticlesMain/passive/RungeKutta"],
+            ["Particles/ParticlesMapping", "Particles/ParticlesMapping"],
+            ["Particles/ParticlesMapping/Quadratic", "Particles/ParticlesMapping/Quadratic"],
+            ["Particles/ParticlesMapping/meshWeighting/CIC", "Particles/ParticlesMapping/meshWeighting/CIC"],
+            ["Particles/ParticlesMapping/meshWeighting/MapToMesh", "Particles/ParticlesMapping/meshWeighting/MapToMesh"],
+            ["PhysicalConstants", "PhysicalConstants"],
+            ["PhysicalConstants/PhysicalConstantsMain", "PhysicalConstants/PhysicalConstantsMain"],
+            ["RuntimeParameters", "RuntimeParameters"],
+            ["RuntimeParameters/RuntimeParametersMain", "RuntimeParameters/RuntimeParametersMain"],
+            ["Simulation", "Simulation"],
+            ["Simulation/SimulationComposition", "Simulation/SimulationComposition"],
+            ["Simulation/SimulationComposition/Burn", "Simulation/SimulationComposition/Burn"],
+            ["Simulation/SimulationComposition/Ionize", "Simulation/SimulationComposition/Ionize"],
+            ["Simulation/SimulationComposition/PrimordialChemistryGA", "Simulation/SimulationComposition/PrimordialChemistryGA"],
+            ["Simulation/SimulationMain", "Simulation/SimulationMain"],
+            ["Simulation/SimulationMain/Blast2", "Simulation/SimulationMain/Blast2"],
+            ["Simulation/SimulationMain/CCSN", "Simulation/SimulationMain/CCSN"],
+            ["Simulation/SimulationMain/CapLaser3D", "Simulation/SimulationMain/CapLaser3D"],
+            ["Simulation/SimulationMain/CapLaserBELLA", "Simulation/SimulationMain/CapLaserBELLA"],
+            ["Simulation/SimulationMain/Cellular", "Simulation/SimulationMain/Cellular"],
+            ["Simulation/SimulationMain/Chemistry_Test", "Simulation/SimulationMain/Chemistry_Test"],
+            ["Simulation/SimulationMain/ConductionDelta", "Simulation/SimulationMain/ConductionDelta"],
+            ["Simulation/SimulationMain/ConductionDeltaSaDiff", "Simulation/SimulationMain/ConductionDeltaSaDiff"],
+            ["Simulation/SimulationMain/Cool_Test", "Simulation/SimulationMain/Cool_Test"],
+            ["Simulation/SimulationMain/Default", "Simulation/SimulationMain/Default"],
+            ["Simulation/SimulationMain/DoubleMachReflection", "Simulation/SimulationMain/DoubleMachReflection"],
+            ["Simulation/SimulationMain/DustCollapse", "Simulation/SimulationMain/DustCollapse"],
+            ["Simulation/SimulationMain/Flame1StageNoise", "Simulation/SimulationMain/Flame1StageNoise"],
+            ["Simulation/SimulationMain/FlameChannel", "Simulation/SimulationMain/FlameChannel"],
+            ["Simulation/SimulationMain/FlatPlate", "Simulation/SimulationMain/FlatPlate"],
+            ["Simulation/SimulationMain/GrayDiffRadShock", "Simulation/SimulationMain/GrayDiffRadShock"],
+            ["Simulation/SimulationMain/HeatedFoil", "Simulation/SimulationMain/HeatedFoil"],
+            ["Simulation/SimulationMain/HeatexchangeIonEle", "Simulation/SimulationMain/HeatexchangeIonEle"],
+            ["Simulation/SimulationMain/HydroStatic", "Simulation/SimulationMain/HydroStatic"],
+            ["Simulation/SimulationMain/IsentropicVortex", "Simulation/SimulationMain/IsentropicVortex"],
+            ["Simulation/SimulationMain/IsentropicVortex/FiguresFromAlanPaperValidationParticles", "Simulation/SimulationMain/IsentropicVortex/FiguresFromAlanPaperValidationParticles"],
+            ["Simulation/SimulationMain/Jeans", "Simulation/SimulationMain/Jeans"],
+            ["Simulation/SimulationMain/LaserSlab", "Simulation/SimulationMain/LaserSlab"],
+            ["Simulation/SimulationMain/MGDInfinite", "Simulation/SimulationMain/MGDInfinite"],
+            ["Simulation/SimulationMain/MGDStep", "Simulation/SimulationMain/MGDStep"],
+            ["Simulation/SimulationMain/MacLaurin", "Simulation/SimulationMain/MacLaurin"],
+            ["Simulation/SimulationMain/NeiTest", "Simulation/SimulationMain/NeiTest"],
+            ["Simulation/SimulationMain/NeiTest/Validate", "Simulation/SimulationMain/NeiTest/Validate"],
+            ["Simulation/SimulationMain/Orbit", "Simulation/SimulationMain/Orbit"],
+            ["Simulation/SimulationMain/Pancake", "Simulation/SimulationMain/Pancake"],
+            ["Simulation/SimulationMain/Plasma", "Simulation/SimulationMain/Plasma"],
+            ["Simulation/SimulationMain/PoisTest", "Simulation/SimulationMain/PoisTest"],
+            ["Simulation/SimulationMain/ProtonImaging", "Simulation/SimulationMain/ProtonImaging"],
+            ["Simulation/SimulationMain/RHD_Riemann2D", "Simulation/SimulationMain/RHD_Riemann2D"],
+            ["Simulation/SimulationMain/RHD_Sod", "Simulation/SimulationMain/RHD_Sod"],
+            ["Simulation/SimulationMain/RTFlame", "Simulation/SimulationMain/RTFlame"],
+            ["Simulation/SimulationMain/ReinickeMeyer", "Simulation/SimulationMain/ReinickeMeyer"],
+            ["Simulation/SimulationMain/SBlast", "Simulation/SimulationMain/SBlast"],
+            ["Simulation/SimulationMain/Sedov", "Simulation/SimulationMain/Sedov"],
+            ["Simulation/SimulationMain/Sedov/WriteParticleSubset", "Simulation/SimulationMain/Sedov/WriteParticleSubset"],
+            ["Simulation/SimulationMain/SedovChamber", "Simulation/SimulationMain/SedovChamber"],
+            ["Simulation/SimulationMain/SedovChamber/WriteParticleSubset", "Simulation/SimulationMain/SedovChamber/WriteParticleSubset"],
+            ["Simulation/SimulationMain/SedovSelfGravity", "Simulation/SimulationMain/SedovSelfGravity"],
+            ["Simulation/SimulationMain/SedovSolidWall", "Simulation/SimulationMain/SedovSolidWall"],
+            ["Simulation/SimulationMain/ShafranovShock", "Simulation/SimulationMain/ShafranovShock"],
+            ["Simulation/SimulationMain/ShuOsher", "Simulation/SimulationMain/ShuOsher"],
+            ["Simulation/SimulationMain/SinkRotatingCloudCore", "Simulation/SimulationMain/SinkRotatingCloudCore"],
+            ["Simulation/SimulationMain/Sod", "Simulation/SimulationMain/Sod"],
+            ["Simulation/SimulationMain/SodSpherical", "Simulation/SimulationMain/SodSpherical"],
+            ["Simulation/SimulationMain/SodStep", "Simulation/SimulationMain/SodStep"],
+            ["Simulation/SimulationMain/StirFromFile", "Simulation/SimulationMain/StirFromFile"],
+            ["Simulation/SimulationMain/StirTurb", "Simulation/SimulationMain/StirTurb"],
+            ["Simulation/SimulationMain/WindTunnel", "Simulation/SimulationMain/WindTunnel"],
+            ["Simulation/SimulationMain/incompFlow/TaylorGreenVortex", "Simulation/SimulationMain/incompFlow/TaylorGreenVortex"],
+            ["Simulation/SimulationMain/incompFlow/Tecplot2D", "Simulation/SimulationMain/incompFlow/Tecplot2D"],
+            ["Simulation/SimulationMain/magnetoHD/2DCartesianBiermannTest", "Simulation/SimulationMain/magnetoHD/2DCartesianBiermannTest"],
+            ["Simulation/SimulationMain/magnetoHD/2DCylindricalBiermannTest", "Simulation/SimulationMain/magnetoHD/2DCylindricalBiermannTest"],
+            ["Simulation/SimulationMain/magnetoHD/AnisoCond", "Simulation/SimulationMain/magnetoHD/AnisoCond"],
+            ["Simulation/SimulationMain/magnetoHD/BlastBS", "Simulation/SimulationMain/magnetoHD/BlastBS"],
+            ["Simulation/SimulationMain/magnetoHD/BrioWu", "Simulation/SimulationMain/magnetoHD/BrioWu"],
+            ["Simulation/SimulationMain/magnetoHD/CurrentSheet", "Simulation/SimulationMain/magnetoHD/CurrentSheet"],
+            ["Simulation/SimulationMain/magnetoHD/FieldLoop", "Simulation/SimulationMain/magnetoHD/FieldLoop"],
+            ["Simulation/SimulationMain/magnetoHD/HallDriftWaves", "Simulation/SimulationMain/magnetoHD/HallDriftWaves"],
+            ["Simulation/SimulationMain/magnetoHD/HallWhistlerWaves", "Simulation/SimulationMain/magnetoHD/HallWhistlerWaves"],
+            ["Simulation/SimulationMain/magnetoHD/Noh", "Simulation/SimulationMain/magnetoHD/Noh"],
+            ["Simulation/SimulationMain/magnetoHD/NohCylindrical", "Simulation/SimulationMain/magnetoHD/NohCylindrical"],
+            ["Simulation/SimulationMain/magnetoHD/OrszagTang", "Simulation/SimulationMain/magnetoHD/OrszagTang"],
+            ["Simulation/SimulationMain/magnetoHD/Rotor", "Simulation/SimulationMain/magnetoHD/Rotor"],
+            ["Simulation/SimulationMain/magnetoHD/Torus", "Simulation/SimulationMain/magnetoHD/Torus"],
+            ["Simulation/SimulationMain/magnetoHD/unitTest/AnisoCond", "Simulation/SimulationMain/magnetoHD/unitTest/AnisoCond"],
+            ["Simulation/SimulationMain/magnetoHD/unitTest/NohCylindricalRagelike", "Simulation/SimulationMain/magnetoHD/unitTest/NohCylindricalRagelike"],
+            ["Simulation/SimulationMain/radflaHD/BondiAccretion", "Simulation/SimulationMain/radflaHD/BondiAccretion"],
+            ["Simulation/SimulationMain/radflaHD/CriticalRadShock", "Simulation/SimulationMain/radflaHD/CriticalRadShock"],
+            ["Simulation/SimulationMain/radflaHD/EnergyXchange", "Simulation/SimulationMain/radflaHD/EnergyXchange"],
+            ["Simulation/SimulationMain/radflaHD/RadBlastWave", "Simulation/SimulationMain/radflaHD/RadBlastWave"],
+            ["Simulation/SimulationMain/radflaHD/SupernovaRad1D", "Simulation/SimulationMain/radflaHD/SupernovaRad1D"],
+            ["Simulation/SimulationMain/unitTest/Cosmology", "Simulation/SimulationMain/unitTest/Cosmology"],
+            ["Simulation/SimulationMain/unitTest/Eos", "Simulation/SimulationMain/unitTest/Eos"],
+            ["Simulation/SimulationMain/unitTest/Eos/Gamma", "Simulation/SimulationMain/unitTest/Eos/Gamma"],
+            ["Simulation/SimulationMain/unitTest/Eos/Helmholtz", "Simulation/SimulationMain/unitTest/Eos/Helmholtz"],
+            ["Simulation/SimulationMain/unitTest/Eos/Multigamma", "Simulation/SimulationMain/unitTest/Eos/Multigamma"],
+            ["Simulation/SimulationMain/unitTest/Gravity", "Simulation/SimulationMain/unitTest/Gravity"],
+            ["Simulation/SimulationMain/unitTest/Gravity/BHTree", "Simulation/SimulationMain/unitTest/Gravity/BHTree"],
+            ["Simulation/SimulationMain/unitTest/Gravity/BHTree-cylinder", "Simulation/SimulationMain/unitTest/Gravity/BHTree-cylinder"],
+            ["Simulation/SimulationMain/unitTest/Gravity/BHTree-jeans", "Simulation/SimulationMain/unitTest/Gravity/BHTree-jeans"],
+            ["Simulation/SimulationMain/unitTest/Gravity/BHTree-layer", "Simulation/SimulationMain/unitTest/Gravity/BHTree-layer"],
+            ["Simulation/SimulationMain/unitTest/Gravity/Poisson", "Simulation/SimulationMain/unitTest/Gravity/Poisson"],
+            ["Simulation/SimulationMain/unitTest/Gravity/Poisson3", "Simulation/SimulationMain/unitTest/Gravity/Poisson3"],
+            ["Simulation/SimulationMain/unitTest/Gravity/Poisson3_active", "Simulation/SimulationMain/unitTest/Gravity/Poisson3_active"],
+            ["Simulation/SimulationMain/unitTest/Grid", "Simulation/SimulationMain/unitTest/Grid"],
+            ["Simulation/SimulationMain/unitTest/Grid/GCell", "Simulation/SimulationMain/unitTest/Grid/GCell"],
+            ["Simulation/SimulationMain/unitTest/Grid/GCellValgrindError", "Simulation/SimulationMain/unitTest/Grid/GCellValgrindError"],
+            ["Simulation/SimulationMain/unitTest/Grid/General", "Simulation/SimulationMain/unitTest/Grid/General"],
+            ["Simulation/SimulationMain/unitTest/Grid/UG", "Simulation/SimulationMain/unitTest/Grid/UG"],
+            ["Simulation/SimulationMain/unitTest/Grid/UGReordered", "Simulation/SimulationMain/unitTest/Grid/UGReordered"],
+            ["Simulation/SimulationMain/unitTest/IO", "Simulation/SimulationMain/unitTest/IO"],
+            ["Simulation/SimulationMain/unitTest/IO/IOMeshReplication", "Simulation/SimulationMain/unitTest/IO/IOMeshReplication"],
+            ["Simulation/SimulationMain/unitTest/IO/IOTypes", "Simulation/SimulationMain/unitTest/IO/IOTypes"],
+            ["Simulation/SimulationMain/unitTest/Laser_quadraticTube", "Simulation/SimulationMain/unitTest/Laser_quadraticTube"],
+            ["Simulation/SimulationMain/unitTest/Multipole", "Simulation/SimulationMain/unitTest/Multipole"],
+            ["Simulation/SimulationMain/unitTest/Multispecies", "Simulation/SimulationMain/unitTest/Multispecies"],
+            ["Simulation/SimulationMain/unitTest/Opacity", "Simulation/SimulationMain/unitTest/Opacity"],
+            ["Simulation/SimulationMain/unitTest/PFFT_BlktriFD", "Simulation/SimulationMain/unitTest/PFFT_BlktriFD"],
+            ["Simulation/SimulationMain/unitTest/PFFT_Poisson", "Simulation/SimulationMain/unitTest/PFFT_Poisson"],
+            ["Simulation/SimulationMain/unitTest/PFFT_PoissonFD", "Simulation/SimulationMain/unitTest/PFFT_PoissonFD"],
+            ["Simulation/SimulationMain/unitTest/PFFT_XYperZneuFD", "Simulation/SimulationMain/unitTest/PFFT_XYperZneuFD"],
+            ["Simulation/SimulationMain/unitTest/ParticlesAdvance", "Simulation/SimulationMain/unitTest/ParticlesAdvance"],
+            ["Simulation/SimulationMain/unitTest/ParticlesAdvance/HomologousPassive", "Simulation/SimulationMain/unitTest/ParticlesAdvance/HomologousPassive"],
+            ["Simulation/SimulationMain/unitTest/ParticlesAdvance/RotatingPassive", "Simulation/SimulationMain/unitTest/ParticlesAdvance/RotatingPassive"],
+            ["Simulation/SimulationMain/unitTest/ParticlesRefine", "Simulation/SimulationMain/unitTest/ParticlesRefine"],
+            ["Simulation/SimulationMain/unitTest/PhysConst", "Simulation/SimulationMain/unitTest/PhysConst"],
+            ["Simulation/SimulationMain/unitTest/Pipeline", "Simulation/SimulationMain/unitTest/Pipeline"],
+            ["Simulation/SimulationMain/unitTest/Pipeline/Cubic", "Simulation/SimulationMain/unitTest/Pipeline/Cubic"],
+            ["Simulation/SimulationMain/unitTest/Pipeline/Linear", "Simulation/SimulationMain/unitTest/Pipeline/Linear"],
+            ["Simulation/SimulationMain/unitTest/Pipeline/PascalTriangle2D", "Simulation/SimulationMain/unitTest/Pipeline/PascalTriangle2D"],
+            ["Simulation/SimulationMain/unitTest/Poisson", "Simulation/SimulationMain/unitTest/Poisson"],
+            ["Simulation/SimulationMain/unitTest/Poisson/BiCG", "Simulation/SimulationMain/unitTest/Poisson/BiCG"],
+            ["Simulation/SimulationMain/unitTest/Poisson/BiCG/MgMCPfft", "Simulation/SimulationMain/unitTest/Poisson/BiCG/MgMCPfft"],
+            ["Simulation/SimulationMain/unitTest/Poisson/MgMC", "Simulation/SimulationMain/unitTest/Poisson/MgMC"],
+            ["Simulation/SimulationMain/unitTest/Poisson/XYZneu_3D", "Simulation/SimulationMain/unitTest/Poisson/XYZneu_3D"],
+            ["Simulation/SimulationMain/unitTest/Poisson/XYdir_2D", "Simulation/SimulationMain/unitTest/Poisson/XYdir_2D"],
+            ["Simulation/SimulationMain/unitTest/ProtonEmission", "Simulation/SimulationMain/unitTest/ProtonEmission"],
+            ["Simulation/SimulationMain/unitTest/ProtonEmission/Validation", "Simulation/SimulationMain/unitTest/ProtonEmission/Validation"],
+            ["Simulation/SimulationMain/unitTest/ProtonImaging", "Simulation/SimulationMain/unitTest/ProtonImaging"],
+            ["Simulation/SimulationMain/unitTest/ProtonImaging/CircleDeflection", "Simulation/SimulationMain/unitTest/ProtonImaging/CircleDeflection"],
+            ["Simulation/SimulationMain/unitTest/Roots", "Simulation/SimulationMain/unitTest/Roots"],
+            ["Simulation/SimulationMain/unitTest/RungeKutta", "Simulation/SimulationMain/unitTest/RungeKutta"],
+            ["Simulation/SimulationMain/unitTest/RungeKutta/2Dellipse", "Simulation/SimulationMain/unitTest/RungeKutta/2Dellipse"],
+            ["Simulation/SimulationMain/unitTest/RungeKutta/3Dcircle", "Simulation/SimulationMain/unitTest/RungeKutta/3Dcircle"],
+            ["Simulation/SimulationMain/unitTest/RungeKutta/BinomialODE", "Simulation/SimulationMain/unitTest/RungeKutta/BinomialODE"],
+            ["Simulation/SimulationMain/unitTest/SinkMomTest", "Simulation/SimulationMain/unitTest/SinkMomTest"],
+            ["Simulation/SimulationMain/unitTest/ThomsonScattering", "Simulation/SimulationMain/unitTest/ThomsonScattering"],
+            ["Simulation/SimulationMain/unitTest/ThomsonScattering/NoRayTracing", "Simulation/SimulationMain/unitTest/ThomsonScattering/NoRayTracing"],
+            ["Simulation/SimulationMain/unitTest/ThomsonScattering/WithRayTracing", "Simulation/SimulationMain/unitTest/ThomsonScattering/WithRayTracing"],
+            ["Simulation/SimulationMain/unitTest/XrayImaging", "Simulation/SimulationMain/unitTest/XrayImaging"],
+            ["Simulation/SimulationMain/unitTest/XrayImaging/PureSphere", "Simulation/SimulationMain/unitTest/XrayImaging/PureSphere"],
+            ["Simulation/SimulationMain/unitTest/XrayImaging/PureSphere3Din2D", "Simulation/SimulationMain/unitTest/XrayImaging/PureSphere3Din2D"],
+            ["diagnostics/ProtonEmission", "diagnostics/ProtonEmission"],
+            ["diagnostics/ProtonEmission/ProtonEmissionMain", "diagnostics/ProtonEmission/ProtonEmissionMain"],
+            ["diagnostics/ProtonEmission/ProtonEmissionMain/ProtonDetection", "diagnostics/ProtonEmission/ProtonEmissionMain/ProtonDetection"],
+            ["diagnostics/ProtonEmission/ProtonEmissionMain/ProtonSource", "diagnostics/ProtonEmission/ProtonEmissionMain/ProtonSource"],
+            ["diagnostics/ProtonEmission/ProtonEmissionMain/ProtonUtilities", "diagnostics/ProtonEmission/ProtonEmissionMain/ProtonUtilities"],
+            ["diagnostics/ProtonEmission/ProtonEmissionMain/ProtonsCreate", "diagnostics/ProtonEmission/ProtonEmissionMain/ProtonsCreate"],
+            ["diagnostics/ProtonEmission/ProtonEmissionMain/ProtonsTrace", "diagnostics/ProtonEmission/ProtonEmissionMain/ProtonsTrace"],
+            ["diagnostics/ProtonImaging", "diagnostics/ProtonImaging"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain", "diagnostics/ProtonImaging/ProtonImagingMain"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/ProtonBeams", "diagnostics/ProtonImaging/ProtonImagingMain/ProtonBeams"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/ProtonDetection", "diagnostics/ProtonImaging/ProtonImagingMain/ProtonDetection"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/ProtonDisk", "diagnostics/ProtonImaging/ProtonImagingMain/ProtonDisk"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/ProtonIO", "diagnostics/ProtonImaging/ProtonImagingMain/ProtonIO"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/ProtonUtilities", "diagnostics/ProtonImaging/ProtonImagingMain/ProtonUtilities"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/ProtonsCreate", "diagnostics/ProtonImaging/ProtonImagingMain/ProtonsCreate"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/ProtonsTrace", "diagnostics/ProtonImaging/ProtonImagingMain/ProtonsTrace"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonBeams", "diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonBeams"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonDetection", "diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonDetection"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonIO", "diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonIO"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonUtilities", "diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonUtilities"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonsCreate", "diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonsCreate"],
+            ["diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonsTrace", "diagnostics/ProtonImaging/ProtonImagingMain/oldOneTimeStep/ProtonsTrace"],
+            ["diagnostics/ThomsonScattering", "diagnostics/ThomsonScattering"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain", "diagnostics/ThomsonScattering/ThomsonScatteringMain"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing", "diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing/LaserBeams", "diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing/LaserBeams"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing/LaserRaysCreate", "diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing/LaserRaysCreate"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing/LightDetection", "diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing/LightDetection"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing/RayTrace", "diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing/RayTrace"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing/ScatteringUtilities", "diagnostics/ThomsonScattering/ThomsonScatteringMain/NoRayTracing/ScatteringUtilities"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing", "diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/CreateRays", "diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/CreateRays"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/Detectors", "diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/Detectors"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/InteractionRegion", "diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/InteractionRegion"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/LaserBeams", "diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/LaserBeams"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/LaserPulses", "diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/LaserPulses"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/ScatteringUtilities", "diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/ScatteringUtilities"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/Species", "diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/Species"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/Spectrum", "diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/Spectrum"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/TraceRays", "diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/TraceRays"],
+            ["diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/TraceRays/CellAverage", "diagnostics/ThomsonScattering/ThomsonScatteringMain/WithRayTracing/TraceRays/CellAverage"],
+            ["diagnostics/ThomsonScattering/localAPI/NoRayTracing", "diagnostics/ThomsonScattering/localAPI/NoRayTracing"],
+            ["diagnostics/ThomsonScattering/localAPI/WithRayTracing", "diagnostics/ThomsonScattering/localAPI/WithRayTracing"],
+            ["diagnostics/XrayImaging", "diagnostics/XrayImaging"],
+            ["diagnostics/XrayImaging/XrayImagingMain", "diagnostics/XrayImaging/XrayImagingMain"],
+            ["diagnostics/XrayImaging/XrayImagingMain/Opacities", "diagnostics/XrayImaging/XrayImagingMain/Opacities"],
+            ["diagnostics/XrayImaging/XrayImagingMain/Opacities/BiggsLighthill", "diagnostics/XrayImaging/XrayImagingMain/Opacities/BiggsLighthill"],
+            ["diagnostics/XrayImaging/XrayImagingMain/Opacities/BiggsLighthill/Original1971data", "diagnostics/XrayImaging/XrayImagingMain/Opacities/BiggsLighthill/Original1971data"],
+            ["diagnostics/XrayImaging/XrayImagingMain/Simple", "diagnostics/XrayImaging/XrayImagingMain/Simple"],
+            ["diagnostics/XrayImaging/XrayImagingMain/Simple/XrayDetection", "diagnostics/XrayImaging/XrayImagingMain/Simple/XrayDetection"],
+            ["diagnostics/XrayImaging/XrayImagingMain/Simple/XrayUtilities", "diagnostics/XrayImaging/XrayImagingMain/Simple/XrayUtilities"],
+            ["diagnostics/XrayImaging/XrayImagingMain/Simple/XraysCreate", "diagnostics/XrayImaging/XrayImagingMain/Simple/XraysCreate"],
+            ["diagnostics/XrayImaging/XrayImagingMain/Simple/XraysTrace", "diagnostics/XrayImaging/XrayImagingMain/Simple/XraysTrace"],
+            ["diagnostics/XrayImaging/localAPI/Direct", "diagnostics/XrayImaging/localAPI/Direct"],
+            ["flashUtilities/SystemIO", "flashUtilities/SystemIO"],
+            ["flashUtilities/SystemIO/SystemIOMain", "flashUtilities/SystemIO/SystemIOMain"],
+            ["flashUtilities/UTCounter", "flashUtilities/UTCounter"],
+            ["flashUtilities/UTCounter/Distributed", "flashUtilities/UTCounter/Distributed"],
+            ["flashUtilities/UTCounter/MasterSlave", "flashUtilities/UTCounter/MasterSlave"],
+            ["flashUtilities/UTCounter/UnitTest", "flashUtilities/UTCounter/UnitTest"],
+            ["flashUtilities/UTPipeline", "flashUtilities/UTPipeline"],
+            ["flashUtilities/UTPipeline/UnitTest", "flashUtilities/UTPipeline/UnitTest"],
+            ["flashUtilities/contiguousConversion/UnitTest", "flashUtilities/contiguousConversion/UnitTest"],
+            ["flashUtilities/contourSurface/UnitTest", "flashUtilities/contourSurface/UnitTest"],
+            ["flashUtilities/datastructures/linkedlist/UnitTest", "flashUtilities/datastructures/linkedlist/UnitTest"],
+            ["flashUtilities/datastructures/linkedlist/UnitTestListOfList", "flashUtilities/datastructures/linkedlist/UnitTestListOfList"],
+            ["flashUtilities/system/memoryUsage/UnitTest1", "flashUtilities/system/memoryUsage/UnitTest1"],
+            ["flashUtilities/system/memoryUsage/UnitTest2", "flashUtilities/system/memoryUsage/UnitTest2"],
+            ["monitors/Debugger", "monitors/Debugger"],
+            ["monitors/Debugger/DebuggerMain", "monitors/Debugger/DebuggerMain"],
+            ["monitors/Debugger/DebuggerMain/UnitTest", "monitors/Debugger/DebuggerMain/UnitTest"],
+            ["monitors/Logfile", "monitors/Logfile"],
+            ["monitors/Logfile/LogfileMain", "monitors/Logfile/LogfileMain"],
+            ["monitors/Profiler", "monitors/Profiler"],
+            ["monitors/Profiler/ProfilerMain", "monitors/Profiler/ProfilerMain"],
+            ["monitors/Timers", "monitors/Timers"],
+            ["monitors/Timers/TimersMain", "monitors/Timers/TimersMain"],
+            ["monitors/Timers/TimersMain/MPINative", "monitors/Timers/TimersMain/MPINative"],
+            ["monitors/Timers/TimersMain/Tau", "monitors/Timers/TimersMain/Tau"],
+            ["multiprocessorTools/Pipeline", "multiprocessorTools/Pipeline"],
+            ["multiprocessorTools/Pipeline/PipelineMain", "multiprocessorTools/Pipeline/PipelineMain"],
+            ["numericalTools/Interpolate", "numericalTools/Interpolate"],
+            ["numericalTools/Interpolate/InterpolateMain", "numericalTools/Interpolate/InterpolateMain"],
+            ["numericalTools/Roots", "numericalTools/Roots"],
+            ["numericalTools/Roots/RootsMain", "numericalTools/Roots/RootsMain"],
+            ["numericalTools/RungeKutta", "numericalTools/RungeKutta"],
+            ["numericalTools/RungeKutta/RungeKuttaMain", "numericalTools/RungeKutta/RungeKuttaMain"],
+            ["physics/Cosmology", "physics/Cosmology"],
+            ["physics/Cosmology/CosmologyMain", "physics/Cosmology/CosmologyMain"],
+            ["physics/Cosmology/CosmologyMain/MatterLambdaKernel", "physics/Cosmology/CosmologyMain/MatterLambdaKernel"],
+            ["physics/Diffuse", "physics/Diffuse"],
+            ["physics/Diffuse/DiffuseFluxBased", "physics/Diffuse/DiffuseFluxBased"],
+            ["physics/Diffuse/DiffuseMain", "physics/Diffuse/DiffuseMain"],
+            ["physics/Diffuse/DiffuseMain/CG", "physics/Diffuse/DiffuseMain/CG"],
+            ["physics/Diffuse/DiffuseMain/Split", "physics/Diffuse/DiffuseMain/Split"],
+            ["physics/Diffuse/DiffuseMain/Unsplit", "physics/Diffuse/DiffuseMain/Unsplit"],
+            ["physics/Eos", "physics/Eos"],
+            ["physics/Eos/EosMain", "physics/Eos/EosMain"],
+            ["physics/Eos/EosMain/Gamma", "physics/Eos/EosMain/Gamma"],
+            ["physics/Eos/EosMain/Gamma/RHD", "physics/Eos/EosMain/Gamma/RHD"],
+            ["physics/Eos/EosMain/Helmholtz", "physics/Eos/EosMain/Helmholtz"],
+            ["physics/Eos/EosMain/Helmholtz/ExternalAbarZbar", "physics/Eos/EosMain/Helmholtz/ExternalAbarZbar"],
+            ["physics/Eos/EosMain/Helmholtz/SpeciesBased", "physics/Eos/EosMain/Helmholtz/SpeciesBased"],
+            ["physics/Eos/EosMain/Helmholtz/Ye", "physics/Eos/EosMain/Helmholtz/Ye"],
+            ["physics/Eos/EosMain/Multigamma", "physics/Eos/EosMain/Multigamma"],
+            ["physics/Eos/EosMain/Tabulated", "physics/Eos/EosMain/Tabulated"],
+            ["physics/Eos/EosMain/Tabulated/Hdf5TableRead", "physics/Eos/EosMain/Tabulated/Hdf5TableRead"],
+            ["physics/Eos/EosMain/multiTemp/Gamma", "physics/Eos/EosMain/multiTemp/Gamma"],
+            ["physics/Eos/EosMain/multiTemp/Gamma/Ye", "physics/Eos/EosMain/multiTemp/Gamma/Ye"],
+            ["physics/Eos/EosMain/multiTemp/Helmholtz", "physics/Eos/EosMain/multiTemp/Helmholtz"],
+            ["physics/Eos/EosMain/multiTemp/Helmholtz/SpeciesBased", "physics/Eos/EosMain/multiTemp/Helmholtz/SpeciesBased"],
+            ["physics/Eos/EosMain/multiTemp/Helmholtz/Ye", "physics/Eos/EosMain/multiTemp/Helmholtz/Ye"],
+            ["physics/Eos/EosMain/multiTemp/MatRad3", "physics/Eos/EosMain/multiTemp/MatRad3"],
+            ["physics/Eos/EosMain/multiTemp/MatRad3/Gamma", "physics/Eos/EosMain/multiTemp/MatRad3/Gamma"],
+            ["physics/Eos/EosMain/multiTemp/MatRad3/Gamma/Ye", "physics/Eos/EosMain/multiTemp/MatRad3/Gamma/Ye"],
+            ["physics/Eos/EosMain/multiTemp/MatRad3/Helmholtz", "physics/Eos/EosMain/multiTemp/MatRad3/Helmholtz"],
+            ["physics/Eos/EosMain/multiTemp/MatRad3/Helmholtz/SpeciesBased", "physics/Eos/EosMain/multiTemp/MatRad3/Helmholtz/SpeciesBased"],
+            ["physics/Eos/EosMain/multiTemp/MatRad3/Helmholtz/Ye", "physics/Eos/EosMain/multiTemp/MatRad3/Helmholtz/Ye"],
+            ["physics/Eos/EosMain/multiTemp/MatRad3/Multigamma", "physics/Eos/EosMain/multiTemp/MatRad3/Multigamma"],
+            ["physics/Eos/EosMain/multiTemp/Multigamma", "physics/Eos/EosMain/multiTemp/Multigamma"],
+            ["physics/Eos/EosMain/multiTemp/Multitype", "physics/Eos/EosMain/multiTemp/Multitype"],
+            ["physics/Eos/EosNuclear", "physics/Eos/EosNuclear"],
+            ["physics/Eos/unitTest/Helmholtz", "physics/Eos/unitTest/Helmholtz"],
+            ["physics/Gravity", "physics/Gravity"],
+            ["physics/Gravity/GravityMain", "physics/Gravity/GravityMain"],
+            ["physics/Gravity/GravityMain/Constant", "physics/Gravity/GravityMain/Constant"],
+            ["physics/Gravity/GravityMain/PlanePar", "physics/Gravity/GravityMain/PlanePar"],
+            ["physics/Gravity/GravityMain/PointMass", "physics/Gravity/GravityMain/PointMass"],
+            ["physics/Gravity/GravityMain/Poisson", "physics/Gravity/GravityMain/Poisson"],
+            ["physics/Gravity/GravityMain/Poisson/BHTree", "physics/Gravity/GravityMain/Poisson/BHTree"],
+            ["physics/Gravity/GravityMain/Poisson/Multigrid", "physics/Gravity/GravityMain/Poisson/Multigrid"],
+            ["physics/Gravity/GravityMain/Poisson/Multipole", "physics/Gravity/GravityMain/Poisson/Multipole"],
+            ["physics/Gravity/GravityMain/Poisson/Pfft", "physics/Gravity/GravityMain/Poisson/Pfft"],
+            ["physics/Gravity/GravityMain/UserDefined", "physics/Gravity/GravityMain/UserDefined"],
+            ["physics/Hydro", "physics/Hydro"],
+            ["physics/Hydro/HydroMain", "physics/Hydro/HydroMain"],
+            ["physics/Hydro/HydroMain/split/MHD_8Wave", "physics/Hydro/HydroMain/split/MHD_8Wave"],
+            ["physics/Hydro/HydroMain/split/PPM", "physics/Hydro/HydroMain/split/PPM"],
+            ["physics/Hydro/HydroMain/split/PPM/PPMKernel", "physics/Hydro/HydroMain/split/PPM/PPMKernel"],
+            ["physics/Hydro/HydroMain/split/RHD", "physics/Hydro/HydroMain/split/RHD"],
+            ["physics/Hydro/HydroMain/unsplit/Hydro_Unsplit", "physics/Hydro/HydroMain/unsplit/Hydro_Unsplit"],
+            ["physics/Hydro/HydroMain/unsplit/MHD_StaggeredMesh", "physics/Hydro/HydroMain/unsplit/MHD_StaggeredMesh"],
+            ["physics/Hydro/HydroMain/unsplit_rad/Hydro_Unsplit", "physics/Hydro/HydroMain/unsplit_rad/Hydro_Unsplit"],
+            ["physics/Hydro/HydroMain/unsplit_rad/MHD_StaggeredMesh", "physics/Hydro/HydroMain/unsplit_rad/MHD_StaggeredMesh"],
+            ["physics/ImBound", "physics/ImBound"],
+            ["physics/IncompNS", "physics/IncompNS"],
+            ["physics/IncompNS/IncompNSExtras", "physics/IncompNS/IncompNSExtras"],
+            ["physics/IncompNS/IncompNSMain", "physics/IncompNS/IncompNSMain"],
+            ["physics/IncompNS/IncompNSStats", "physics/IncompNS/IncompNSStats"],
+            ["physics/RadTrans", "physics/RadTrans"],
+            ["physics/RadTrans/RadTransMain", "physics/RadTrans/RadTransMain"],
+            ["physics/RadTrans/RadTransMain/MGD", "physics/RadTrans/RadTransMain/MGD"],
+            ["physics/RadTrans/RadTransMain/MGD/ExpRelax", "physics/RadTrans/RadTransMain/MGD/ExpRelax"],
+            ["physics/RadTrans/RadTransMain/MGD/Unified", "physics/RadTrans/RadTransMain/MGD/Unified"],
+            ["physics/RadTrans/RadTransMain/NeutrinoLeakage", "physics/RadTrans/RadTransMain/NeutrinoLeakage"],
+            ["physics/RayTrace", "physics/RayTrace"],
+            ["physics/SolidMechanics", "physics/SolidMechanics"],
+            ["physics/TreeRay", "physics/TreeRay"],
+            ["physics/TreeRay/TreeRayMain", "physics/TreeRay/TreeRayMain"],
+            ["physics/TreeRay/TreeRayMain/OpticalDepth", "physics/TreeRay/TreeRayMain/OpticalDepth"],
+            ["physics/materialProperties/Conductivity", "physics/materialProperties/Conductivity"],
+            ["physics/materialProperties/Conductivity/ConductivityAniso", "physics/materialProperties/Conductivity/ConductivityAniso"],
+            ["physics/materialProperties/Conductivity/ConductivityAniso/Constant", "physics/materialProperties/Conductivity/ConductivityAniso/Constant"],
+            ["physics/materialProperties/Conductivity/ConductivityMain", "physics/materialProperties/Conductivity/ConductivityMain"],
+            ["physics/materialProperties/Conductivity/ConductivityMain/Constant", "physics/materialProperties/Conductivity/ConductivityMain/Constant"],
+            ["physics/materialProperties/Conductivity/ConductivityMain/Constant-diff", "physics/materialProperties/Conductivity/ConductivityMain/Constant-diff"],
+            ["physics/materialProperties/Conductivity/ConductivityMain/LeeMore", "physics/materialProperties/Conductivity/ConductivityMain/LeeMore"],
+            ["physics/materialProperties/Conductivity/ConductivityMain/PowerLaw", "physics/materialProperties/Conductivity/ConductivityMain/PowerLaw"],
+            ["physics/materialProperties/Conductivity/ConductivityMain/PowerLaw-gray", "physics/materialProperties/Conductivity/ConductivityMain/PowerLaw-gray"],
+            ["physics/materialProperties/Conductivity/ConductivityMain/Spitzer", "physics/materialProperties/Conductivity/ConductivityMain/Spitzer"],
+            ["physics/materialProperties/Conductivity/ConductivityMain/SpitzerHighZ", "physics/materialProperties/Conductivity/ConductivityMain/SpitzerHighZ"],
+            ["physics/materialProperties/MagneticResistivity", "physics/materialProperties/MagneticResistivity"],
+            ["physics/materialProperties/MagneticResistivity/MagneticResistivityMain", "physics/materialProperties/MagneticResistivity/MagneticResistivityMain"],
+            ["physics/materialProperties/MagneticResistivity/MagneticResistivityMain/Constant", "physics/materialProperties/MagneticResistivity/MagneticResistivityMain/Constant"],
+            ["physics/materialProperties/MagneticResistivity/MagneticResistivityMain/SpitzerHighZ", "physics/materialProperties/MagneticResistivity/MagneticResistivityMain/SpitzerHighZ"],
+            ["physics/materialProperties/MassDiffusivity", "physics/materialProperties/MassDiffusivity"],
+            ["physics/materialProperties/NSE", "physics/materialProperties/NSE"],
+            ["physics/materialProperties/Opacity", "physics/materialProperties/Opacity"],
+            ["physics/materialProperties/Opacity/OpacityMain", "physics/materialProperties/Opacity/OpacityMain"],
+            ["physics/materialProperties/Opacity/OpacityMain/BremsstrahlungAndThomson", "physics/materialProperties/Opacity/OpacityMain/BremsstrahlungAndThomson"],
+            ["physics/materialProperties/Opacity/OpacityMain/Constant", "physics/materialProperties/Opacity/OpacityMain/Constant"],
+            ["physics/materialProperties/Opacity/OpacityMain/Constcm2g", "physics/materialProperties/Opacity/OpacityMain/Constcm2g"],
+            ["physics/materialProperties/Opacity/OpacityMain/Multispecies", "physics/materialProperties/Opacity/OpacityMain/Multispecies"],
+            ["physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Constant", "physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Constant"],
+            ["physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Constcm2g", "physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Constcm2g"],
+            ["physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Integrate", "physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Integrate"],
+            ["physics/materialProperties/Opacity/OpacityMain/Multispecies/method/LowTemp", "physics/materialProperties/Opacity/OpacityMain/Multispecies/method/LowTemp"],
+            ["physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Numerics", "physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Numerics"],
+            ["physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Tabulated", "physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Tabulated"],
+            ["physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Tabulated/IONMIX_datafiles", "physics/materialProperties/Opacity/OpacityMain/Multispecies/method/Tabulated/IONMIX_datafiles"],
+            ["physics/materialProperties/Opacity/OpacityMain/OPAL", "physics/materialProperties/Opacity/OpacityMain/OPAL"],
+            ["physics/materialProperties/Opacity/OpacityMain/OPAL/Numerics", "physics/materialProperties/Opacity/OpacityMain/OPAL/Numerics"],
+            ["physics/materialProperties/Viscosity", "physics/materialProperties/Viscosity"],
+            ["physics/materialProperties/Viscosity/ViscosityMain", "physics/materialProperties/Viscosity/ViscosityMain"],
+            ["physics/materialProperties/Viscosity/ViscosityMain/Constant", "physics/materialProperties/Viscosity/ViscosityMain/Constant"],
+            ["physics/materialProperties/Viscosity/ViscosityMain/Spitzer", "physics/materialProperties/Viscosity/ViscosityMain/Spitzer"],
+            ["physics/sourceTerms/Burn", "physics/sourceTerms/Burn"],
+            ["physics/sourceTerms/Burn/BurnIntegrate", "physics/sourceTerms/Burn/BurnIntegrate"],
+            ["physics/sourceTerms/Burn/BurnMain", "physics/sourceTerms/Burn/BurnMain"],
+            ["physics/sourceTerms/Burn/BurnMain/nuclearBurn/Aprox13", "physics/sourceTerms/Burn/BurnMain/nuclearBurn/Aprox13"],
+            ["physics/sourceTerms/Burn/BurnMain/nuclearBurn/Aprox13/NotUsed", "physics/sourceTerms/Burn/BurnMain/nuclearBurn/Aprox13/NotUsed"],
+            ["physics/sourceTerms/Burn/BurnMain/nuclearBurn/Aprox19", "physics/sourceTerms/Burn/BurnMain/nuclearBurn/Aprox19"],
+            ["physics/sourceTerms/Burn/BurnMain/nuclearBurn/Iso7", "physics/sourceTerms/Burn/BurnMain/nuclearBurn/Iso7"],
+            ["physics/sourceTerms/Cool", "physics/sourceTerms/Cool"],
+            ["physics/sourceTerms/Deleptonize", "physics/sourceTerms/Deleptonize"],
+            ["physics/sourceTerms/Deleptonize/DeleptonizeMain", "physics/sourceTerms/Deleptonize/DeleptonizeMain"],
+            ["physics/sourceTerms/EnergyDeposition", "physics/sourceTerms/EnergyDeposition"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserBeams", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserBeams"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserComm", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserComm"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserComm/Async", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserComm/Async"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserComm/Sync", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserComm/Sync"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserIO", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserIO"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserPulses", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserPulses"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRayTrace", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRayTrace"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRayTrace/CellAverage", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRayTrace/CellAverage"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRayTrace/CubicInterpolation", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRayTrace/CubicInterpolation"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRayTrace/CubicInterpolation/PPRT", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRayTrace/CubicInterpolation/PPRT"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRayTrace/CubicInterpolation/RK", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRayTrace/CubicInterpolation/RK"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRaysCreate", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserRaysCreate"],
+            ["physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserUtilities", "physics/sourceTerms/EnergyDeposition/EnergyDepositionMain/Laser/LaserUtilities"],
+            ["physics/sourceTerms/Flame", "physics/sourceTerms/Flame"],
+            ["physics/sourceTerms/Flame/FlameEffects", "physics/sourceTerms/Flame/FlameEffects"],
+            ["physics/sourceTerms/Flame/FlameEffects/BurnParametric", "physics/sourceTerms/Flame/FlameEffects/BurnParametric"],
+            ["physics/sourceTerms/Flame/FlameEffects/EIP", "physics/sourceTerms/Flame/FlameEffects/EIP"],
+            ["physics/sourceTerms/Flame/FlameMain", "physics/sourceTerms/Flame/FlameMain"],
+            ["physics/sourceTerms/Flame/FlameMain/RDSplit5point", "physics/sourceTerms/Flame/FlameMain/RDSplit5point"],
+            ["physics/sourceTerms/Flame/FlameSpeed", "physics/sourceTerms/Flame/FlameSpeed"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe/TFI", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe/TFI"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe/TFI/Charlette", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe/TFI/Charlette"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe/TFI/Damkohler", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe/TFI/Damkohler"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe/TFI/Kolmogorov", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe/TFI/Kolmogorov"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe/TFI/Pocheau", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/CONe/TFI/Pocheau"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/TFI", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/TFI"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/TFI/Charlette", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/TFI/Charlette"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/TFI/Damkohler", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/TFI/Damkohler"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/TFI/Kolmogorov", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/TFI/Kolmogorov"],
+            ["physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/TFI/Pocheau", "physics/sourceTerms/Flame/FlameSpeed/BuoyancyCompensation/TFI/Pocheau"],
+            ["physics/sourceTerms/Flame/FlameSpeed/Constant", "physics/sourceTerms/Flame/FlameSpeed/Constant"],
+            ["physics/sourceTerms/Flame/FlameSpeed/Constant/TFI", "physics/sourceTerms/Flame/FlameSpeed/Constant/TFI"],
+            ["physics/sourceTerms/Flame/FlameSpeed/Constant/TFI/Charlette", "physics/sourceTerms/Flame/FlameSpeed/Constant/TFI/Charlette"],
+            ["physics/sourceTerms/Flame/FlameSpeed/Constant/TFI/Damkohler", "physics/sourceTerms/Flame/FlameSpeed/Constant/TFI/Damkohler"],
+            ["physics/sourceTerms/Flame/FlameSpeed/Constant/TFI/Kolmogorov", "physics/sourceTerms/Flame/FlameSpeed/Constant/TFI/Kolmogorov"],
+            ["physics/sourceTerms/Flame/FlameSpeed/Constant/TFI/Pocheau", "physics/sourceTerms/Flame/FlameSpeed/Constant/TFI/Pocheau"],
+            ["physics/sourceTerms/Flame/FlameSpeed/LaminarOnly", "physics/sourceTerms/Flame/FlameSpeed/LaminarOnly"],
+            ["physics/sourceTerms/Flame/FlameSpeed/LaminarOnly/TFI", "physics/sourceTerms/Flame/FlameSpeed/LaminarOnly/TFI"],
+            ["physics/sourceTerms/Flame/FlameSpeed/LaminarOnly/TFI/Charlette", "physics/sourceTerms/Flame/FlameSpeed/LaminarOnly/TFI/Charlette"],
+            ["physics/sourceTerms/Flame/FlameSpeed/LaminarOnly/TFI/Damkohler", "physics/sourceTerms/Flame/FlameSpeed/LaminarOnly/TFI/Damkohler"],
+            ["physics/sourceTerms/Flame/FlameSpeed/LaminarOnly/TFI/Kolmogorov", "physics/sourceTerms/Flame/FlameSpeed/LaminarOnly/TFI/Kolmogorov"],
+            ["physics/sourceTerms/Flame/FlameSpeed/LaminarOnly/TFI/Pocheau", "physics/sourceTerms/Flame/FlameSpeed/LaminarOnly/TFI/Pocheau"],
+            ["physics/sourceTerms/Flame/FlameSpeed/laminar/CO", "physics/sourceTerms/Flame/FlameSpeed/laminar/CO"],
+            ["physics/sourceTerms/Flame/FlameSpeed/laminar/CONe", "physics/sourceTerms/Flame/FlameSpeed/laminar/CONe"],
+            ["physics/sourceTerms/Heat", "physics/sourceTerms/Heat"],
+            ["physics/sourceTerms/Heat/HeatMain", "physics/sourceTerms/Heat/HeatMain"],
+            ["physics/sourceTerms/Heat/HeatMain/Neutrino", "physics/sourceTerms/Heat/HeatMain/Neutrino"],
+            ["physics/sourceTerms/Heat/HeatMain/RadioactiveDecay", "physics/sourceTerms/Heat/HeatMain/RadioactiveDecay"],
+            ["physics/sourceTerms/Heatexchange", "physics/sourceTerms/Heatexchange"],
+            ["physics/sourceTerms/Heatexchange/HeatexchangeMain", "physics/sourceTerms/Heatexchange/HeatexchangeMain"],
+            ["physics/sourceTerms/Heatexchange/HeatexchangeMain/ConstCoulomb", "physics/sourceTerms/Heatexchange/HeatexchangeMain/ConstCoulomb"],
+            ["physics/sourceTerms/Heatexchange/HeatexchangeMain/Constant", "physics/sourceTerms/Heatexchange/HeatexchangeMain/Constant"],
+            ["physics/sourceTerms/Heatexchange/HeatexchangeMain/Immediate", "physics/sourceTerms/Heatexchange/HeatexchangeMain/Immediate"],
+            ["physics/sourceTerms/Heatexchange/HeatexchangeMain/LeeMore", "physics/sourceTerms/Heatexchange/HeatexchangeMain/LeeMore"],
+            ["physics/sourceTerms/Heatexchange/HeatexchangeMain/Spitzer", "physics/sourceTerms/Heatexchange/HeatexchangeMain/Spitzer"],
+            ["physics/sourceTerms/Ionize", "physics/sourceTerms/Ionize"],
+            ["physics/sourceTerms/Ionize/IonizeMain", "physics/sourceTerms/Ionize/IonizeMain"],
+            ["physics/sourceTerms/Ionize/IonizeMain/Eqi", "physics/sourceTerms/Ionize/IonizeMain/Eqi"],
+            ["physics/sourceTerms/Ionize/IonizeMain/Nei", "physics/sourceTerms/Ionize/IonizeMain/Nei"],
+            ["physics/sourceTerms/Polytrope", "physics/sourceTerms/Polytrope"],
+            ["physics/sourceTerms/Polytrope/PolytropeMain", "physics/sourceTerms/Polytrope/PolytropeMain"],
+            ["physics/sourceTerms/PrimordialChemistry", "physics/sourceTerms/PrimordialChemistry"],
+            ["physics/sourceTerms/PrimordialChemistry/PrimordialChemistryIntegrate", "physics/sourceTerms/PrimordialChemistry/PrimordialChemistryIntegrate"],
+            ["physics/sourceTerms/PrimordialChemistry/PrimordialChemistryMain", "physics/sourceTerms/PrimordialChemistry/PrimordialChemistryMain"],
+            ["physics/sourceTerms/PrimordialChemistry/PrimordialChemistryMain/GA08", "physics/sourceTerms/PrimordialChemistry/PrimordialChemistryMain/GA08"],
+            ["physics/sourceTerms/Stir", "physics/sourceTerms/Stir"],
+            ["physics/sourceTerms/Stir/StirMain", "physics/sourceTerms/Stir/StirMain"],
+            ["physics/sourceTerms/Stir/StirMain/FromFile", "physics/sourceTerms/Stir/StirMain/FromFile"],
+            ["physics/sourceTerms/Stir/StirMain/Generate", "physics/sourceTerms/Stir/StirMain/Generate"],
+            ["physics/sourceTerms/Turb", "physics/sourceTerms/Turb"],
+            ["physics/sourceTerms/Turb/TurbMain", "physics/sourceTerms/Turb/TurbMain"],
+            ["physics/utilities/PlasmaState", "physics/utilities/PlasmaState"],
+            ["physics/utilities/PlasmaState/PlasmaStateMain", "physics/utilities/PlasmaState/PlasmaStateMain"]
+        ],
+        "SetupArgumentShortcut": [
+            ["0", "No"],
+            ["1", "Yes"]
+        ],
+        "SimulationCapLasersim_currType": [
+            ["0", "Linear ramp"],
+            ["1", "Exponential ramp"],
+            ["2", "From external file"]
+        ],
+        "SimulationCapLasersim_eosFill": [
+            ["eos_tab", "eos_tab"],
+            ["eos_gam", "eos_gam"]
+        ],
+        "SimulationCapLasersim_eosWall": [
+            ["eos_tab", "eos_tab"],
+            ["eos_gam", "eos_gam"]
+        ],
+        "SlopeLimiter": [
+            ["mc", "mc"],
+            ["vanLeer", "vanLeer"],
+            ["minmod", "minmod"],
+            ["hybrid", "hybrid"],
+            ["limited", "limited"]
+        ],
+        "VariableName": [
+            ["dens", "dens"],
+            ["depo", "depo"],
+            ["tele", "tele"],
+            ["tion", "tion"],
+            ["trad", "trad"],
+            ["ye", "ye"],
+            ["sumy", "sumy"],
+            ["fill", "fill"],
+            ["wall", "wall"],
+            ["magz", "magz"],
+            ["velx", "velx"],
+            ["kapa", "kapa"],
+            ["flam", "flam"]
+        ],
+        "VariableNameOptional": [
+            ["none", "none"],
+            ["dens", "dens"],
+            ["depo", "depo"],
+            ["tele", "tele"],
+            ["tion", "tion"],
+            ["trad", "trad"],
+            ["ye", "ye"],
+            ["sumy", "sumy"],
+            ["fill", "fill"],
+            ["wall", "wall"],
+            ["magz", "magz"],
+            ["velx", "velx"],
+            ["kapa", "kapa"],
+            ["flam", "flam"]
+        ],
+        "WallSpecies": [
+            ["alumina", "Alumina"]
         ]
     },
     "dynamicFiles": {
@@ -479,22 +1043,6 @@
         }
     },
     "model": {
-        "simulation": {
-            "flashType": ["Simulation Type", "flashType", "RTFlame"]
-        },
-        "simulationStatus": {},
-        "gridEvolutionAnimation": {
-            "y1": ["Y1 Value", "ValueList", ""],
-            "y2": ["Y2 Value", "ValueList", ""],
-            "y3": ["Y3 Value", "ValueList", ""],
-            "notes": ["Notes", "Text", ""]
-        },
-        "varAnimation": {
-            "var": ["Variable Name", "VariableName", "dens"],
-            "framesPerSecond": ["Frames per Second", "FramesPerSecond", "2"],
-            "colorMap": ["Color Map", "ColorMap", "coolwarm"],
-            "notes": ["Notes", "Text", ""]
-        },
         "Driver": {
             "allowDtSTSDominate": ["allowDtSTSDominate", "Boolean", "0", "allow a situation in which dt_STS becomes larger than dt_Hydro\n(dt_advection) (assuming that diffusion dt is smaller than advection dt)\nupto advection one, but not faster than the advection advancement. This\nwill be useful in solving PDE systems that are hyperbolic + parabolic.\nFALSE will use the STS algorithm to even accelerate advection time\nadvancement, which in turn, will use larger advection dt than advection\ndt from CFL limits. This will be useful in solving only hyperbolic PDE\nsystems in general. When hyperbolic + parabolic PDE system is to be\nsolved, then we suggest that users use less agressive super time\nstepping method by using useSTSforDiffusion = TRUE."],
             "dr_abortPause": ["dr_abortPause", "Integer", 2, "When Driver_abortFlash is called to abnormally end execution, and\ndr_abortPause is grater than zero, the FLASH Driver_abortFlash code will\nsleep for dr_abortPause seconds after writing explanatory messages (to\nstandard output and, possibly, to log files) but before calling\nMPI_ABORT. See also eachProcWritesOwnAbortLog for controlling the\ngeneration of per-processor log files.", 0],
@@ -559,6 +1107,12 @@
             "zmax": ["Z Maximum [cm]", "Float", 1.0, "physical domain lower bound in x dir"],
             "zmin": ["Z Minimum [cm]", "Float", 0.0, "physical domain lower bound in z dir"],
             "zr_boundary_type": ["Z Upper Boundary Type", "GridBoundaryType", "periodic", "upper boundary condition in z dir"]
+        },
+        "gridEvolutionAnimation": {
+            "y1": ["Y1 Value", "ValueList", ""],
+            "y2": ["Y2 Value", "ValueList", ""],
+            "y3": ["Y3 Value", "ValueList", ""],
+            "notes": ["Notes", "Text", ""]
         },
         "Gridparamesh": {
             "convertToConsvdInMeshInterp": ["convertToConsvdInMeshInterp", "Boolean", "1", "indicates if appropriate variables are converted to conserved form\nduring propagation within the interpolation routines invoked by\nParamesh. This applies to interpolation (both \"prolongation\" and\n\"restriction\") in the course of refinement, derefinement, or guardcell\nfilling. This is the newer way of ensuring that solution variables are\ninterpolated in the correct form. It avoids unnecessary conversions back\nand force and should replace the old mechanism enabled by runtime\nparameter \"convertToConsvdForMeshCalls\". However, it is only available\nwith PARAMESH 3 or later."],
@@ -856,74 +1410,6 @@
             "op_fillLowTemp": ["op_fillLowTemp", "Float", 0.0],
             "op_wallLowTemp": ["op_wallLowTemp", "Float", 0.0]
         },
-        "SimulationCapLaser3D": {
-            "sim_condWall": ["sim_condWall", "Float", 195000.0, "Wall conductivity at the gas/wall interface"],
-            "sim_eosFill": ["Fill EOS Type", "SimulationCapLasersim_eosFill", "eos_gam"],
-            "sim_eosWall": ["Wall EOS Type", "SimulationCapLasersim_eosWall", "eos_tab"],
-            "sim_currType": ["Current Calculation Type", "SimulationCapLasersim_currType", "1", "how to calculate the current"],
-            "sim_currFile": ["Current File", "InputFile", "", "file describing current over time"],
-            "sim_riseTime": ["Rise Time", "Float", 1.8e-9, "rise time to peak current in seconds"],
-            "sim_peakCurr": ["Peak Current", "Float", 3.1e2, "peak current at wall in amperes"],
-            "sim_peakField": ["Peak Field", "Float", 2.4e3, "peak field in gauss at capillary wall"],
-            "sim_period": ["Circuit Period", "Float", 300e-9 , "circuit period in seconds"],
-            "sim_rhoFill": ["Fill Initial Density", "Float", 2.655e-07],
-            "sim_rhoWall": ["Wall Initial Density", "Float", 2.7],
-            "sim_rWall": ["Wall Gas Radius", "Float", 250.0e-4, "wall radius for position of gas/wall interface"],
-            "sim_teleFill": ["Fill Electron Temp.", "Float", 290.11375],
-            "sim_teleWall": ["Wall Electron Temp.", "Float", 290.11375],
-            "sim_tionFill": ["Fill Ion Temp.", "Float", 290.11375],
-            "sim_tionWall": ["Wall Ion Temp.", "Float", 290.11375],
-            "sim_tradFill": ["Fill Radiation Temp.", "Float", 290.11375],
-            "sim_tradWall": ["Wall Radiation Temp.", "Float", 290.11375],
-            "sim_zminWall": ["Wall Minimum Zbar", "Float", 0.0]
-        },
-        "SimulationCapLaserBELLA": {
-            "sim_condWall": ["sim_condWall", "Float", 195000.0, "Wall conductivity at the gas/wall interface"],
-            "sim_eosFill": ["Fill EOS Type", "SimulationCapLasersim_eosFill", "eos_gam"],
-            "sim_eosWall": ["Wall EOS Type", "SimulationCapLasersim_eosWall", "eos_tab"],
-            "sim_currType": ["Current Calculation Type", "SimulationCapLasersim_currType", "1", "how to calculate the current"],
-            "sim_currFile": ["Current File", "InputFile", "", "file describing current over time"],
-            "sim_riseTime": ["Rise Time", "Float", 1.8e-9, "rise time to peak current in seconds"],
-            "sim_peakCurr": ["Peak Current", "Float", 3.1e2, "peak current at wall in amperes"],
-            "sim_rhoFill": ["Fill Initial Density", "Float", 2.655e-07],
-            "sim_rhoWall": ["Wall Initial Density", "Float", 2.7],
-            "sim_teleFill": ["Fill Electron Temp.", "Float", 290.11375],
-            "sim_teleWall": ["Wall Electron Temp.", "Float", 290.11375],
-            "sim_tionFill": ["Fill Ion Temp.", "Float", 290.11375],
-            "sim_tionWall": ["Wall Ion Temp.", "Float", 290.11375],
-            "sim_tradFill": ["Fill Radiation Temp.", "Float", 290.11375],
-            "sim_tradWall": ["Wall Radiation Temp.", "Float", 290.11375],
-            "sim_zminWall": ["Wall Minimum Zbar", "Float", 0.0]
-        },
-        "physicsmaterialPropertiesConductivity": {
-            "useConductivity": ["Use Conductivity", "Boolean", "1", "whether the conductivity material property is being used"]
-        },
-        "physicsmaterialPropertiesMagneticResistivity": {
-            "useMagneticResistivity": ["Use Magnetic Resistivity", "Boolean", "0", "whether the magnetic resistivity material property is being used"]
-        },
-        "physicsmaterialPropertiesOpacity": {
-            "useOpacity": ["Use Opacity", "Boolean", "1", "flags whether the Opacity unit is being used at all"]
-        },
-        "physicsmaterialPropertiesOpacityMultispecies": {
-            "op_fillAbsorb": ["Fill Absorb", "physicsmaterialPropertiesOpacityMultispeciesop_fillAbsorb", "op_undefined"],
-            "op_fillAbsorbConstant": ["op_fillAbsorbConstant", "Float", -1.0],
-            "op_fillEmiss": ["Fill Emiss", "physicsmaterialPropertiesOpacityMultispeciesop_fillEmiss", "op_undefined"],
-            "op_fillEmissConstant": ["op_fillEmissConstant", "Float", -1.0],
-            "op_fillFileName": ["Fill Filename", "String", ""],
-            "op_fillFileType": ["Fill File Type", "String", ""],
-            "op_fillTrans": ["Fill Trans", "physicsmaterialPropertiesOpacityMultispeciesop_fillTrans", "op_undefined"],
-            "op_fillTransConstant": ["op_fillTransConstant", "Float", -1.0],
-            "op_wallAbsorb": ["Wall Absorb", "physicsmaterialPropertiesOpacityMultispeciesop_wallAbsorb", "op_undefined"],
-            "op_wallAbsorbConstant": ["op_wallAbsorbConstant", "Float", -1.0],
-            "op_wallEmiss": ["Wall Emiss", "physicsmaterialPropertiesOpacityMultispeciesop_wallEmiss", "op_undefined"],
-            "op_wallEmissConstant": ["op_wallEmissConstant", "Float", -1.0],
-            "op_wallFileName": ["Wall Filename", "String", ""],
-            "op_wallFileType": ["Wall File Type", "String", ""],
-            "op_wallTrans": ["Wall Trans", "physicsmaterialPropertiesOpacityMultispeciesop_wallTrans", "op_undefined"],
-            "op_wallTransConstant": ["op_wallTransConstant", "Float", -1.0],
-            "opacity_ignoreLowTemp": ["opacity_ignoreLowTemp", "Boolean", "1", "control parameter indicating if the low temperature capability should be\nignored"],
-            "opacity_writeOpacityInfo": ["opacity_writeOpacityInfo", "Boolean", "0", "control parameter indicating if detailed info of the opacity unit should\nbe written out"]
-        },
         "physicsDiffuse": {
             "diff_eleFlCoef": ["Flux Limiter Coefficient", "Float", 1.0, "Electron conduction flux limiter coefficient"],
             "diff_eleFlMode": ["diff_eleFlMode", "physicsDiffusediff_eleFlMode", "fl_none", "Electron conduction flux limiter mode"],
@@ -961,30 +1447,116 @@
             "diff_thetaImplct": ["Implicitness Factor", "Float", 0.5, "", 0.0, 1.0],
             "diff_updEint": ["diff_updEint", "Boolean", "0"]
         },
-        "SimulationRTFlame": {
-            "dens_unburned": ["Unburned Density [g/cc]", "Float", 100000000.0, "dens_unburned"],
-            "flame_initial_position": ["Initial Flame Position [cm]", "Float", 0.0, "flame_initial_position"],
-            "particle_attribute_1": ["particle_attribute_1", "String", "dens"],
-            "particle_attribute_2": ["particle_attribute_2", "String", "temp"],
-            "particle_attribute_4": ["particle_attribute_4", "String", "flam"],
-            "refine_buf": ["refine_buf", "Float", 100000.0, "Buffer to prevent refinement pattern jitter"],
-            "refine_lead": ["refine_lead", "Float", 200000.0, "Distance above highest burned cell which refined region will reach"],
-            "refine_region_size": ["refine_region_size", "Float", 6000000.0, "Total size of refine region (See source for diagram of parameter\nmeanings)"],
-            "refine_region_stepdown_size": ["refine_region_stepdown_size", "Float", 4500000.0, "Distance behind fully refined region that is one lower refinement level"],
-            "refine_uniform_region": ["refine_uniform_region", "Boolean", "0", "Select whether to refine a selected region uniformly or use\nstandard-style refinement checks (configured with other parameters)"],
-            "sim_ParticleRefineRegion": ["sim_ParticleRefineRegion", "Boolean", "0"],
-            "sim_ParticleRefineRegionBottom": ["sim_ParticleRefineRegionBottom", "Float", 6000000.0],
-            "sim_ParticleRefineRegionLevel": ["sim_ParticleRefineRegionLevel", "Integer", 2],
-            "sim_ParticleRefineRegionTop": ["sim_ParticleRefineRegionTop", "Float", 20000000.0],
-            "spert_ampl1": ["Amplitude Perturbation 1", "Float", 0.0],
-            "spert_ampl2": ["Amplitude Perturbation 2", "Float", 0.0],
-            "spert_phase1": ["Phase Perturbation 1", "Float", 0.0],
-            "spert_phase2": ["Phase Perturbation 2", "Float", 0.0],
-            "spert_wl1": ["Wavelength Perturbation 1", "Float", 1.0],
-            "spert_wl2": ["Wavelength Perturbation 2", "Float", 1.0],
-            "temp_unburned": ["Unburned Temperature [K]", "Float", 100000000.0, "temp_unburned"],
-            "vel_pert_amp": ["vel_pert_amp", "Float", 0.0],
-            "vel_pert_wavelength1": ["vel_pert_wavelength1", "Float", 1.0]
+        "physicsEosTabulatedHdf5TableRead": {
+            "eos_useLogTables": ["eos_useLogTables", "Boolean", "1"]
+        },
+        "physicsGravity": {
+            "grav_boundary_type": ["Boundary Condition", "physicsGravitygrav_boundary_type", "isolated", "Type of gravitational boundary condition if a Poisson solve is used for\nGravity; string-valued version of grav_boundary. Accepts \"isolated\",\n\"periodic\", \"dirichlet\", and maybe others, depending on the Poisson\nsolver used. This is declared in the stub level of the Gravity unit to\nallow the Grid unit to refer to this runtime parameter even when no\nGravity implementation is included. (grav_boundary_type)"],
+            "useGravity": ["Use Gravity", "Boolean", "1", "Should the gravity calculations be performed? (useGravity)"]
+        },
+        "physicsGravityConstant": {
+            "gconst": ["Acceleration Constant", "Float", -981.0, "Gravitational acceleration constant (gconst)"],
+            "gdirec": ["Direction of Acceleration", "physicsGravityConstantgdirec", "x", "Direction of acceleration (\"x\", \"y\", \"z\") (gdirec)"]
+        },
+        "physicsHydro": {
+            "UnitSystem": ["UnitSystem", "String", "none", "System of Units"],
+            "cfl": ["Courant Factor", "Float", 0.8, "cfl"],
+            "threadHydroBlockList": ["threadHydroBlockList", "Boolean", "0"],
+            "threadHydroWithinBlock": ["threadHydroWithinBlock", "Boolean", "0"],
+            "updateHydroFluxes": ["updateHydroFluxes", "Boolean", "1", "whether fluxes computed by Hydro should be used to update the solution\n(currently, probably only used in split PPM Hydro)"],
+            "useHydro": ["Use Hydrodynamics", "Boolean", "1", "Should any Hydro calculations be performed? (useHydro)"],
+            "use_cma_advection": ["use_cma_advection", "Boolean", "0", "Use the CMA advection with partial masses being primary variables; thos\nparameter only affects the unsplit PPM hydro solver."],
+            "use_cma_flattening": ["use_cma_flattening", "Boolean", "0", "Use the flattening procedure for the abundances as described in the CMA\npaper; this parameter only affects the unsplit PPM hydro solver."]
+        },
+        "physicsHydrounsplit": {
+            "EOSforRiemann": ["EOSforRiemann", "Boolean", "0", "Turn on/off calls to Eos for thermo of reconstructed face states\n(MODE_DENS_PRES)"],
+            "LimitedSlopeBeta": ["Limited Slope Beta", "Float", 1.0, "LimitedSlopeBeta"],
+            "RiemannSolver": ["Riemann Solver", "RiemannSolver", "HLLC", "RiemannSolver"],
+            "addThermalFlux": ["addThermalFlux", "Constant", "FALSE"],
+            "charLimiting": ["Characteristic Limiting", "Boolean", "1", "Apply limiting for characteristic variable (charLimiting)"],
+            "conserveAngMom": ["conserveAngMom", "Boolean", "0", "Conservative formulation for cylindrical coordinates regarding the\ntoroidal momentum"],
+            "cvisc": ["Artificial Viscosity Constant", "Float", 0.1, "cvisc"],
+            "entropy": ["Entropy Fix", "Boolean", "0", "Entropy Fix routine for the Roe Riemann solver: (entropy)"],
+            "entropyFixMethod": ["entropyFixMethod", "String", "HARTENHYMAN", "Entropy fix method for the Roe Riemann solver Harten or HartenHyman"],
+            "hy_3Torder": ["hy_3Torder", "physicsHydrounsplithy_3Torder", -1, "Reconstruction order for eint, eele, eion, erad in HEDP simulations"],
+            "hy_cflFallbackFactor": ["hy_cflFallbackFactor", "Float", 0.9, "factor for scaling CFL factor when it is lowered because of fallback in\nproblematic cells"],
+            "hy_eosModeGc": ["hy_eosModeGc", "physicsHydrounsplithy_eosModeGc", "see eosMode", "Eos mode that the Hydro unit should apply to guard cells before the\nfirst major loop, i.e., before computing Riemann input states by\nreconstruction etc. The special value \"see eosMode\" can be used to\nindicate the mode set by the runtime parameter \"eosMode\". Other values\nare as for \"eosMode\"."],
+            "hy_fPresInMomFlux": ["hy_fPresInMomFlux", "Float", 1.0, "Percentage of the pressure gradient (values range from 0 to 1) that is\ntreated as part of momentum fluxes", 0.0, 1.0],
+            "hy_fallbackLowerCFL": ["hy_fallbackLowerCFL", "Boolean", "0", "Lower the simulation CFL if fallin back to a lower reconstruction order\nin problematic cells"],
+            "hy_fullSpecMsFluxHandling": ["hy_fullSpecMsFluxHandling", "Boolean", "1", "Are species and mass scalars updated with fluxes that have undergone the\nfull treatment applied to other fluxes, including fine-coarse-boundary\nflux correction if that is done to fluxes of other conserved variables?"],
+            "hybridOrderKappa": ["hybridOrderKappa", "Float", 0.0, "A constant value to determine shock strengths for hybrid order"],
+            "hydroComputeDtOption": ["hydroComputeDtOption", "physicsHydrounsplithydroComputeDtOption", -1, "An option where to compute hydro dt. Choices are integer values [-1, 0,\n1] as follows: -1: Hydro_computeDt.F90,  the old standard way that has\nmost extensive supports and well-tested; 0: hy_uhd_energyFix.F90, a\nlight weighted version without calling a global loop Hydro_computeDt; 1:\nhy_getFaceFlux.F90,   another light weighted dt call during flux\ncalculations."],
+            "irenorm": ["irenorm", "Integer", 0, "Renormalize abundances"],
+            "order": ["Order", "physicsHydrounsplitorder", 2, "1st order Godunov scheme, 2nd MUSCL-Hancock scheme, or 3rd PPM, 5th WENO (order)"],
+            "radiusGP": ["radiusGP", "Float", 2.0],
+            "shockDetect": ["Use Strong Compressive Shock Detection", "Boolean", "0", "Switch to use a strong compressive shock detection (shockDetect)"],
+            "shockLowerCFL": ["shockLowerCFL", "Boolean", "0", "Lower the simulation CFL if shocks are detected"],
+            "sigmaGP": ["sigmaGP", "Float", 3.0],
+            "slopeLimiter": ["Slope Limiter", "SlopeLimiter", "vanLeer", "slopeLimiter"],
+            "small": ["small", "Float", 1e-10, "Cutoff value"],
+            "smalle": ["smalle", "Float", 1e-10, "Cutoff value for energy"],
+            "smallp": ["smallp", "Float", 1e-10, "Cutoff value for pressure"],
+            "smallt": ["smallt", "Float", 1e-10, "Cutoff value for temperature"],
+            "smallu": ["smallu", "Float", 1e-10, "Cutoff value for velocity"],
+            "smallx": ["smallx", "Float", 1e-10, "Cutoff value for abundances"],
+            "smlrho": ["smlrho", "Float", 1e-10, "Cutoff value for density"],
+            "tiny": ["tiny", "Float", 1e-16, "A threshold value for an arbitrarily small number"],
+            "transOrder": ["transOrder", "physicsHydrounsplittransOrder", 1, "order of approximating transeverse flux derivative in data\nreconstruction"],
+            "use_3dFullCTU": ["use_3dFullCTU", "Boolean", "1", "Turn on/off the full CTU scheme that gives CFL <= 1 for 3D"],
+            "use_auxEintEqn": ["use_auxEintEqn", "Boolean", "1", "Turn on/off solving the auxilary internal energy equation"],
+            "use_avisc": ["use_avisc", "Boolean", "0"],
+            "use_flattening": ["use_flattening", "Boolean", "0", "Switch for PPM flattening"],
+            "use_gravHalfUpdate": ["use_gravHalfUpdate", "Boolean", "1", "Include gravitational accelerations to hydro coupling at n+1/2"],
+            "use_hybridOrder": ["use_hybridOrder", "Boolean", "0", "Apply RH jump condition to check monotonicity of reconstructed values"],
+            "use_steepening": ["use_steepening", "Boolean", "0", "Switch for steepening contact discontinuities for 3rd order PPM"],
+            "use_upwindTVD": ["use_upwindTVD", "Boolean", "0", "Turn on/off upwinding TVD slopes"],
+            "wenoMethod": ["wenoMethod", "String", "WENO5"]
+        },
+        "physicsHydrounsplitMHD_StaggeredMesh": {
+            "E_modification": ["E_modification", "Boolean", "1", "Switch for modified electric fields calculation from flux"],
+            "E_upwind": ["E_upwind", "Boolean", "0", "Switch for upwind update for induction equations"],
+            "ForceHydroLimit": ["ForceHydroLimit", "Boolean", "0", "Switch to force B=0 limit, i.e., the solver will not update B fields"],
+            "conserveAngField": ["conserveAngField", "Boolean", "0", "Turn on/off alternate formulation for toroidal induction"],
+            "energyFix": ["energyFix", "Boolean", "0", "Switch for an energy correction for CT scheme"],
+            "hallVelocity": ["hallVelocity", "Boolean", "0", "Switch to use u_ele = u - J/(ne qe)"],
+            "hy_bier1TA": ["hy_bier1TA", "Float", -1.0, "Atomic number to use for 1T Biermann Battery term"],
+            "hy_bier1TZ": ["hy_bier1TZ", "Float", -1.0, "Ionization number to use for 1T Biermann Battery term"],
+            "hy_biermannCoef": ["hy_biermannCoef", "Float", 1.0, "Coefficient of Biermann Battery flux"],
+            "hy_biermannSource": ["hy_biermannSource", "Boolean", "0", "Switch to implement battery term as an external source"],
+            "killdivb": ["killdivb", "Boolean", "1", "Switch for maintaing solenoidal field"],
+            "killdivb8w": ["killdivb8w", "Boolean", "0", "Switch for maintaing solenoidal field using Powell's 8wave"],
+            "prolMethod": ["prolMethod", "String", "INJECTION_PROL", "Injection or Balsara's method in prolongation"],
+            "use_Biermann": ["use_Biermann", "Boolean", "0", "Switch to add the Battery term for B-field generation"],
+            "use_Biermann1T": ["use_Biermann1T", "Boolean", "0", "Switch to add the 1T Battery term for B-field generation"]
+        },
+        "physicsmaterialPropertiesConductivity": {
+            "useConductivity": ["Use Conductivity", "Boolean", "1", "whether the conductivity material property is being used"]
+        },
+        "physicsmaterialPropertiesMagneticResistivity": {
+            "useMagneticResistivity": ["Use Magnetic Resistivity", "Boolean", "0", "whether the magnetic resistivity material property is being used"]
+        },
+        "physicsmaterialPropertiesOpacity": {
+            "useOpacity": ["Use Opacity", "Boolean", "1", "flags whether the Opacity unit is being used at all"]
+        },
+        "physicsmaterialPropertiesOpacityMultispecies": {
+            "op_fillAbsorb": ["Fill Absorb", "physicsmaterialPropertiesOpacityMultispeciesop_fillAbsorb", "op_undefined"],
+            "op_fillAbsorbConstant": ["op_fillAbsorbConstant", "Float", -1.0],
+            "op_fillEmiss": ["Fill Emiss", "physicsmaterialPropertiesOpacityMultispeciesop_fillEmiss", "op_undefined"],
+            "op_fillEmissConstant": ["op_fillEmissConstant", "Float", -1.0],
+            "op_fillFileName": ["Fill Filename", "String", ""],
+            "op_fillFileType": ["Fill File Type", "String", ""],
+            "op_fillTrans": ["Fill Trans", "physicsmaterialPropertiesOpacityMultispeciesop_fillTrans", "op_undefined"],
+            "op_fillTransConstant": ["op_fillTransConstant", "Float", -1.0],
+            "op_wallAbsorb": ["Wall Absorb", "physicsmaterialPropertiesOpacityMultispeciesop_wallAbsorb", "op_undefined"],
+            "op_wallAbsorbConstant": ["op_wallAbsorbConstant", "Float", -1.0],
+            "op_wallEmiss": ["Wall Emiss", "physicsmaterialPropertiesOpacityMultispeciesop_wallEmiss", "op_undefined"],
+            "op_wallEmissConstant": ["op_wallEmissConstant", "Float", -1.0],
+            "op_wallFileName": ["Wall Filename", "String", ""],
+            "op_wallFileType": ["Wall File Type", "String", ""],
+            "op_wallTrans": ["Wall Trans", "physicsmaterialPropertiesOpacityMultispeciesop_wallTrans", "op_undefined"],
+            "op_wallTransConstant": ["op_wallTransConstant", "Float", -1.0],
+            "opacity_ignoreLowTemp": ["opacity_ignoreLowTemp", "Boolean", "1", "control parameter indicating if the low temperature capability should be\nignored"],
+            "opacity_writeOpacityInfo": ["opacity_writeOpacityInfo", "Boolean", "0", "control parameter indicating if detailed info of the opacity unit should\nbe written out"]
         },
         "physicsRadTrans": {
             "rt_dtFactor": ["Time Step Coefficient", "Float", 0.1, "Coefficient for RadTrans time step", 0.0],
@@ -1183,88 +1755,6 @@
             "threadRayTrace": ["threadRayTrace", "Boolean", "0", "Use threading when tracing the rays through each block?"],
             "useEnergyDeposition": ["Use Energy Deposition", "Boolean", "1", "Use Laser energy deposition."]
         },
-        "physicsEosTabulatedHdf5TableRead": {
-            "eos_useLogTables": ["eos_useLogTables", "Boolean", "1"]
-        },
-        "physicsGravity": {
-            "grav_boundary_type": ["Boundary Condition", "physicsGravitygrav_boundary_type", "isolated", "Type of gravitational boundary condition if a Poisson solve is used for\nGravity; string-valued version of grav_boundary. Accepts \"isolated\",\n\"periodic\", \"dirichlet\", and maybe others, depending on the Poisson\nsolver used. This is declared in the stub level of the Gravity unit to\nallow the Grid unit to refer to this runtime parameter even when no\nGravity implementation is included. (grav_boundary_type)"],
-            "useGravity": ["Use Gravity", "Boolean", "1", "Should the gravity calculations be performed? (useGravity)"]
-        },
-        "physicsGravityConstant": {
-            "gconst": ["Acceleration Constant", "Float", -981.0, "Gravitational acceleration constant (gconst)"],
-            "gdirec": ["Direction of Acceleration", "physicsGravityConstantgdirec", "x", "Direction of acceleration (\"x\", \"y\", \"z\") (gdirec)"]
-        },
-        "physicsHydro": {
-            "UnitSystem": ["UnitSystem", "String", "none", "System of Units"],
-            "cfl": ["Courant Factor", "Float", 0.8, "cfl"],
-            "threadHydroBlockList": ["threadHydroBlockList", "Boolean", "0"],
-            "threadHydroWithinBlock": ["threadHydroWithinBlock", "Boolean", "0"],
-            "updateHydroFluxes": ["updateHydroFluxes", "Boolean", "1", "whether fluxes computed by Hydro should be used to update the solution\n(currently, probably only used in split PPM Hydro)"],
-            "useHydro": ["Use Hydrodynamics", "Boolean", "1", "Should any Hydro calculations be performed? (useHydro)"],
-            "use_cma_advection": ["use_cma_advection", "Boolean", "0", "Use the CMA advection with partial masses being primary variables; thos\nparameter only affects the unsplit PPM hydro solver."],
-            "use_cma_flattening": ["use_cma_flattening", "Boolean", "0", "Use the flattening procedure for the abundances as described in the CMA\npaper; this parameter only affects the unsplit PPM hydro solver."]
-        },
-        "physicsHydrounsplit": {
-            "EOSforRiemann": ["EOSforRiemann", "Boolean", "0", "Turn on/off calls to Eos for thermo of reconstructed face states\n(MODE_DENS_PRES)"],
-            "LimitedSlopeBeta": ["Limited Slope Beta", "Float", 1.0, "LimitedSlopeBeta"],
-            "RiemannSolver": ["Riemann Solver", "RiemannSolver", "HLLC", "RiemannSolver"],
-            "addThermalFlux": ["addThermalFlux", "Constant", "FALSE"],
-            "charLimiting": ["Characteristic Limiting", "Boolean", "1", "Apply limiting for characteristic variable (charLimiting)"],
-            "conserveAngMom": ["conserveAngMom", "Boolean", "0", "Conservative formulation for cylindrical coordinates regarding the\ntoroidal momentum"],
-            "cvisc": ["Artificial Viscosity Constant", "Float", 0.1, "cvisc"],
-            "entropy": ["Entropy Fix", "Boolean", "0", "Entropy Fix routine for the Roe Riemann solver: (entropy)"],
-            "entropyFixMethod": ["entropyFixMethod", "String", "HARTENHYMAN", "Entropy fix method for the Roe Riemann solver Harten or HartenHyman"],
-            "hy_3Torder": ["hy_3Torder", "physicsHydrounsplithy_3Torder", -1, "Reconstruction order for eint, eele, eion, erad in HEDP simulations"],
-            "hy_cflFallbackFactor": ["hy_cflFallbackFactor", "Float", 0.9, "factor for scaling CFL factor when it is lowered because of fallback in\nproblematic cells"],
-            "hy_eosModeGc": ["hy_eosModeGc", "physicsHydrounsplithy_eosModeGc", "see eosMode", "Eos mode that the Hydro unit should apply to guard cells before the\nfirst major loop, i.e., before computing Riemann input states by\nreconstruction etc. The special value \"see eosMode\" can be used to\nindicate the mode set by the runtime parameter \"eosMode\". Other values\nare as for \"eosMode\"."],
-            "hy_fPresInMomFlux": ["hy_fPresInMomFlux", "Float", 1.0, "Percentage of the pressure gradient (values range from 0 to 1) that is\ntreated as part of momentum fluxes", 0.0, 1.0],
-            "hy_fallbackLowerCFL": ["hy_fallbackLowerCFL", "Boolean", "0", "Lower the simulation CFL if fallin back to a lower reconstruction order\nin problematic cells"],
-            "hy_fullSpecMsFluxHandling": ["hy_fullSpecMsFluxHandling", "Boolean", "1", "Are species and mass scalars updated with fluxes that have undergone the\nfull treatment applied to other fluxes, including fine-coarse-boundary\nflux correction if that is done to fluxes of other conserved variables?"],
-            "hybridOrderKappa": ["hybridOrderKappa", "Float", 0.0, "A constant value to determine shock strengths for hybrid order"],
-            "hydroComputeDtOption": ["hydroComputeDtOption", "physicsHydrounsplithydroComputeDtOption", -1, "An option where to compute hydro dt. Choices are integer values [-1, 0,\n1] as follows: -1: Hydro_computeDt.F90,  the old standard way that has\nmost extensive supports and well-tested; 0: hy_uhd_energyFix.F90, a\nlight weighted version without calling a global loop Hydro_computeDt; 1:\nhy_getFaceFlux.F90,   another light weighted dt call during flux\ncalculations."],
-            "irenorm": ["irenorm", "Integer", 0, "Renormalize abundances"],
-            "order": ["Order", "physicsHydrounsplitorder", 2, "1st order Godunov scheme, 2nd MUSCL-Hancock scheme, or 3rd PPM, 5th WENO (order)"],
-            "radiusGP": ["radiusGP", "Float", 2.0],
-            "shockDetect": ["Use Strong Compressive Shock Detection", "Boolean", "0", "Switch to use a strong compressive shock detection (shockDetect)"],
-            "shockLowerCFL": ["shockLowerCFL", "Boolean", "0", "Lower the simulation CFL if shocks are detected"],
-            "sigmaGP": ["sigmaGP", "Float", 3.0],
-            "slopeLimiter": ["Slope Limiter", "SlopeLimiter", "vanLeer", "slopeLimiter"],
-            "small": ["small", "Float", 1e-10, "Cutoff value"],
-            "smalle": ["smalle", "Float", 1e-10, "Cutoff value for energy"],
-            "smallp": ["smallp", "Float", 1e-10, "Cutoff value for pressure"],
-            "smallt": ["smallt", "Float", 1e-10, "Cutoff value for temperature"],
-            "smallu": ["smallu", "Float", 1e-10, "Cutoff value for velocity"],
-            "smallx": ["smallx", "Float", 1e-10, "Cutoff value for abundances"],
-            "smlrho": ["smlrho", "Float", 1e-10, "Cutoff value for density"],
-            "tiny": ["tiny", "Float", 1e-16, "A threshold value for an arbitrarily small number"],
-            "transOrder": ["transOrder", "physicsHydrounsplittransOrder", 1, "order of approximating transeverse flux derivative in data\nreconstruction"],
-            "use_3dFullCTU": ["use_3dFullCTU", "Boolean", "1", "Turn on/off the full CTU scheme that gives CFL <= 1 for 3D"],
-            "use_auxEintEqn": ["use_auxEintEqn", "Boolean", "1", "Turn on/off solving the auxilary internal energy equation"],
-            "use_avisc": ["use_avisc", "Boolean", "0"],
-            "use_flattening": ["use_flattening", "Boolean", "0", "Switch for PPM flattening"],
-            "use_gravHalfUpdate": ["use_gravHalfUpdate", "Boolean", "1", "Include gravitational accelerations to hydro coupling at n+1/2"],
-            "use_hybridOrder": ["use_hybridOrder", "Boolean", "0", "Apply RH jump condition to check monotonicity of reconstructed values"],
-            "use_steepening": ["use_steepening", "Boolean", "0", "Switch for steepening contact discontinuities for 3rd order PPM"],
-            "use_upwindTVD": ["use_upwindTVD", "Boolean", "0", "Turn on/off upwinding TVD slopes"],
-            "wenoMethod": ["wenoMethod", "String", "WENO5"]
-        },
-        "physicsHydrounsplitMHD_StaggeredMesh": {
-            "E_modification": ["E_modification", "Boolean", "1", "Switch for modified electric fields calculation from flux"],
-            "E_upwind": ["E_upwind", "Boolean", "0", "Switch for upwind update for induction equations"],
-            "ForceHydroLimit": ["ForceHydroLimit", "Boolean", "0", "Switch to force B=0 limit, i.e., the solver will not update B fields"],
-            "conserveAngField": ["conserveAngField", "Boolean", "0", "Turn on/off alternate formulation for toroidal induction"],
-            "energyFix": ["energyFix", "Boolean", "0", "Switch for an energy correction for CT scheme"],
-            "hallVelocity": ["hallVelocity", "Boolean", "0", "Switch to use u_ele = u - J/(ne qe)"],
-            "hy_bier1TA": ["hy_bier1TA", "Float", -1.0, "Atomic number to use for 1T Biermann Battery term"],
-            "hy_bier1TZ": ["hy_bier1TZ", "Float", -1.0, "Ionization number to use for 1T Biermann Battery term"],
-            "hy_biermannCoef": ["hy_biermannCoef", "Float", 1.0, "Coefficient of Biermann Battery flux"],
-            "hy_biermannSource": ["hy_biermannSource", "Boolean", "0", "Switch to implement battery term as an external source"],
-            "killdivb": ["killdivb", "Boolean", "1", "Switch for maintaing solenoidal field"],
-            "killdivb8w": ["killdivb8w", "Boolean", "0", "Switch for maintaing solenoidal field using Powell's 8wave"],
-            "prolMethod": ["prolMethod", "String", "INJECTION_PROL", "Injection or Balsara's method in prolongation"],
-            "use_Biermann": ["use_Biermann", "Boolean", "0", "Switch to add the Battery term for B-field generation"],
-            "use_Biermann1T": ["use_Biermann1T", "Boolean", "0", "Switch to add the 1T Battery term for B-field generation"]
-        },
         "physicssourceTermsEnergyDepositionLaserLaserIO": {
             "ed_laserIOMaxNumberOfPositions": ["Max Ray Positions", "Integer", -1, "Maximum number of positions to store for each IO ray"],
             "ed_laserIOMaxNumberOfRays": ["Max Rays", "Integer", -1, "Maximum number of IO rays to write out accross each process"],
@@ -1296,36 +1786,123 @@
             "hx_dtFactor": ["hx_dtFactor", "Float", 0.5, "", 0.0],
             "hx_ieTimeCoef": ["hx_ieTimeCoef", "Float", 1.0, "Constant coefficient for scaling ion/ele coupling time", 0.0],
             "hx_relTol": ["hx_relTol", "Float", -1.0, "relative tolerance for temperature errors introduced by HeatExchange.\nThis runtime parameter affects the time step computed by\nHeatexchange_computeDt. Basically, if the max (abs) temperature\nadjustment that would be introduced in any nonzero component in any cell\nis less than hx_relTol, then the time step limit is relaxed. Set to a\nnegative value to inherite the value of runtime parameter eos_tolerance."]
+        },
+        "setupArguments": {
+            "auto": ["Auto", "Boolean", "0", "Enable setup to generate a 'rough draft' of a Units file."],
+            "cartesian": ["Cartesian", "SetupArgumentShortcut", "0", "Use Cartesian geometry."],
+            "cylindrical": ["Cylindrical", "SetupArgumentShortcut", "0", "Use cylindrical geometry."],
+            "d": ["Dimensions", "SetupArgumentDimension", "2", "Dimensionality of problem to solve."],
+            "ed_maxBeams": ["Maxmimum Laser Beams", "NoDashInteger", 6, "Maximum number of laser beams."],
+            "ed_maxPulseSections": ["Maximum Sections per Laser Pulse", "NoDashInteger", 20, "Maximum number of laser beams."],
+            "ed_maxPulses": ["Maximum Laser Pulses", "NoDashInteger", 5, "Maximum number of laser pulses"],
+            "hdf5typeio": ["HDF5 Parallel IO Output", "SetupArgumentShortcut", "0", "Use  hdf5 with parallel io capability for compatible binary IO output."],
+            "laser": ["Laser", "SetupArgumentShortcut", "0", "Use source terms for energy deposition."],
+            "maxblocks": ["Maximum Blocks", "Integer", "", "Maximum number of blocks per process."],
+            "mgd": ["Magento Gas Dynamics", "SetupArgumentShortcut", "0", "Use the MGD (magneto gas dynamic) radiative transfermodule."],
+            "mgd_meshgroups": ["Magneto Gas Dynamics Mesh Groups", "NoDashInteger", 1, "mgd ̇meshgroups * meshCopyCount sets the MAXIMUM number of radiation groups that can be used in a simulation."],
+            "mtmmmt": ["MultiTemp/MultiType and Tabulated EOSes", "SetupArgumentShortcut", "0", "Use the MultiTemp/MultiType and Tabulated EOSes (for HEDPsimulations)."],
+            "nofbs": ["Uniform Grid (Non-Fixed Block Size)", "SetupArgumentShortcut", "0", "Use the uniform grid in a non-fixed block size mode."],
+            "noio": ["No IO", "SetupArgumentShortcut", "0", "Disable IO."],
+            "nxb": ["Zones Per Block (X)", "Integer", 8, "How many cells each block of the mesh contains (not counting guard cells)."],
+            "nyb": ["Zones Per Block (Y)", "Integer", 8, "How many cells each block of the mesh contains (not counting guard cells)."],
+            "nzb": ["Zones Per Block (Z)", "Integer", 8, "How many cells each block of the mesh contains (not counting guard cells)."],
+            "opt": ["Compiler Optimization", "Boolean", "0", "Enable compiler optimization."],
+            "pm2": ["PARAMESH2 Grid", "SetupArgumentShortcut", "0", "Use the PARAMESH2 grid."],
+            "pm40": ["PARAMESH4.0 Grid", "SetupArgumentShortcut", "0", "Use the PARAMESH4.0 grid."],
+            "pm4dev": ["PARAMESH4DEV Grid", "SetupArgumentShortcut", "0", "Use the PARAMESH4DEV grid."],
+            "polar": ["Polar", "SetupArgumentShortcut", "0", "Use polar geometry."],
+            "species": ["Species", "String", "", "An alternative to specifying the SPECIES in the Config file."],
+            "spherical": ["Spherical", "SetupArgumentShortcut", "0", "Use spherical geometry."],
+            "splithydro": ["Hydro Solver", "SetupArgumentShortcut", "0", "Use a split Hydro solver."],
+            "ug": ["Uniform Grid (Fixed Block Size)", "SetupArgumentShortcut", "0", "Use the uniform grid in a fixed block size mode."],
+            "uhd": ["Unsplit Hydro Solver", "SetupArgumentShortcut", "0", "Use the Unsplit Hydro solver."],
+            "usm": ["Unsplit Staggered Mesh MHD Solver", "SetupArgumentShortcut", "0", "Use the Unsplit Staggered Mesh MHD solver."],
+            "usm3t": ["Unsplit MHD with MultiTemp EOS", "SetupArgumentShortcut", "0", "Use unsplit MHD with MultiTemp EOS."]
+        },
+        "simulation": {
+            "flashType": ["Simulation Type", "flashType", "RTFlame"]
+        },
+        "SimulationCapLaser3D": {
+            "sim_condWall": ["sim_condWall", "Float", 195000.0, "Wall conductivity at the gas/wall interface"],
+            "sim_eosFill": ["Fill EOS Type", "SimulationCapLasersim_eosFill", "eos_gam"],
+            "sim_eosWall": ["Wall EOS Type", "SimulationCapLasersim_eosWall", "eos_tab"],
+            "sim_currType": ["Current Calculation Type", "SimulationCapLasersim_currType", "1", "how to calculate the current"],
+            "sim_currFile": ["Current File", "InputFile", "", "file describing current over time"],
+            "sim_riseTime": ["Rise Time", "Float", 1.8e-9, "rise time to peak current in seconds"],
+            "sim_peakCurr": ["Peak Current", "Float", 3.1e2, "peak current at wall in amperes"],
+            "sim_peakField": ["Peak Field", "Float", 2.4e3, "peak field in gauss at capillary wall"],
+            "sim_period": ["Circuit Period", "Float", 300e-9 , "circuit period in seconds"],
+            "sim_rhoFill": ["Fill Initial Density", "Float", 2.655e-07],
+            "sim_rhoWall": ["Wall Initial Density", "Float", 2.7],
+            "sim_rWall": ["Wall Gas Radius", "Float", 250.0e-4, "wall radius for position of gas/wall interface"],
+            "sim_teleFill": ["Fill Electron Temp.", "Float", 290.11375],
+            "sim_teleWall": ["Wall Electron Temp.", "Float", 290.11375],
+            "sim_tionFill": ["Fill Ion Temp.", "Float", 290.11375],
+            "sim_tionWall": ["Wall Ion Temp.", "Float", 290.11375],
+            "sim_tradFill": ["Fill Radiation Temp.", "Float", 290.11375],
+            "sim_tradWall": ["Wall Radiation Temp.", "Float", 290.11375],
+            "sim_zminWall": ["Wall Minimum Zbar", "Float", 0.0]
+        },
+        "SimulationCapLaserBELLA": {
+            "sim_condWall": ["sim_condWall", "Float", 195000.0, "Wall conductivity at the gas/wall interface"],
+            "sim_eosFill": ["Fill EOS Type", "SimulationCapLasersim_eosFill", "eos_gam"],
+            "sim_eosWall": ["Wall EOS Type", "SimulationCapLasersim_eosWall", "eos_tab"],
+            "sim_currType": ["Current Calculation Type", "SimulationCapLasersim_currType", "1", "how to calculate the current"],
+            "sim_currFile": ["Current File", "InputFile", "", "file describing current over time"],
+            "sim_riseTime": ["Rise Time", "Float", 1.8e-9, "rise time to peak current in seconds"],
+            "sim_peakCurr": ["Peak Current", "Float", 3.1e2, "peak current at wall in amperes"],
+            "sim_rhoFill": ["Fill Initial Density", "Float", 2.655e-07],
+            "sim_rhoWall": ["Wall Initial Density", "Float", 2.7],
+            "sim_teleFill": ["Fill Electron Temp.", "Float", 290.11375],
+            "sim_teleWall": ["Wall Electron Temp.", "Float", 290.11375],
+            "sim_tionFill": ["Fill Ion Temp.", "Float", 290.11375],
+            "sim_tionWall": ["Wall Ion Temp.", "Float", 290.11375],
+            "sim_tradFill": ["Fill Radiation Temp.", "Float", 290.11375],
+            "sim_tradWall": ["Wall Radiation Temp.", "Float", 290.11375],
+            "sim_zminWall": ["Wall Minimum Zbar", "Float", 0.0]
+        },
+        "SimulationRTFlame": {
+            "dens_unburned": ["Unburned Density [g/cc]", "Float", 100000000.0, "dens_unburned"],
+            "flame_initial_position": ["Initial Flame Position [cm]", "Float", 0.0, "flame_initial_position"],
+            "particle_attribute_1": ["particle_attribute_1", "String", "dens"],
+            "particle_attribute_2": ["particle_attribute_2", "String", "temp"],
+            "particle_attribute_4": ["particle_attribute_4", "String", "flam"],
+            "refine_buf": ["refine_buf", "Float", 100000.0, "Buffer to prevent refinement pattern jitter"],
+            "refine_lead": ["refine_lead", "Float", 200000.0, "Distance above highest burned cell which refined region will reach"],
+            "refine_region_size": ["refine_region_size", "Float", 6000000.0, "Total size of refine region (See source for diagram of parameter\nmeanings)"],
+            "refine_region_stepdown_size": ["refine_region_stepdown_size", "Float", 4500000.0, "Distance behind fully refined region that is one lower refinement level"],
+            "refine_uniform_region": ["refine_uniform_region", "Boolean", "0", "Select whether to refine a selected region uniformly or use\nstandard-style refinement checks (configured with other parameters)"],
+            "sim_ParticleRefineRegion": ["sim_ParticleRefineRegion", "Boolean", "0"],
+            "sim_ParticleRefineRegionBottom": ["sim_ParticleRefineRegionBottom", "Float", 6000000.0],
+            "sim_ParticleRefineRegionLevel": ["sim_ParticleRefineRegionLevel", "Integer", 2],
+            "sim_ParticleRefineRegionTop": ["sim_ParticleRefineRegionTop", "Float", 20000000.0],
+            "spert_ampl1": ["Amplitude Perturbation 1", "Float", 0.0],
+            "spert_ampl2": ["Amplitude Perturbation 2", "Float", 0.0],
+            "spert_phase1": ["Phase Perturbation 1", "Float", 0.0],
+            "spert_phase2": ["Phase Perturbation 2", "Float", 0.0],
+            "spert_wl1": ["Wavelength Perturbation 1", "Float", 1.0],
+            "spert_wl2": ["Wavelength Perturbation 2", "Float", 1.0],
+            "temp_unburned": ["Unburned Temperature [K]", "Float", 100000000.0, "temp_unburned"],
+            "vel_pert_amp": ["vel_pert_amp", "Float", 0.0],
+            "vel_pert_wavelength1": ["vel_pert_wavelength1", "Float", 1.0]
+        },
+        "simulationStatus": {},
+        "varAnimation": {
+            "var": ["Variable Name", "VariableName", "dens"],
+            "framesPerSecond": ["Frames per Second", "FramesPerSecond", "2"],
+            "colorMap": ["Color Map", "ColorMap", "coolwarm"],
+            "notes": ["Notes", "Text", ""]
         }
     },
     "view": {
-        "gridEvolutionAnimation": {
-            "title": "Grid Quantity Evolution",
-            "advanced": [
-                "y1",
-                "y2",
-                "y3",
-                "notes"
-            ]
-        },
-        "varAnimation": {
-            "title": "Variable Plot",
-            "advanced": [
-                "var",
-                "framesPerSecond",
-                "colorMap",
-                "notes"
-            ]
-        },
-        "simulation": {
-            "title": "FLASH Simulation",
-            "advanced": [
-                "name",
-                "flashType"
-            ]
-        },
-        "simulationStatus": {
-            "title": "Simulation Status",
+        "Driver": {
+            "title": "Simulation Driver",
+            "basic": [
+                "tmax",
+                "dtinit",
+                "IO.plotFileIntervalTime",
+                "allowDtSTSDominate"
+            ],
             "advanced": []
         },
         "Grid": {
@@ -1387,6 +1964,78 @@
             ],
             "advanced": []
         },
+        "gridEvolutionAnimation": {
+            "title": "Grid Quantity Evolution",
+            "advanced": [
+                "y1",
+                "y2",
+                "y3",
+                "notes"
+            ]
+        },
+        "physicsDiffuse": {
+            "title": "Diffusive Effects",
+            "basic": [
+                "useDiffuse",
+                "diff_useEleCond",
+                "diff_eleFlMode",
+                "diff_eleFlCoef",
+                "dt_diff_factor",
+                "physicsDiffuseUnsplit.diff_thetaImplct",
+                [
+                    ["X", [
+                        "diff_eleXlBoundaryType",
+                        "diff_eleXrBoundaryType"
+                    ]],
+                    ["Y", [
+                        "diff_eleYlBoundaryType",
+                        "diff_eleYrBoundaryType"
+                    ]],
+                    ["Z", [
+                        "diff_eleZlBoundaryType",
+                        "diff_eleZrBoundaryType"
+                    ]]
+                ]
+            ],
+            "advanced": []
+         },
+        "physicsHydro": {
+            "title": "Hydrodynamics",
+            "basic": [
+                "useHydro",
+                "cfl",
+                "physicsHydrounsplit.order",
+                "physicsHydrounsplit.slopeLimiter",
+                "physicsHydrounsplit.LimitedSlopeBeta",
+                "physicsHydrounsplit.charLimiting",
+                "physicsHydrounsplit.cvisc",
+                "physicsHydrounsplit.RiemannSolver",
+                "physicsHydrounsplit.entropy",
+                "physicsHydrounsplit.shockDetect"
+            ],
+            "advanced": []
+        },
+        "physicsmaterialProperties": {
+            "title": "Material Properties",
+            "basic": [
+                "physicsmaterialPropertiesOpacity.useOpacity",
+                "physicsmaterialPropertiesConductivity.useConductivity",
+                "physicsmaterialPropertiesMagneticResistivity.useMagneticResistivity",
+                [
+                    ["Fill", [
+                        "physicsmaterialPropertiesOpacityMultispecies.op_fillAbsorb",
+                        "physicsmaterialPropertiesOpacityMultispecies.op_fillEmiss",
+                        "physicsmaterialPropertiesOpacityMultispecies.op_fillTrans"
+                    ]],
+                    ["Wall", [
+                        "physicsmaterialPropertiesOpacityMultispecies.op_wallAbsorb",
+                        "physicsmaterialPropertiesOpacityMultispecies.op_wallEmiss",
+                        "physicsmaterialPropertiesOpacityMultispecies.op_wallTrans"
+                    ]]
+                ]
+            ],
+            "advanced": []
+        },
         "physicsRadTrans": {
             "title": "Radiative Transfer",
             "basic": [
@@ -1421,203 +2070,6 @@
                     "physicsRadTransMGD.rt_mgdBounds_6",
                     "physicsRadTransMGD.rt_mgdBounds_7"
                 ]]
-            ],
-            "advanced": []
-        },
-        "physicsHydro": {
-            "title": "Hydrodynamics",
-            "basic": [
-                "useHydro",
-                "cfl",
-                "physicsHydrounsplit.order",
-                "physicsHydrounsplit.slopeLimiter",
-                "physicsHydrounsplit.LimitedSlopeBeta",
-                "physicsHydrounsplit.charLimiting",
-                "physicsHydrounsplit.cvisc",
-                "physicsHydrounsplit.RiemannSolver",
-                "physicsHydrounsplit.entropy",
-                "physicsHydrounsplit.shockDetect"
-            ],
-            "advanced": []
-        },
-        "physicsDiffuse": {
-            "title": "Diffusive Effects",
-            "basic": [
-                "useDiffuse",
-                "diff_useEleCond",
-                "diff_eleFlMode",
-                "diff_eleFlCoef",
-                "dt_diff_factor",
-                "physicsDiffuseUnsplit.diff_thetaImplct",
-                [
-                    ["X", [
-                        "diff_eleXlBoundaryType",
-                        "diff_eleXrBoundaryType"
-                    ]],
-                    ["Y", [
-                        "diff_eleYlBoundaryType",
-                        "diff_eleYrBoundaryType"
-                    ]],
-                    ["Z", [
-                        "diff_eleZlBoundaryType",
-                        "diff_eleZrBoundaryType"
-                    ]]
-                ]
-            ],
-            "advanced": []
-         },
-        "Driver": {
-            "title": "Simulation Driver",
-            "basic": [
-                "tmax",
-                "dtinit",
-                "IO.plotFileIntervalTime",
-                "allowDtSTSDominate"
-            ],
-            "advanced": []
-        },
-        "SimulationCapLaser3D": {
-            "title": "CapLaser 3D Settings",
-            "basic": [
-                ["Main", [
-                    "sim_currType",
-                    "sim_currFile",
-                    "sim_peakCurr",
-                    "sim_peakField",
-                    "sim_period",
-                    "sim_riseTime",
-                    "sim_zminWall",
-                    "sim_rWall",
-                    [
-                        ["Fill", [
-                            "sim_eosFill",
-                            "sim_rhoFill",
-                            "sim_teleFill",
-                            "sim_tionFill",
-                            "sim_tradFill"
-                        ]],
-                        ["Wall", [
-                            "sim_eosWall",
-                            "sim_rhoWall",
-                            "sim_teleWall",
-                            "sim_tionWall",
-                            "sim_tradWall"
-                        ]]
-                    ]
-                ]],
-                ["Multispecies", [
-                    [
-                        ["Fill", [
-                            "Multispecies.ms_fillSpecies",
-                            "Multispecies.ms_fillA",
-                            "Multispecies.ms_fillZ",
-                            "Multispecies.ms_fillZMin",
-                            "Multispecies.eos_fillEosType"
-                        ]],
-                        ["Wall", [
-                            "Multispecies.ms_wallSpecies",
-                            "Multispecies.ms_wallA",
-                            "Multispecies.ms_wallZ",
-                            "Multispecies.ms_wallZMin",
-                            "Multispecies.eos_wallEosType"
-                        ]]
-                    ]
-                ]]
-            ],
-            "advanced": [
-                "physicssourceTermsHeatexchange.useHeatexchange"
-            ]
-        },
-        "SimulationCapLaserBELLA": {
-            "title": "CapLaserBELLA Settings",
-            "basic": [
-                ["Main", [
-                    "sim_currType",
-                    "sim_currFile",
-                    "sim_peakCurr",
-                    "sim_riseTime",
-                    "sim_zminWall",
-                    [
-                        ["Fill", [
-                            "sim_eosFill",
-                            "sim_rhoFill",
-                            "sim_teleFill",
-                            "sim_tionFill",
-                            "sim_tradFill"
-                        ]],
-                        ["Wall", [
-                            "sim_eosWall",
-                            "sim_rhoWall",
-                            "sim_teleWall",
-                            "sim_tionWall",
-                            "sim_tradWall"
-                        ]]
-                    ]
-                ]],
-                ["Multispecies", [
-                    [
-                        ["Fill", [
-                            "Multispecies.ms_fillSpecies",
-                            "Multispecies.ms_fillA",
-                            "Multispecies.ms_fillZ",
-                            "Multispecies.ms_fillZMin",
-                            "Multispecies.eos_fillEosType"
-                        ]],
-                        ["Wall", [
-                            "Multispecies.ms_wallSpecies",
-                            "Multispecies.ms_wallA",
-                            "Multispecies.ms_wallZ",
-                            "Multispecies.ms_wallZMin",
-                            "Multispecies.eos_wallEosType"
-                        ]]
-                    ]
-                ]]
-            ],
-            "advanced": [
-                "physicssourceTermsHeatexchange.useHeatexchange"
-            ]
-        },
-        "SimulationRTFlame": {
-            "title": "RTFlame Settings",
-            "basic": [
-                "flame_initial_position",
-                "dens_unburned",
-                "temp_unburned",
-                [
-                    ["Amplitude [cm]", [
-                        "spert_ampl1",
-                        "spert_ampl2"
-                    ]],
-                    ["Wavelength [cm]", [
-                        "spert_wl1",
-                        "spert_wl2"
-                    ]],
-                    ["Phase [rad]", [
-                        "spert_phase1",
-                        "spert_phase2"
-                    ]]
-                ]
-            ],
-            "advanced": []
-        },
-        "physicsmaterialProperties": {
-            "title": "Material Properties",
-            "basic": [
-                "physicsmaterialPropertiesOpacity.useOpacity",
-                "physicsmaterialPropertiesConductivity.useConductivity",
-                "physicsmaterialPropertiesMagneticResistivity.useMagneticResistivity",
-                [
-                    ["Fill", [
-                        "physicsmaterialPropertiesOpacityMultispecies.op_fillAbsorb",
-                        "physicsmaterialPropertiesOpacityMultispecies.op_fillEmiss",
-                        "physicsmaterialPropertiesOpacityMultispecies.op_fillTrans"
-                    ]],
-                    ["Wall", [
-                        "physicsmaterialPropertiesOpacityMultispecies.op_wallAbsorb",
-                        "physicsmaterialPropertiesOpacityMultispecies.op_wallEmiss",
-                        "physicsmaterialPropertiesOpacityMultispecies.op_wallTrans"
-                    ]]
-                ]
             ],
             "advanced": []
         },
@@ -1725,6 +2177,192 @@
                 "physicsGravityConstant.gconst",
                 "physicsGravityConstant.gdirec"
             ],
+            "advanced": []
+        },
+        "setupArguments": {
+            "title": "Setup Arguments",
+            "basic": [
+                "auto",
+                "cartesian",
+                "cylindrical",
+                "d",
+                "maxblocks",
+                "nofbs",
+                "noio",
+                "nxb",
+                "nyb",
+                "nzb",
+                "opt",
+                "pm2",
+                "pm40",
+                "pm4dev",
+                "polar",
+                "spherical",
+                "splithydro",
+                "ug",
+                "uhd",
+                "usm"
+            ],
+            "advanced": [
+                "ed_maxBeams",
+                "ed_maxPulseSections",
+                "ed_maxPulses",
+                "hdf5typeio",
+                "laser",
+                "mgd",
+                "mgd_meshgroups",
+                "mtmmmt",
+                "species",
+                "usm3t"
+            ]
+        },
+        "simulation": {
+            "title": "FLASH Simulation",
+            "advanced": [
+                "name",
+                "flashType"
+            ]
+        },
+        "SimulationCapLaserBELLA": {
+            "title": "CapLaserBELLA Settings",
+            "basic": [
+                ["Main", [
+                    "sim_currType",
+                    "sim_currFile",
+                    "sim_peakCurr",
+                    "sim_riseTime",
+                    "sim_zminWall",
+                    [
+                        ["Fill", [
+                            "sim_eosFill",
+                            "sim_rhoFill",
+                            "sim_teleFill",
+                            "sim_tionFill",
+                            "sim_tradFill"
+                        ]],
+                        ["Wall", [
+                            "sim_eosWall",
+                            "sim_rhoWall",
+                            "sim_teleWall",
+                            "sim_tionWall",
+                            "sim_tradWall"
+                        ]]
+                    ]
+                ]],
+                ["Multispecies", [
+                    [
+                        ["Fill", [
+                            "Multispecies.ms_fillSpecies",
+                            "Multispecies.ms_fillA",
+                            "Multispecies.ms_fillZ",
+                            "Multispecies.ms_fillZMin",
+                            "Multispecies.eos_fillEosType"
+                        ]],
+                        ["Wall", [
+                            "Multispecies.ms_wallSpecies",
+                            "Multispecies.ms_wallA",
+                            "Multispecies.ms_wallZ",
+                            "Multispecies.ms_wallZMin",
+                            "Multispecies.eos_wallEosType"
+                        ]]
+                    ]
+                ]]
+            ],
+            "advanced": [
+                "physicssourceTermsHeatexchange.useHeatexchange"
+            ]
+        },
+        "SimulationCapLaser3D": {
+            "title": "CapLaser 3D Settings",
+            "basic": [
+                ["Main", [
+                    "sim_currType",
+                    "sim_currFile",
+                    "sim_peakCurr",
+                    "sim_peakField",
+                    "sim_period",
+                    "sim_riseTime",
+                    "sim_zminWall",
+                    "sim_rWall",
+                    [
+                        ["Fill", [
+                            "sim_eosFill",
+                            "sim_rhoFill",
+                            "sim_teleFill",
+                            "sim_tionFill",
+                            "sim_tradFill"
+                        ]],
+                        ["Wall", [
+                            "sim_eosWall",
+                            "sim_rhoWall",
+                            "sim_teleWall",
+                            "sim_tionWall",
+                            "sim_tradWall"
+                        ]]
+                    ]
+                ]],
+                ["Multispecies", [
+                    [
+                        ["Fill", [
+                            "Multispecies.ms_fillSpecies",
+                            "Multispecies.ms_fillA",
+                            "Multispecies.ms_fillZ",
+                            "Multispecies.ms_fillZMin",
+                            "Multispecies.eos_fillEosType"
+                        ]],
+                        ["Wall", [
+                            "Multispecies.ms_wallSpecies",
+                            "Multispecies.ms_wallA",
+                            "Multispecies.ms_wallZ",
+                            "Multispecies.ms_wallZMin",
+                            "Multispecies.eos_wallEosType"
+                        ]]
+                    ]
+                ]]
+            ],
+            "advanced": [
+                "physicssourceTermsHeatexchange.useHeatexchange"
+            ]
+        },
+        "SimulationRTFlame": {
+            "title": "RTFlame Settings",
+            "basic": [
+                "flame_initial_position",
+                "dens_unburned",
+                "temp_unburned",
+                [
+                    ["Amplitude [cm]", [
+                        "spert_ampl1",
+                        "spert_ampl2"
+                    ]],
+                    ["Wavelength [cm]", [
+                        "spert_wl1",
+                        "spert_wl2"
+                    ]],
+                    ["Phase [rad]", [
+                        "spert_phase1",
+                        "spert_phase2"
+                    ]]
+                ]
+            ],
+            "advanced": []
+        },
+        "simulationStatus": {
+            "title": "Simulation Status",
+            "advanced": []
+        },
+        "varAnimation": {
+            "title": "Variable Plot",
+            "advanced": [
+                "var",
+                "framesPerSecond",
+                "colorMap",
+                "notes"
+            ]
+        },
+        "withUnitArguments": {
+            "title": "Units to Include",
+            "basic": [],
             "advanced": []
         }
     }

--- a/sirepo/package_data/static/json/flash-schema.json
+++ b/sirepo/package_data/static/json/flash-schema.json
@@ -1787,6 +1787,9 @@
             "hx_ieTimeCoef": ["hx_ieTimeCoef", "Float", 1.0, "Constant coefficient for scaling ion/ele coupling time", 0.0],
             "hx_relTol": ["hx_relTol", "Float", -1.0, "relative tolerance for temperature errors introduced by HeatExchange.\nThis runtime parameter affects the time step computed by\nHeatexchange_computeDt. Basically, if the max (abs) temperature\nadjustment that would be introduced in any nonzero component in any cell\nis less than hx_relTol, then the time step limit is relaxed. Set to a\nnegative value to inherite the value of runtime parameter eos_tolerance."]
         },
+        "problemFiles": {
+            "archive": ["ZIP Archive", "InputFile", "", "ZIP archive containing files for a FLASH problem (Config, Makefile, F90)."]
+        },
         "setupArguments": {
             "auto": ["Auto", "Boolean", "0", "Enable setup to generate a 'rough draft' of a Units file."],
             "cartesian": ["Cartesian", "SetupArgumentShortcut", "0", "Use Cartesian geometry."],
@@ -2176,6 +2179,13 @@
                 "grav_boundary_type",
                 "physicsGravityConstant.gconst",
                 "physicsGravityConstant.gdirec"
+            ],
+            "advanced": []
+        },
+        "problemFiles": {
+            "title": "Problem Files",
+            "basic": [
+                "archive"
             ],
             "advanced": []
         },

--- a/sirepo/package_data/template/flash/examples/caplaser3d.json
+++ b/sirepo/package_data/template/flash/examples/caplaser3d.json
@@ -813,6 +813,21 @@
             "hx_ieTimeCoef": 1,
             "hx_relTol": -1
         },
+        "setupArguments": {
+            "auto": "1",
+            "cartesian": "1",
+            "d": 3,
+            "ed_maxBeams": 1,
+            "ed_maxPulseSections": 4,
+            "ed_maxPulses": 1,
+            "hdf5typeio": "1",
+            "laser": "1",
+            "mgd": "1",
+            "mgd_meshgroups": 6,
+            "mtmmmt": "1",
+            "species": "fill,wall",
+            "usm3t": "1"
+        },
         "simFolder": {},
         "simulation": {
             "documentationUrl": "",

--- a/sirepo/package_data/template/flash/examples/caplaser3d.json
+++ b/sirepo/package_data/template/flash/examples/caplaser3d.json
@@ -813,6 +813,9 @@
             "hx_ieTimeCoef": 1,
             "hx_relTol": -1
         },
+        "problemFiles": {
+            "archive": "CapLaser3D.zip"
+        },
         "setupArguments": {
             "auto": "1",
             "cartesian": "1",

--- a/sirepo/package_data/template/flash/examples/caplaserbella.json
+++ b/sirepo/package_data/template/flash/examples/caplaserbella.json
@@ -765,6 +765,9 @@
             "hx_ieTimeCoef": 1,
             "hx_relTol": -1
         },
+        "problemFiles": {
+            "archive": "CapLaserBELLA.zip"
+        },
         "setupArguments": {
             "auto": "1",
             "d": 2,

--- a/sirepo/package_data/template/flash/examples/caplaserbella.json
+++ b/sirepo/package_data/template/flash/examples/caplaserbella.json
@@ -765,6 +765,25 @@
             "hx_ieTimeCoef": 1,
             "hx_relTol": -1
         },
+        "setupArguments": {
+            "auto": "1",
+            "d": 2,
+            "ed_maxBeams": 1,
+            "ed_maxPulseSections": 4,
+            "ed_maxPulses": 1,
+            "hdf5typeio": "1",
+            "laser": "1",
+            "mgd": "1",
+            "mgd_meshgroups": 6,
+            "mtmmmt": "1",
+            "nxb": 8,
+            "nyb": 8,
+            "species": "fill,wall",
+            "units": [
+               "physics/sourceTerms/Heatexchange/HeatexchangeMain/LeeMore"
+            ],
+            "usm3t": "1"
+        },
         "simFolder": {},
         "simulation": {
             "documentationUrl": "",

--- a/sirepo/package_data/template/flash/examples/rtflame.json
+++ b/sirepo/package_data/template/flash/examples/rtflame.json
@@ -765,6 +765,9 @@
             "hx_ieTimeCoef": 1,
             "hx_relTol": -1
         },
+        "problemFiles": {
+            "archive": null
+        },
         "setupArguments": {
             "auto": "1",
             "d": 2,

--- a/sirepo/package_data/template/flash/examples/rtflame.json
+++ b/sirepo/package_data/template/flash/examples/rtflame.json
@@ -765,6 +765,12 @@
             "hx_ieTimeCoef": 1,
             "hx_relTol": -1
         },
+        "setupArguments": {
+            "auto": "1",
+            "d": 2,
+            "nxb": 16,
+            "nyb": 16
+        },
         "simFolder": {},
         "simulation": {
             "documentationUrl": "",

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -27,7 +27,7 @@ import shutil
 def audit_proprietary_lib_files(*uid):
     """Add/removes proprietary files based on a user's roles
 
-    For example, add the Flash rpm if user has the flash role.
+    For example, add the FLASH proprietary files if user has the sim_type_flash role.
 
     Args:
         *uid: UID(s) of the user(s) to audit. If None, all users will be audited.

--- a/sirepo/pkcli/flash.py
+++ b/sirepo/pkcli/flash.py
@@ -6,10 +6,13 @@
 """
 from __future__ import absolute_import, division, print_function
 from pykern import pkio
+from pykern import pkjson
 from pykern.pkdebug import pkdp, pkdc
 from sirepo import mpi
 from sirepo import simulation_db
 from sirepo.template import template_common
+import os
+import re
 import sirepo.sim_data
 import sirepo.template.flash as template
 import subprocess
@@ -22,3 +25,18 @@ def run_background(cfg_dir):
             template_common.INPUT_BASE_NAME,
         )),
     )])
+
+
+def units(src_path):
+    res = []
+    p = pkio.py_path(src_path).join('source')
+    for d, _, _ in os.walk(p):
+        m = re.search(
+            r'^(?:{})(.*\/[A-Z0-9][A-Za-z0-9-_\.]+$)'.format(re.escape(str(p))),
+            d,
+        )
+        if m:
+            s = m.group(1)[1:]
+            res.append([s, s])
+    res.sort()
+    pkjson.dump_pretty(res, filename='res.json')

--- a/sirepo/pkcli/setup_dev.py
+++ b/sirepo/pkcli/setup_dev.py
@@ -19,19 +19,19 @@ def default_command():
         'Only to be used in dev. channel={}'.format(pkconfig.cfg.channel)
     cfg = pkconfig.init(
         proprietary_code_uri=(
-            f'file://{pathlib.Path.home()}/src/radiasoft/rsconf/rpm',
+            f'file://{pathlib.Path.home()}/src/radiasoft/rsconf/proprietary',
             str,
-            'root uri of RPMs',
+            'root uri of proprietary codes files location',
         ),
     )
     _proprietary_codes()
 
 
 def _proprietary_codes():
-    """Get proprietary tarballs and put it in the proprietary code dir
+    """Get proprietary files and put it in the proprietary code dir
 
     Args:
-      uri (str): where to get tarball (file:// or http://)
+      uri (str): where to get file (file:// or http://)
     """
     import sirepo.feature_config
     import sirepo.sim_data
@@ -46,16 +46,14 @@ def _proprietary_codes():
         r = pkio.mkdir_parent(
             sirepo.srdb.proprietary_code_dir(s),
         ).join(f)
-        # POSIT: download/installers/rpm-code/dev-build.sh
-        # TODO(e-carlin): need to fix all of the rsconf code and install code to now handle tarballs
-        # manually moving files for now
-        u = f'{cfg.proprietary_code_uri}/{f}'
+        # POSIT: download/installers/flash-tarball/radiasoft-download.sh
+        u = f'{cfg.proprietary_code_uri}/{s}-dev.tar.gz'
         try:
             urllib.request.urlretrieve(u, r)
         except urllib.error.URLError as e:
             if not isinstance(e.reason, FileNotFoundError):
                 raise
-            pkdlog('uri={} not found; mocking empty rpm={}', u, r)
+            pkdlog('uri={} not found; mocking empty file={}', u, r)
             pkio.write_text(
                 r,
                 'mocked by sirepo.pkcli.setup_dev',

--- a/sirepo/pkcli/setup_dev.py
+++ b/sirepo/pkcli/setup_dev.py
@@ -40,14 +40,16 @@ def _proprietary_codes():
     import urllib.request
 
     for s in sirepo.feature_config.cfg().proprietary_sim_types:
-        f = sirepo.sim_data.get_class(s).proprietary_code_rpm()
+        f = sirepo.sim_data.get_class(s).proprietary_code_tarball()
         if not f:
             return
         r = pkio.mkdir_parent(
             sirepo.srdb.proprietary_code_dir(s),
         ).join(f)
         # POSIT: download/installers/rpm-code/dev-build.sh
-        u = f'{cfg.proprietary_code_uri}/rscode-{s}-dev.rpm'
+        # TODO(e-carlin): need to fix all of the rsconf code and install code to now handle tarballs
+        # manually moving files for now
+        u = f'{cfg.proprietary_code_uri}/{f}'
         try:
             urllib.request.urlretrieve(u, r)
         except urllib.error.URLError as e:

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -549,10 +549,10 @@ def api_updateFolder():
     req = http_request.parse_post()
     o = srschema.parse_folder(req.req_data['oldName'])
     if o == '/':
-        raise util.Error('cannot rename root ("/") folder')
+        raise sirepo.util.Error('cannot rename root ("/") folder')
     n = srschema.parse_folder(req.req_data['newName'])
     if n == '/':
-        raise util.Error('cannot folder to root ("/")')
+        raise sirepo.util.Error('cannot folder to root ("/")')
     for r in simulation_db.iterate_simulation_datafiles(req.type, _simulation_data_iterator):
         f = r.models.simulation.folder
         l = o.lower()

--- a/sirepo/sim_data/__init__.py
+++ b/sirepo/sim_data/__init__.py
@@ -474,8 +474,12 @@ class SimDataBase(object):
         return 2 if cls.is_parallel(data) else 1
 
     @classmethod
-    def proprietary_code_rpm(cls):
+    def proprietary_code_tarball(cls):
         return None
+
+    @classmethod
+    def proprietary_code_lib_file_basenames(cls):
+        return []
 
     @classmethod
     def put_sim_file(cls, file_path, basename, data):
@@ -689,8 +693,8 @@ class SimDataBase(object):
             dm.simulation.folder = '/Examples'
 
     @classmethod
-    def _proprietary_code_rpm(cls):
-        return f'{cls.sim_type()}.rpm'
+    def _proprietary_code_tarball(cls):
+        return f'{cls.sim_type()}.tar.gz'
 
     @classmethod
     def _put_sim_db_file(cls, file_path, uri):
@@ -731,10 +735,6 @@ class SimDataBase(object):
             data.models.simulation.simulationId,
             basename,
         )
-
-    @classmethod
-    def _sim_src_tarball_path(cls):
-        return cfg.local_share_dir.join(cls.sim_type(), f'{cls.sim_type()}.tar.gz')
 
 
 class SimDbFileNotFound(Exception):

--- a/sirepo/sim_data/flash.py
+++ b/sirepo/sim_data/flash.py
@@ -232,7 +232,7 @@ class SimData(sirepo.sim_data.SimDataBase):
 
     @classmethod
     def _flash_src_tarball_basename(cls):
-        return 'source.tar.gz'
+        return 'flash.tar.gz'
 
     @classmethod
     def _lib_file_basenames(cls, data):

--- a/sirepo/sim_data/flash.py
+++ b/sirepo/sim_data/flash.py
@@ -13,6 +13,7 @@ import re
 import sirepo.sim_data
 import sirepo.simulation_db
 import sirepo.util
+import zipfile
 
 
 
@@ -32,6 +33,7 @@ class SimData(sirepo.sim_data.SimDataBase):
             if m != n:
                 dm[n] = dm[m]
                 del dm[m]
+        cls.__fixup_old_data_problem_files(data)
         cls.__fixup_old_data_setup_arguments(data)
         cls._init_models(dm)
         if dm.simulation.flashType == 'CapLaser':
@@ -116,8 +118,16 @@ class SimData(sirepo.sim_data.SimDataBase):
         return cls._flash_file_basename(cls._FLASH_SETUP_UNITS_PREFIX, data)
 
     @classmethod
-    def proprietary_code_rpm(cls):
-        return cls._proprietary_code_rpm()
+    def proprietary_code_tarball(cls):
+        return cls._proprietary_code_tarball()
+
+    @classmethod
+    def proprietary_code_lib_file_basenames(cls):
+        return [
+            'problemFiles-archive.CapLaser3D.zip',
+            'problemFiles-archive.CapLaserBELLA.zip',
+            cls._flash_src_tarball_basename(),
+        ]
 
     @classmethod
     def sim_files_to_run_dir(cls, data, run_dir):
@@ -136,26 +146,33 @@ class SimData(sirepo.sim_data.SimDataBase):
         import sirepo.template.flash
         import subprocess
 
-        with open(cls.lib_file_abspath(cls.proprietary_code_rpm())) as i:
-            subprocess.check_output(
-                "rpm2cpio - | cpio --extract --make-directories",
-                cwd='/',
-                #SECURITY: No user defined input in cmd so shell=True is ok
-                shell=True,
-                stderr=subprocess.STDOUT,
-                stdin=i,
-            )
         subprocess.check_output(
             [
                 'tar',
                 '--extract',
                 '--gunzip',
-                f'--file={cls._sim_src_tarball_path()}',
+                f'--file={cls._flash_src_tarball_basename()}',
                 f'--directory={run_dir}',
             ],
             stderr=subprocess.STDOUT,
         )
         s = run_dir.join(cls.sim_type())
+        if data.models.problemFiles.archive:
+            for i, r in cls._flash_extract_problem_files_archive(
+                    run_dir.join(cls._flash_problem_files_archive_basename(data)),
+            ):
+                b = pkio.py_path(i.filename).basename
+                if not re.match(r'(\w+\.F90)|(Config)|(Makefile)', b):
+                    continue
+                p = s.join(
+                    'source',
+                    'Simulation',
+                    'SimulationMain',
+                    data.models.simulation.flashType,
+                    b,
+                )
+                pkio.mkdir_parent_only(p)
+                pkio.write_text(p, r())
         t = s.join(data.models.simulation.flashType)
         with run_dir.join(template_common.COMPILE_LOG).open('w') as log:
             k = PKDict(
@@ -176,14 +193,29 @@ class SimData(sirepo.sim_data.SimDataBase):
             p.move(run_dir.join(b))
 
     @classmethod
+    def _flash_extract_problem_files_archive(cls, path):
+        with zipfile.ZipFile(path, 'r') as z:
+            for i in z.infolist():
+                yield i, lambda: z.read(i)
+
+    @classmethod
     def _flash_file_basename(cls, prefix, data):
         return prefix + cls._FLASH_FILE_NAME_SEP + cls._flash_file_hash(data)
 
     @classmethod
     def _flash_file_hash(cls, data):
+        f = []
+        if data.models.problemFiles.archive:
+            f = [r() for _, r in cls._flash_extract_problem_files_archive(
+                cls.lib_file_abspath(
+                    cls._flash_problem_files_archive_basename(data),
+                    data=data,
+                ),
+            )]
         return sirepo.util.url_safe_hash(str((
             data.models.simulation.flashType,
             data.models.setupArguments,
+            f,
         )))
 
     @classmethod
@@ -191,17 +223,32 @@ class SimData(sirepo.sim_data.SimDataBase):
         return basename.split(cls._FLASH_FILE_NAME_SEP)[0]
 
     @classmethod
+    def _flash_problem_files_archive_basename(cls, data):
+       return cls.lib_file_name_with_model_field(
+           'problemFiles',
+            'archive',
+            data.models.problemFiles.archive,
+       )
+
+    @classmethod
+    def _flash_src_tarball_basename(cls):
+        return 'source.tar.gz'
+
+    @classmethod
     def _lib_file_basenames(cls, data):
         t = data.models.simulation.flashType
+        r = [cls._flash_src_tarball_basename()]
+        if data.models.problemFiles.archive:
+            r.append(cls._flash_problem_files_archive_basename(data))
         if t == 'RTFlame':
-            return ['helm_table.dat']
+            return r + ['helm_table.dat']
         if 'CapLaser' in t:
-            r = [
+            r.extend([
                 'alumina-wall-imx.cn4',
                 'argon-fill-imx.cn4',
                 'helium-fill-imx.cn4',
                 'hydrogen-fill-imx.cn4',
-            ]
+            ])
             if t == 'CapLaserBELLA'  and data.models['SimulationCapLaserBELLA'].sim_currType == '2':
                 r.append(cls.lib_file_name_with_model_field(
                     'SimulationCapLaserBELLA',
@@ -217,6 +264,17 @@ class SimData(sirepo.sim_data.SimDataBase):
             PKDict(basename=cls.flash_exe_basename(data), is_exe=True),
             PKDict(basename=cls.flash_setup_units_basename(data)),
         ]
+
+    @classmethod
+    def __fixup_old_data_problem_files(cls, data):
+        dm = data.models
+        if 'problemFiles' in dm:
+            return
+        f = None
+        t = dm.simulation.flashType
+        if 'CapLaser' in t:
+            f = f'{t}.zip'
+        dm.problemFiles = PKDict(archive=f)
 
     @classmethod
     def __fixup_old_data_setup_arguments(cls, data):


### PR DESCRIPTION
~~This branch is __not__ ready to be merged. There is work to be done in the installer and possibly rsconf to handle the changes in how the distribution of FLASH is performed. But, these changes can be reviewed while I’m working on them.~~
The pr's are open: radiasoft/download#149 and radiasoft/rsconf#138

This branch is base off radiasoft/sirepoflash/issue/16-setup-command. Please review and merge #3325 before reviewing this.


Users can now upload a ZIP archive containing FLASH problem files
(F90, Config, and Makefile). These will be unpacked in the proper location
in the FLASH source code and used when compiling.

Some notable changes:
- The FLASH source code is no longer distributed as an rpm. It is
distributed as a tarball that lives in the user's lib dir.
- CapLaser3D and CapLaserBELLA are no longer distributed inside
of the FLASH source code. They are now files in the lib dir. They are
distributed alongside the FLASH source code. Upon getting the FLASH role
they are unpacked in the user's lib dir.
