### PR TITLE
Issue/3354 audit force

### DIFF
--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -612,7 +612,6 @@ def _init():
         return
     global logged_in_user, user_dir_not_found
 
-
     def logged_in_user(*args, **kwargs):
         return cfg.logged_in_user
 

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -402,7 +402,7 @@ def set_user_outside_of_flask_request(uid=None):
     """A user set explicitly outside of flask request cycle"""
     assert not util.in_flask_request(), \
         'Only call from outside a flask request context'
-    with cookie.set_cookie_for_utils():
+    with cookie.set_cookie_outside_of_flask_request():
         import sirepo.auth.guest
         if uid:
             _login_user(sirepo.auth.guest, uid)

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -194,7 +194,6 @@ def logged_in_user(check_path=True):
             cookie.unchecked_get_value(_COOKIE_METHOD),
         )
     if check_path:
-        # TODO(e-carlin): simulation_db won't be initialized in a context outside of server
         simulation_db.user_path(u, check=True)
     return u
 

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -64,8 +64,6 @@ def audit_proprietary_lib_files(uid):
 
     def _add(proprietary_code_dir, sim_type, sim_data_class):
         p = proprietary_code_dir.join(sim_data_class.proprietary_code_tarball())
-        # TODO(e-carlin): discuss with rn what we should do if this fails
-        # This was what through an error and caused the migration not to finish
         sirepo.simulation_db.verify_app_directory(sim_type, uid=uid)
         with sirepo.simulation_db.tmp_dir(chdir=True, uid=uid) as t:
             d = t.join(p.basename)

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -43,16 +43,19 @@ def all_uids():
     return UserRegistration.search_all_for_column('uid')
 
 
-def audit_proprietary_lib_files():
+def audit_proprietary_lib_files(uid):
     """Add/removes proprietary files based on a user's roles
 
     For example, add the Flash tarball if user has the flash role.
+
+    Args:
+      uid (str): The uid of the user to audit
     """
     import contextlib
     import py
     import pykern.pkconfig
     import pykern.pkio
-    import sirepo.auth
+    import sirepo.auth_role
     import sirepo.feature_config
     import sirepo.sim_data
     import sirepo.simulation_db
@@ -61,8 +64,10 @@ def audit_proprietary_lib_files():
 
     def _add(proprietary_code_dir, sim_type, sim_data_class):
         p = proprietary_code_dir.join(sim_data_class.proprietary_code_tarball())
-        sirepo.simulation_db.verify_app_directory(sim_type)
-        with sirepo.simulation_db.tmp_dir(chdir=True) as t:
+        # TODO(e-carlin): discuss with rn what we should do if this fails
+        # This was what through an error and caused the migration not to finish
+        sirepo.simulation_db.verify_app_directory(sim_type, uid=uid)
+        with sirepo.simulation_db.tmp_dir(chdir=True, uid=uid) as t:
             d = t.join(p.basename)
             d.mksymlinkto(p, absolute=False)
             subprocess.check_output(
@@ -74,7 +79,7 @@ def audit_proprietary_lib_files():
                 ],
                 stderr=subprocess.STDOUT,
             )
-            l = sirepo.simulation_db.simulation_lib_dir(sim_type)
+            l = sirepo.simulation_db.simulation_lib_dir(sim_type, uid=uid)
             e = [f.basename for f in pykern.pkio.sorted_glob(l.join('*'))]
             for f in sim_data_class.proprietary_code_lib_file_basenames():
                 if f not in e:
@@ -89,13 +94,14 @@ def audit_proprietary_lib_files():
             f'{d} proprietary_code_dir must exist' \
             + ('; run: sirepo setup_dev' if pykern.pkconfig.channel_in('dev') else '')
         r = UserRole.has_role(
-            sirepo.auth.logged_in_user(),
-            sirepo.auth.role_for_sim_type(t),
+            uid,
+            sirepo.auth_role.role_for_sim_type(t),
         )
         if r:
             _add(d, t, c)
             continue
-        pykern.pkio.unchecked_remove(sirepo.simulation_db.simulation_dir(t))
+        # SECURITY: User no longer has access so remove all artifacts
+        pykern.pkio.unchecked_remove(sirepo.simulation_db.simulation_dir(t, uid=uid))
 
 
 def init():
@@ -189,35 +195,29 @@ def init():
                 ]
 
         @classmethod
-        def add_roles(cls, roles):
-            import sirepo.auth
-
+        def add_roles(cls, uid, roles):
             with thread_lock:
                 for r in roles:
-                    UserRole(uid=sirepo.auth.logged_in_user(), role=r).save()
-                audit_proprietary_lib_files()
+                    UserRole(uid=uid, role=r).save()
+                audit_proprietary_lib_files(uid)
 
         @classmethod
-        def delete_roles(cls, roles):
-            import sirepo.auth
-
+        def delete_roles(cls, uid, roles):
             with thread_lock:
                 cls._session.query(cls).filter(
-                    cls.uid == sirepo.auth.logged_in_user(),
+                    cls.uid == uid,
                 ).filter(
                     cls.role.in_(roles),
                 ).delete(synchronize_session='fetch')
                 cls._session.commit()
-                audit_proprietary_lib_files()
+                audit_proprietary_lib_files(uid)
 
         @classmethod
-        def get_roles(cls, check_path=True):
-            import sirepo.auth
-
+        def get_roles(cls, uid):
             with thread_lock:
                 return UserRole.search_all_for_column(
                     'role',
-                    uid=sirepo.auth.logged_in_user(check_path=check_path),
+                    uid=uid,
                 )
 
 
@@ -228,11 +228,11 @@ def init():
 
         @classmethod
         def uids_of_paid_users(cls):
-            import sirepo.auth
+            import sirepo.auth_role
 
             return [
                 x[0] for x in cls._session.query(cls).with_entities(cls.uid).filter(
-                    cls.role.in_(sirepo.auth.PAID_USER_ROLES),
+                    cls.role.in_(sirepo.auth_role.PAID_USER_ROLES),
                 ).distinct().all()
             ]
     UserDbBase.metadata.create_all(_engine)
@@ -303,13 +303,12 @@ def _migrate_db_file(fn):
 
 
 def _migrate_role_jupyterhub():
-    import sirepo.auth
+    import sirepo.auth_role
     import sirepo.template
 
-    r = sirepo.auth.role_for_sim_type('jupyterhublogin')
+    r = sirepo.auth_role.role_for_sim_type('jupyterhublogin')
     if not sirepo.template.is_sim_type('jupyterhublogin') or \
        r in UserRole.all_roles():
         return
     for u in all_uids():
-        with sirepo.auth.set_user_outside_of_flask_request(u):
-            UserRole.add_roles([r])
+        UserRole.add_roles(u, [r])

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -311,5 +311,5 @@ def _migrate_role_jupyterhub():
        r in UserRole.all_roles():
         return
     for u in all_uids():
-        with sirepo.auth.set_user(u):
+        with sirepo.auth.set_user_outside_of_flask_request(u):
             UserRole.add_roles([r])

--- a/sirepo/auth_role.py
+++ b/sirepo/auth_role.py
@@ -14,10 +14,6 @@ ROLE_PAYMENT_PLAN_PREMIUM = 'premium'
 
 PAID_USER_ROLES = (ROLE_PAYMENT_PLAN_PREMIUM, ROLE_PAYMENT_PLAN_ENTERPRISE)
 
-# TODO(e-carlin): go through all of auth and move any funcs
-# with role into here. Also just search for role and see
-# if there is other stuff that can be here
-
 
 def check_user_has_role(uid, role, raise_forbidden=True):
     if sirepo.auth_db.UserRole.has_role(uid, role):
@@ -27,17 +23,15 @@ def check_user_has_role(uid, role, raise_forbidden=True):
     return False
 
 
-
-# TODO(e-carlin): fix all uses of this method to point to here
 def get_all_roles():
     return [
         role_for_sim_type(t) for t in sirepo.feature_config.cfg().proprietary_sim_types
     ] + [
-        # TODO(e-carlin): mv role_ into here
         ROLE_ADM,
         ROLE_PAYMENT_PLAN_ENTERPRISE,
         ROLE_PAYMENT_PLAN_PREMIUM,
     ]
+
 
 def role_for_sim_type(sim_type):
     return 'sim_type_' + sim_type

--- a/sirepo/auth_role.py
+++ b/sirepo/auth_role.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+u"""User roles
+
+:copyright: Copyright (c) 2021 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from __future__ import absolute_import, division, print_function
+import sirepo.auth_db
+import sirepo.util
+
+ROLE_ADM = 'adm'
+ROLE_PAYMENT_PLAN_ENTERPRISE = 'enterprise'
+ROLE_PAYMENT_PLAN_PREMIUM = 'premium'
+
+PAID_USER_ROLES = (ROLE_PAYMENT_PLAN_PREMIUM, ROLE_PAYMENT_PLAN_ENTERPRISE)
+
+# TODO(e-carlin): go through all of auth and move any funcs
+# with role into here. Also just search for role and see
+# if there is other stuff that can be here
+
+
+def check_user_has_role(uid, role, raise_forbidden=True):
+    if sirepo.auth_db.UserRole.has_role(uid, role):
+        return True
+    if raise_forbidden:
+        sirepo.util.raise_forbidden('uid={} role={} not found'.format(uid, role))
+    return False
+
+
+
+# TODO(e-carlin): fix all uses of this method to point to here
+def get_all_roles():
+    return [
+        role_for_sim_type(t) for t in sirepo.feature_config.cfg().proprietary_sim_types
+    ] + [
+        # TODO(e-carlin): mv role_ into here
+        ROLE_ADM,
+        ROLE_PAYMENT_PLAN_ENTERPRISE,
+        ROLE_PAYMENT_PLAN_PREMIUM,
+    ]
+
+def role_for_sim_type(sim_type):
+    return 'sim_type_' + sim_type

--- a/sirepo/cookie.py
+++ b/sirepo/cookie.py
@@ -125,8 +125,6 @@ def _set_cookie(header):
         sirepo.srcontext.set(_SRCONTEXT_COOKIE_STATE_KEY, p)
 
 
-# TODO(e-carlin): change to PKDict
-# srcontext expects pkdict because it calls pkdel?
 class _State(dict):
 
     def __init__(self, header):

--- a/sirepo/db_upgrade.py
+++ b/sirepo/db_upgrade.py
@@ -30,7 +30,7 @@ def do_all():
         ).save()
 
 
-def _20210211_add_flash_proprietary_lib_files():
+def _20210211_add_flash_proprietary_lib_files(force=False):
     """Add proprietary lib files to existing FLASH users' lib dir"""
 
     if not sirepo.template.is_sim_type('flash'):
@@ -42,7 +42,7 @@ def _20210211_add_flash_proprietary_lib_files():
             uid=u,
         ).join('flash.rpm'))
         # Add's the flash proprietary lib files (unpacks flash.tar.gz)
-        sirepo.auth_db.audit_proprietary_lib_files(u)
+        sirepo.auth_db.audit_proprietary_lib_files(u, force=force, sim_types=set(('flash',)))
 
 
 def _20210211_upgrade_runner_to_job_db():
@@ -145,3 +145,7 @@ def _20210211_upgrade_runner_to_job_db():
                 k.error = getattr(e, 'args', []) or e
                 s += ' error={error}'
             pkdlog(s, **k)
+
+
+def _20210218_add_flash_proprietary_lib_files_force():
+    _20210211_add_flash_proprietary_lib_files(force=True)

--- a/sirepo/db_upgrade.py
+++ b/sirepo/db_upgrade.py
@@ -36,7 +36,7 @@ def _20210211_add_flash_proprietary_lib_files():
     if not sirepo.template.is_sim_type('flash'):
         return
     for u in sirepo.auth_db.all_uids():
-        with sirepo.auth.set_user(u):
+        with sirepo.auth.set_user_outside_of_flask_request(u):
             # Remove the existing rpm
             pkio.unchecked_remove(sirepo.simulation_db.simulation_lib_dir(
                 'flash',

--- a/sirepo/db_upgrade.py
+++ b/sirepo/db_upgrade.py
@@ -36,13 +36,13 @@ def _20210211_add_flash_proprietary_lib_files():
     if not sirepo.template.is_sim_type('flash'):
         return
     for u in sirepo.auth_db.all_uids():
-        with sirepo.auth.set_user_outside_of_flask_request(u):
-            # Remove the existing rpm
-            pkio.unchecked_remove(sirepo.simulation_db.simulation_lib_dir(
-                'flash',
-            ).join('flash.rpm'))
-            # Add's the flash proprietary lib files (unpacks flash.tar.gz)
-            sirepo.auth_db.audit_proprietary_lib_files()
+        # Remove the existing rpm
+        pkio.unchecked_remove(sirepo.simulation_db.simulation_lib_dir(
+            'flash',
+            uid=u,
+        ).join('flash.rpm'))
+        # Add's the flash proprietary lib files (unpacks flash.tar.gz)
+        sirepo.auth_db.audit_proprietary_lib_files(u)
 
 
 def _20210211_upgrade_runner_to_job_db():

--- a/sirepo/http_reply.py
+++ b/sirepo/http_reply.py
@@ -75,8 +75,8 @@ def gen_file_as_attachment(content_or_path, filename=None, content_type=None):
         if isinstance(content_or_path, pkconst.PY_PATH_LOCAL_TYPE):
             return flask.send_file(str(content_or_path))
         if content_type == 'application/json':
-            return flask.current_app.response_class(pkjson.dump_pretty(content_or_path))
-        return flask.current_app.response_class(content_or_path)
+            return sirepo.util.flask_app().response_class(pkjson.dump_pretty(content_or_path))
+        return sirepo.util.flask_app().response_class(content_or_path)
 
     if filename is None:
         # dies if content_or_path is not a path
@@ -105,7 +105,7 @@ def gen_json(value, pretty=False, response_kwargs=None):
     Returns:
         flask.Response: reply object
     """
-    app = flask.current_app
+    app = sirepo.util.flask_app()
     if not response_kwargs:
         response_kwargs = PKDict()
     return app.response_class(
@@ -323,7 +323,7 @@ def _gen_exception_reply_Redirect(args):
 
 def _gen_exception_reply_Response(args):
     r = args.response
-    assert isinstance(r, flask.current_app.response_class), \
+    assert isinstance(r, sirepo.util.flask_app().response_class), \
         'invalid class={} response={}'.format(type(r), r)
     return r
 

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -39,7 +39,10 @@ def adjust_supervisor_srtime(days):
 
 @api_perm.require_user
 def api_admJobs():
-    sirepo.auth.check_user_has_role(sirepo.auth.ROLE_ADM)
+    sirepo.auth_role.check_user_has_role(
+        sirepo.auth.logged_in_user(),
+        sirepo.auth_role.ROLE_ADM,
+    )
     return _request(
         _request_content=PKDict(**sirepo.http_request.parse_post()),
     )

--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -128,7 +128,7 @@ class DriverBase(PKDict):
 
     def make_lib_dir_symlink(self, op):
         m = op.msg
-        with sirepo.auth.set_user(m.uid):
+        with sirepo.auth.set_user_outside_of_flask_request(m.uid):
             d = sirepo.simulation_db.simulation_lib_dir(m.simulationType)
             op.lib_dir_symlink = job.LIB_FILE_ROOT.join(
                 job.unique_key()

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -291,7 +291,7 @@ class _ComputeJob(PKDict):
                 - cfg.purge_non_premium_after_secs
             )
             for u, v in _get_uids_and_files():
-                with sirepo.auth.set_user(u):
+                with sirepo.auth.set_user_outside_of_flask_request(u):
                     for f in v:
                         _purge_sim(jid=f.purebasename)
                 await tornado.gen.sleep(0)

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function
 from pykern import pkconfig
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp
+import contextlib
 import jupyterhub.auth
 import sirepo.auth
 import sirepo.cookie
@@ -32,42 +33,43 @@ class Authenticator(jupyterhub.auth.Authenticator):
         sirepo.server.init()
 
     async def authenticate(self, handler, data):
-        _set_cookie(handler)
-        try:
-            sirepo.auth.require_user()
-            sirepo.auth.require_sim_type('jupyterhublogin')
-        except werkzeug.exceptions.Forbidden:
-            # returning None means the user is forbidden (403)
-            # https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.authenticate
-            return None
-        except sirepo.util.SRException as e:
-            r = e.sr_args.get('routeName')
-            if r not in ('completeRegistration', 'login', 'loginFail'):
-                raise
-            handler.redirect(f'{_JUPYTERHUBLOGIN_ROUTE}#/{r}')
-            raise tornado.web.Finish()
-        u = sirepo.sim_api.jupyterhublogin.unchecked_jupyterhub_user_name(
-            have_simulation_db=False,
-        )
-        if not u:
-            handler.redirect(f'{_JUPYTERHUBLOGIN_ROUTE}')
-            raise tornado.web.Finish()
-        return u
+        with _set_cookie(handler):
+            try:
+                sirepo.auth.require_user()
+                sirepo.auth.require_sim_type('jupyterhublogin')
+            except werkzeug.exceptions.Forbidden:
+                # returning None means the user is forbidden (403)
+                # https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.authenticate
+                return None
+            except sirepo.util.SRException as e:
+                r = e.sr_args.get('routeName')
+                if r not in ('completeRegistration', 'login', 'loginFail'):
+                    raise
+                handler.redirect(f'{_JUPYTERHUBLOGIN_ROUTE}#/{r}')
+                raise tornado.web.Finish()
+            u = sirepo.sim_api.jupyterhublogin.unchecked_jupyterhub_user_name(
+                have_simulation_db=False,
+            )
+            if not u:
+                handler.redirect(f'{_JUPYTERHUBLOGIN_ROUTE}')
+                raise tornado.web.Finish()
+            return u
 
     async def refresh_user(self, user, handler=None):
-        _set_cookie(handler)
-        try:
-            sirepo.auth.require_user()
-        except sirepo.util.SRException:
-            # Returning False is what the jupyterhub API expects and jupyterhub
-            # will handle re-authenticating the user.
-            # https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.refresh_user
-            return False
-        return True
+        with _set_cookie(handler):
+            try:
+                sirepo.auth.require_user()
+            except sirepo.util.SRException:
+                # Returning False is what the jupyterhub API expects and jupyterhub
+                # will handle re-authenticating the user.
+                # https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.refresh_user
+                return False
+            return True
 
 
+@contextlib.contextmanager
 def _set_cookie(handler):
-    # TODO(e-carlin): impl with
-    sirepo.cookie.set_cookie_for_utils(
+    with sirepo.cookie.set_cookie_for_utils(
         handler.get_cookie(sirepo.cookie.cfg.http_name),
-    )
+    ):
+        yield

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -69,7 +69,7 @@ class Authenticator(jupyterhub.auth.Authenticator):
 
 @contextlib.contextmanager
 def _set_cookie(handler):
-    with sirepo.cookie.set_cookie_for_utils(
+    with sirepo.cookie.set_cookie_outside_of_flask_request(
         handler.get_cookie(sirepo.cookie.cfg.http_name),
     ):
         yield

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -67,6 +67,7 @@ class Authenticator(jupyterhub.auth.Authenticator):
 
 
 def _set_cookie(handler):
+    # TODO(e-carlin): impl with
     sirepo.cookie.set_cookie_for_utils(
         handler.get_cookie(sirepo.cookie.cfg.http_name),
     )

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -40,8 +40,7 @@ def audit_proprietary_lib_files(*uid):
 
     #TODO(robnagler) locking
     for u in uid or sirepo.auth_db.all_uids():
-        with sirepo.auth.set_user_outside_of_flask_request(u):
-            sirepo.auth_db.audit_proprietary_lib_files()
+        sirepo.auth_db.audit_proprietary_lib_files(u)
 
 
 def create_examples():

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -40,7 +40,7 @@ def audit_proprietary_lib_files(*uid):
 
     #TODO(robnagler) locking
     for u in uid or sirepo.auth_db.all_uids():
-        with sirepo.auth.set_user(u):
+        with sirepo.auth.set_user_outside_of_flask_request(u):
             sirepo.auth_db.audit_proprietary_lib_files()
 
 
@@ -54,16 +54,16 @@ def create_examples():
         if _is_src_dir(d):
             continue;
         uid = simulation_db.uid_from_dir_name(d)
-        auth.set_user_for_utils(uid)
-        for sim_type in feature_config.cfg().sim_types:
-            simulation_db.verify_app_directory(sim_type)
-            names = [x.name for x in simulation_db.iterate_simulation_datafiles(
-                sim_type, simulation_db.process_simulation_list, {
-                    'simulation.isExample': True,
-                })]
-            for example in simulation_db.examples(sim_type):
-                if example.models.simulation.name not in names:
-                    _create_example(example)
+        with auth.set_user_outside_of_flask_request(uid):
+            for sim_type in feature_config.cfg().sim_types:
+                simulation_db.verify_app_directory(sim_type)
+                names = [x.name for x in simulation_db.iterate_simulation_datafiles(
+                    sim_type, simulation_db.process_simulation_list, {
+                        'simulation.isExample': True,
+                    })]
+                for example in simulation_db.examples(sim_type):
+                    if example.models.simulation.name not in names:
+                        _create_example(example)
 
 
 def move_user_sims(target_uid=''):

--- a/sirepo/pkcli/roles.py
+++ b/sirepo/pkcli/roles.py
@@ -83,5 +83,5 @@ def _parse_args(uid_or_email, roles):
         a = sirepo.auth.get_all_roles()
         assert set(roles).issubset(a), \
             'roles={} not a subset valid all_roles={}'.format(roles, a)
-    with sirepo.auth.set_user(u):
+    with sirepo.auth.set_user_outside_of_flask_request(u):
         yield

--- a/sirepo/pkcli/roles.py
+++ b/sirepo/pkcli/roles.py
@@ -8,9 +8,9 @@ from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdc, pkdexc, pkdlog, pkdp
 from sirepo.pkcli import admin
-import contextlib
 import pykern.pkcli
 import sirepo.auth
+import sirepo.auth_role
 import sirepo.auth_db
 import sirepo.server
 
@@ -22,8 +22,8 @@ def add(uid_or_email, *roles):
         *roles: The roles to assign to the user
     """
 
-    with _parse_args(uid_or_email, roles):
-        sirepo.auth_db.UserRole.add_roles(roles)
+    u = _parse_args(uid_or_email, roles)
+    sirepo.auth_db.UserRole.add_roles(u, roles)
 
 
 def add_roles(*args):
@@ -38,8 +38,8 @@ def delete(uid_or_email, *roles):
         *roles (args): The roles to delete
     """
 
-    with _parse_args(uid_or_email, []):
-        sirepo.auth_db.UserRole.delete_roles(roles)
+    u = _parse_args(uid_or_email, roles)
+    sirepo.auth_db.UserRole.delete_roles(u, roles)
 
 
 def delete_roles(*args):
@@ -53,8 +53,8 @@ def list(uid_or_email):
         uid_or_email (str): Uid or email of the user
     """
 
-    with _parse_args(uid_or_email, []):
-        return sirepo.auth_db.UserRole.get_roles()
+    u = _parse_args(uid_or_email, [])
+    sirepo.auth_db.UserRole.get_roles(u)
 
 
 def list_roles(*args):
@@ -65,7 +65,6 @@ def list_roles(*args):
 
 # TODO(e-carlin): This only works for email auth or using a uid
 # doesn't work for other auth methods (ex GitHub)
-@contextlib.contextmanager
 def _parse_args(uid_or_email, roles):
     sirepo.server.init()
 
@@ -80,8 +79,7 @@ def _parse_args(uid_or_email, roles):
     if not u:
         pykern.pkcli.command_error('uid_or_email={} not found', uid_or_email)
     if roles:
-        a = sirepo.auth.get_all_roles()
+        a = sirepo.auth_role.get_all_roles()
         assert set(roles).issubset(a), \
             'roles={} not a subset valid all_roles={}'.format(roles, a)
-    with sirepo.auth.set_user_outside_of_flask_request(u):
-        yield
+    return u

--- a/sirepo/pkcli/roles.py
+++ b/sirepo/pkcli/roles.py
@@ -54,7 +54,7 @@ def list(uid_or_email):
     """
 
     u = _parse_args(uid_or_email, [])
-    sirepo.auth_db.UserRole.get_roles(u)
+    return sirepo.auth_db.UserRole.get_roles(u)
 
 
 def list_roles(*args):

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -105,7 +105,7 @@ def jupyterhub():
     try:
         import jupyterhub
     except ImportError:
-        raise AssertionError('jupyterhub not installed. run `pip install jupyterhub`')
+        raise AssertionError('jupyterhub not installed. run `pip install jupyterhub==1.1.0 notebook`')
     import sirepo.sim_api.jupyterhublogin
     import sirepo.server
 

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -504,17 +504,15 @@ def api_srwLight():
 
 @api_perm.allow_visitor
 def api_srUnit():
-    # TODO(e-carlin): util.flask_app()
-    v = getattr(flask.current_app, SRUNIT_TEST_IN_REQUEST)
+    import sirepo.auth
+    import sirepo.cookie
+    v = getattr(sirepo.util.flask_app(), SRUNIT_TEST_IN_REQUEST)
     u =  contextlib.nullcontext
     if v.want_user:
-        import sirepo.auth
-        import sirepo.cookie
         sirepo.cookie.set_sentinel()
         sirepo.auth.login(sirepo.auth.guest, is_mock=True)
     with u():
         if v.want_cookie:
-            import sirepo.cookie
             sirepo.cookie.set_sentinel()
         v.op()
     return http_reply.gen_json_ok()

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -511,10 +511,9 @@ def api_srUnit():
     if v.want_user:
         sirepo.cookie.set_sentinel()
         sirepo.auth.login(sirepo.auth.guest, is_mock=True)
-    with u():
-        if v.want_cookie:
-            sirepo.cookie.set_sentinel()
-        v.op()
+    if v.want_cookie:
+        sirepo.cookie.set_sentinel()
+    v.op()
     return http_reply.gen_json_ok()
 
 
@@ -636,7 +635,6 @@ def init(uwsgi=None, use_reloader=False, is_server=False):
     sirepo.util.init(server_context=True)
     uri_router.init(_app, simulation_db)
     if is_server:
-        assert not sirepo.util.in_flask_request()
         sirepo.db_upgrade.do_all()
     return _app
 

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -30,6 +30,8 @@ JupyterhubUser = None
 
 _HUB_USER_SEP = '-'
 
+_JUPYTERHUB_LOGOUT_USER_NAME_ATTR = 'jupyterhub_logout_user_name'
+
 
 @sirepo.api_perm.require_user
 def api_migrateJupyterhub():
@@ -146,11 +148,11 @@ def _create_user(github_handle=None):
 
 
 def _event_auth_logout(kwargs):
-    flask.g.jupyterhub_logout_user_name = _unchecked_hub_user(kwargs.uid)
+    sirepo.srcontext.set(_JUPYTERHUB_LOGOUT_USER_NAME_ATTR, _unchecked_hub_user(kwargs.uid))
 
 
 def _event_end_api_call(kwargs):
-    u = flask.g.get('jupyterhub_logout_user_name', None)
+    u = sirepo.srcontext.get(_JUPYTERHUB_LOGOUT_USER_NAME_ATTR)
     if not u:
        return
     for c in (

--- a/sirepo/srcontext.py
+++ b/sirepo/srcontext.py
@@ -18,6 +18,7 @@ def get(key, default=None):
     return _context().get(key, default)
 
 
+# TODO(e-carlin): is this used anywhere?
 def pop(key, default=None):
     return _context().pkdel(key, default)
 

--- a/sirepo/srcontext.py
+++ b/sirepo/srcontext.py
@@ -18,9 +18,8 @@ def get(key, default=None):
     return _context().get(key, default)
 
 
-# TODO(e-carlin): is this used anywhere?
 def pop(key, default=None):
-    return _context().pkdel(key, default)
+    return _context().pop(key, default)
 
 
 def set(key, value):

--- a/sirepo/srcontext.py
+++ b/sirepo/srcontext.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+u"""Manage global context in threaded (Flask) and non-threaded (Tornado) applications
+
+:copyright: Copyright (c) 2021 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from __future__ import absolute_import, division, print_function
+from pykern.pkcollections import PKDict
+from pykern.pkdebug import pkdp
+import sirepo.util
+
+_FLASK_G_SR_CONTEXT_KEY = 'srcontext'
+
+_NON_THREADED_CONTEXT = PKDict()
+
+
+def get(key, default=None):
+    return _context().get(key, default)
+
+
+def pop(key, default=None):
+    return _context().pkdel(key, default)
+
+
+def set(key, value):
+    _context()[key] = value
+
+
+def setdefault(key, default=None):
+    return _context().setdefault(key, default)
+
+
+def _context():
+    if sirepo.util.in_flask_request():
+        import flask
+        return flask.g.setdefault(_FLASK_G_SR_CONTEXT_KEY, default=PKDict())
+    return _NON_THREADED_CONTEXT

--- a/sirepo/uri.py
+++ b/sirepo/uri.py
@@ -37,7 +37,7 @@ def app_root(sim_type):
     """Generate uri for application root
 
     Args:
-        sim_type (str): application name [flask.g.sirepo_sim_type]
+        sim_type (str): application name
 
     Returns:
         str: formatted URI

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -192,35 +192,35 @@ def _dispatch(path):
     Returns:
         Flask.response
     """
-    sirepo.auth.process_request()
-    try:
-        if path is None:
-            return call_api(_empty_route.func, {})
-        # werkzeug doesn't convert '+' to ' '
-        parts = re.sub(r'\+', ' ', path).split('/')
+    with sirepo.auth.process_request():
         try:
-            route = _uri_to_route[parts[0]]
-            parts.pop(0)
-        except KeyError:
-            # sim_types (applications)
-            route = _default_route
-        kwargs = PKDict()
-        for p in route.params:
-            if not parts:
-                if not p.is_optional:
-                    raise sirepo.util.raise_not_found('{}: uri missing parameter ({})', path, p.name)
-                break
-            if p.is_path_info:
-                kwargs[p.name] = '/'.join(parts)
-                parts = None
-                break
-            kwargs[p.name] = parts.pop(0)
-        if parts:
-            raise sirepo.util.raise_not_found('{}: unknown parameters in uri ({})', parts, path)
-        return call_api(route.func, kwargs)
-    except Exception as e:
-        pkdlog('exception={} path={} stack={}', e, path, pkdexc())
-        raise
+            if path is None:
+                return call_api(_empty_route.func, {})
+            # werkzeug doesn't convert '+' to ' '
+            parts = re.sub(r'\+', ' ', path).split('/')
+            try:
+                route = _uri_to_route[parts[0]]
+                parts.pop(0)
+            except KeyError:
+                # sim_types (applications)
+                route = _default_route
+            kwargs = PKDict()
+            for p in route.params:
+                if not parts:
+                    if not p.is_optional:
+                        raise sirepo.util.raise_not_found('{}: uri missing parameter ({})', path, p.name)
+                    break
+                if p.is_path_info:
+                    kwargs[p.name] = '/'.join(parts)
+                    parts = None
+                    break
+                kwargs[p.name] = parts.pop(0)
+            if parts:
+                raise sirepo.util.raise_not_found('{}: unknown parameters in uri ({})', parts, path)
+            return call_api(route.func, kwargs)
+        except Exception as e:
+            pkdlog('exception={} path={} stack={}', e, path, pkdexc())
+            raise
 
 
 def _dispatch_empty():

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -182,7 +182,6 @@ def err(obj, fmt='', *args, **kwargs):
 
 
 def flask_app():
-    # TODO(e-carlin): I think we may want to remove this and always use in_flask_request
     import flask
 
     return flask.current_app or None

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -182,9 +182,15 @@ def err(obj, fmt='', *args, **kwargs):
 
 
 def flask_app():
+    # TODO(e-carlin): I think we may want to remove this and always use in_flask_request
     import flask
 
     return flask.current_app or None
+
+def in_flask_request():
+    import flask
+
+    return flask.request or None
 
 
 def init(server_context=False):

--- a/tests/adm_and_own_jobs_test.py
+++ b/tests/adm_and_own_jobs_test.py
@@ -68,7 +68,7 @@ def test_srw_user_see_only_own_jobs(auth_fc):
     from pykern import pkunit
     from pykern.pkdebug import pkdp
     import sirepo.auth_db
-    import sirepo.auth
+    import sirepo.auth_role
 
     def _cancel_job(user, cancel_req):
         _login_as_user(user)
@@ -114,9 +114,11 @@ def test_srw_user_see_only_own_jobs(auth_fc):
 
     def _make_user_adm(uid):
         import sirepo.pkcli.roles
+        print('uuuuuuuuuuuuuuuuu ', uid)
+        print('rrrrrrrrrrrrrrrrrr ', sirepo.auth_role.ROLE_ADM)
         sirepo.pkcli.roles.add_roles(
             uid,
-            sirepo.auth.ROLE_ADM,
+            sirepo.auth_role.ROLE_ADM,
         )
         r = sirepo.auth_db.UserRole.search_all_for_column('uid')
         pkunit.pkeq(1, len(r), 'One user with role adm r={}', r)

--- a/tests/adm_and_own_jobs_test.py
+++ b/tests/adm_and_own_jobs_test.py
@@ -114,8 +114,6 @@ def test_srw_user_see_only_own_jobs(auth_fc):
 
     def _make_user_adm(uid):
         import sirepo.pkcli.roles
-        print('uuuuuuuuuuuuuuuuu ', uid)
-        print('rrrrrrrrrrrrrrrrrr ', sirepo.auth_role.ROLE_ADM)
         sirepo.pkcli.roles.add_roles(
             uid,
             sirepo.auth_role.ROLE_ADM,

--- a/tests/auth1_test.py
+++ b/tests/auth1_test.py
@@ -23,7 +23,6 @@ def test_login():
 
     r = auth.api_authState()
     pkre('LoggedIn": false.*Registration": false', pkcompat.from_bytes(r.data))
-    delattr(flask.g, 'sirepo_cookie')
     auth.process_request()
     with pkunit.pkexcept('SRException.*routeName=login'):
         auth.logged_in_user()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,9 +55,6 @@ def fc_module(request, cfg=None):
 
 @pytest.fixture
 def import_req(request):
-    import flask
-
-    flask.g = {}
 
     def w(path):
         import sirepo.http_request

--- a/tests/cookie2_test.py
+++ b/tests/cookie2_test.py
@@ -5,21 +5,16 @@ u"""Test sirepo.cookie
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from __future__ import absolute_import, division, print_function
-import pytest
+from pykern.pkcollections import PKDict
 from sirepo import srunit
+import pytest
 
 @srunit.wrap_in_request(want_user=False)
 def test_set_get():
     from pykern import pkunit, pkcompat
     from pykern.pkunit import pkeq
     from pykern.pkdebug import pkdp
-    from pykern import pkcollections
     from sirepo import cookie
-
-    class _Response(pkcollections.Dict):
-        def set_cookie(self, *args, **kwargs):
-            self.args = args
-            self.kwargs = kwargs
 
     with cookie.process_header('x'):
         with pkunit.pkexcept('KeyError'):
@@ -27,17 +22,29 @@ def test_set_get():
         with pkunit.pkexcept('AssertionError'):
             cookie.set_value('hi2', 'hello')
         pkeq(None, cookie.unchecked_get_value('hi3'))
-        # Nest cookie contexts
-        with cookie.set_cookie_for_utils():
-            cookie.set_value('hi4', 'hello')
-            r = _Response(status_code=200)
-            cookie.save_to_cookie(r)
-            pkeq('sirepo_dev', r.args[0])
-            pkeq(False, r.kwargs['secure'])
-            pkeq('hello', cookie.get_value('hi4'))
-            cookie.unchecked_remove('hi4')
-            pkeq(None, cookie.unchecked_get_value('hi4'))
-    with cookie.process_header(
-        'sirepo_dev={}'.format(pkcompat.from_bytes(r.args[1])),
-    ):
+
+
+def test_cookie_outside_of_flask_request():
+    from pykern import pkcompat
+    from pykern.pkunit import pkeq
+    from sirepo import cookie
+
+    with cookie.set_cookie_outside_of_flask_request():
+        cookie.set_value('hi4', 'hello')
+        r = _Response(status_code=200)
+        cookie.save_to_cookie(r)
+        pkeq('sirepo_dev', r.args[0])
+        pkeq(False, r.kwargs['secure'])
         pkeq('hello', cookie.get_value('hi4'))
+        cookie.unchecked_remove('hi4')
+        pkeq(None, cookie.unchecked_get_value('hi4'))
+        # Nest cookie contexts
+        with cookie.process_header(
+            'sirepo_dev={}'.format(pkcompat.from_bytes(r.args[1])),
+        ):
+            pkeq('hello', cookie.get_value('hi4'))
+
+class _Response(PKDict):
+    def set_cookie(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs

--- a/tests/pkcli/roles_test.py
+++ b/tests/pkcli/roles_test.py
@@ -17,8 +17,8 @@ def setup_module(module):
 def test_flash_change_role_change_lib_files(auth_fc):
     from pykern import pkio
     from pykern import pkunit
-    import sirepo.auth
     import sirepo.auth_db
+    import sirepo.auth_role
     import sirepo.pkcli.roles
     import sirepo.srdb
 
@@ -28,7 +28,7 @@ def test_flash_change_role_change_lib_files(auth_fc):
             f = getattr(sirepo.pkcli.roles, 'delete_roles')
         f(
             fc.sr_auth_state().uid,
-            sirepo.auth.role_for_sim_type(fc.sr_sim_type),
+            sirepo.auth_role.role_for_sim_type(fc.sr_sim_type),
         )
 
     def _check_file(exists=True):

--- a/tests/proprietary_sim_types_test.py
+++ b/tests/proprietary_sim_types_test.py
@@ -22,6 +22,7 @@ def test_myapp(auth_fc):
     from pykern.pkdebug import pkdlog, pkdexc, pkdp
     import sirepo.pkcli.setup_dev
     import sirepo.pkcli.roles
+    import sirepo.auth_role
 
     sirepo.pkcli.setup_dev.default_command()
     fc = auth_fc
@@ -43,7 +44,7 @@ def test_myapp(auth_fc):
     pkunit.pkeq(403, r.status_code)
     sirepo.pkcli.roles.add_roles(
         fc.sr_auth_state().uid,
-        sirepo.auth.role_for_sim_type(fc.sr_sim_type),
+        sirepo.auth_role.role_for_sim_type(fc.sr_sim_type),
     )
     r = fc.sr_run_sim(fc.sr_sim_data(), 'heightWeightReport')
     p = r.get('plots')

--- a/tests/supervisor_purge_free_sims_test.py
+++ b/tests/supervisor_purge_free_sims_test.py
@@ -26,7 +26,7 @@ def test_myapp_free_user_sim_purged(auth_fc):
     from pykern import pkio
     from pykern import pkunit
     from pykern.pkdebug import pkdp
-    import sirepo.auth
+    import sirepo.auth_role
 
     def _check_run_dir(should_exist=0):
         f = pkio.walk_tree(fc.sr_user_dir(), file_re=m)
@@ -36,7 +36,7 @@ def test_myapp_free_user_sim_purged(auth_fc):
         import sirepo.pkcli.roles
         sirepo.pkcli.roles.add_roles(
             uid,
-            sirepo.auth.ROLE_PAYMENT_PLAN_PREMIUM,
+            sirepo.auth_role.ROLE_PAYMENT_PLAN_PREMIUM,
         )
         r = sirepo.auth_db.UserRole.search_all_for_column('uid')
         pkunit.pkeq(r, [uid], 'expecting one premium user with same id')


### PR DESCRIPTION
This branch is based on issue/3350-flask-g. Please review and merge #3352 before reviewing this.

Changes have been made to the flash src (radiasoft/download#152)
that require updating the FLASH lib files for all users. Force
overwriting the existing files even though the names are the same.

Add sim_types param to audit_proprietary_lib_files so we can enforce
that the db_upgrade code only audit's FLASH proprietary lib files.