### PR TITLE
Fix #3307: running multiple jobs at NERSC

### DIFF
--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -87,7 +87,6 @@ class DriverBase(PKDict):
             _idle_timer=None,
             _websocket=None,
             _websocket_ready=sirepo.tornado.Event(),
-#TODO(robnagler) https://github.com/radiasoft/sirepo/issues/2195
         )
         self._sim_db_file_token = sirepo.sim_db_file.token_for_user(self.uid)
         # Drivers persist for the life of the program so they are never removed

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -35,20 +35,20 @@ class SbatchDriver(job_driver.DriverBase):
 
     def __init__(self, op):
         def _op_queue_size(op_kind):
-            return self.cfg.num_concurrent_op_run if op_kind == job.OP_RUN else 1
+            return self.cfg.run_slots if op_kind == job.OP_RUN else 1
 
         super().__init__(op)
         self.pkupdate(
             # before it is overwritten by prepare_send
             _local_user_dir=pkio.py_path(op.msg.userDir),
             _srdb_root=None,
-            # Allow num_concurrent_op_run and every other op type to
+            # Allow self.cfg.run_slots and every other op type to
             # run (assume OP_RUN is one of OPS_THAT_NEED_SLOTS). This
             # is essentially a no-op (sbatch constrains its own cpu
             # resources) but makes it easier to code the other cases.
             cpu_slot_q=sirepo.job_supervisor.SlotQueue(
                 len(job_driver.OPS_THAT_NEED_SLOTS)
-                + self.cfg.num_concurrent_op_run
+                + self.cfg.run_slots
                 - 1,
             ),
             op_slot_q={
@@ -89,7 +89,7 @@ class SbatchDriver(job_driver.DriverBase):
             cores=(None, int, 'dev cores config'),
             host=pkconfig.Required(str, 'host name for slum controller'),
             host_key=pkconfig.Required(str, 'host key'),
-            num_concurrent_op_run=(1, int, 'number of concurrent OP_RUN for each user'),
+            run_slots=(1, int, 'number of concurrent OP_RUN for each user'),
             shifter_image=(None, str, 'needed if using Shifter'),
             sirepo_cmd=pkconfig.Required(str, 'how to run sirepo'),
             srdb_root=pkconfig.Required(_cfg_srdb_root, 'where to run job_agent, must include {sbatch_user}'),

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -17,6 +17,7 @@ import asyncio
 import asyncssh
 import datetime
 import errno
+import sirepo.job_supervisor
 import sirepo.simulation_db
 import sirepo.srdb
 import sirepo.util
@@ -33,14 +34,27 @@ class SbatchDriver(job_driver.DriverBase):
     __instances = PKDict()
 
     def __init__(self, op):
+        def _op_queue_size(op_kind):
+            return self.cfg.num_concurrent_op_run if op_kind == job.OP_RUN else 1
+
         super().__init__(op)
         self.pkupdate(
             # before it is overwritten by prepare_send
             _local_user_dir=pkio.py_path(op.msg.userDir),
             _srdb_root=None,
-            # we allow one of each op type in. This is essentially a no-op (ha ha)
-            # but makes it easier to code the other cases.
-            cpu_slot_q=job_supervisor.SlotQueue(len(job_driver.OPS_THAT_NEED_SLOTS)),
+            # Allow num_concurrent_op_run and every other op type to
+            # run (assume OP_RUN is one of OPS_THAT_NEED_SLOTS). This
+            # is essentially a no-op (sbatch constrains its own cpu
+            # resources) but makes it easier to code the other cases.
+            cpu_slot_q=sirepo.job_supervisor.SlotQueue(
+                len(job_driver.OPS_THAT_NEED_SLOTS)
+                + self.cfg.num_concurrent_op_run
+                - 1,
+            ),
+            op_slot_q={
+                k: sirepo.job_supervisor.SlotQueue(maxsize=_op_queue_size(k))
+                for k in job_driver.OPS_THAT_NEED_SLOTS
+            },
         )
         self.__instances[self.uid] = self
 
@@ -75,6 +89,7 @@ class SbatchDriver(job_driver.DriverBase):
             cores=(None, int, 'dev cores config'),
             host=pkconfig.Required(str, 'host name for slum controller'),
             host_key=pkconfig.Required(str, 'host key'),
+            num_concurrent_op_run=(1, int, 'number of concurrent OP_RUN for each user'),
             shifter_image=(None, str, 'needed if using Shifter'),
             sirepo_cmd=pkconfig.Required(str, 'how to run sirepo'),
             srdb_root=pkconfig.Required(_cfg_srdb_root, 'where to run job_agent, must include {sbatch_user}'),

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -754,14 +754,11 @@ exec srun {s} /bin/bash bash.stdin
             )
             return
         self._status = r.group()
-        if self._status in ('PENDING', 'CONFIGURING'):
+        if not self._start_ready.is_set():
+            self._start_time = int(time.time())
+            self._start_ready.set()
+        if self._status in ('CONFIGURING', 'COMPLETING', 'PENDING', 'RUNNING'):
             return
-        else:
-            if not self._start_ready.is_set():
-                self._start_time = int(time.time())
-                self._start_ready.set()
-            if self._status in ('COMPLETING', 'RUNNING'):
-                return
         c = self._status == 'COMPLETED'
         self._stopped_sentinel.write(job.COMPLETED if c else job.ERROR)
         if not c:

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -601,6 +601,19 @@ class _SbatchRun(_SbatchCmd):
         self.msg.jobCmd = 'sbatch_status'
         self.pkdel('_in_file').remove()
 
+    async def _await_start_ready(self):
+        await self._start_ready.wait()
+        if self._terminating:
+            return
+        self._in_file = self._create_in_file()
+        pkdlog(
+            '{} sbatch_id={} starting jobCmd={}',
+            self,
+            self._sbatch_id,
+            self.msg.jobCmd,
+        )
+        await super().start()
+
     def destroy(self):
         if self._status_cb:
             self._status_cb.stop()
@@ -654,17 +667,10 @@ class _SbatchRun(_SbatchCmd):
         )
         self._start_ready = sirepo.tornado.Event()
         self._status_cb.start()
-        await self._start_ready.wait()
-        if self._terminating:
-            return
-        self._in_file = self._create_in_file()
-        pkdlog(
-            '{} sbatch_id={} starting jobCmd={}',
-            self,
-            self._sbatch_id,
-            self.msg.jobCmd,
-        )
-        await super().start()
+        # Starting an sbatch job may involve a long wait in the queue
+        # so release back to agent loop so we can process other ops
+        # while we wait for the job to start running
+        tornado.ioloop.IOLoop.current().add_callback(self._await_start_ready)
 
     async def _prepare_simulation(self):
         c = _SbatchCmd(
@@ -754,11 +760,14 @@ exec srun {s} /bin/bash bash.stdin
             )
             return
         self._status = r.group()
-        if not self._start_ready.is_set():
-            self._start_time = int(time.time())
-            self._start_ready.set()
-        if self._status in ('CONFIGURING', 'COMPLETING', 'PENDING', 'RUNNING'):
+        if self._status in ('PENDING', 'CONFIGURING'):
             return
+        else:
+            if not self._start_ready.is_set():
+                self._start_time = int(time.time())
+                self._start_ready.set()
+            if self._status in ('COMPLETING', 'RUNNING'):
+                return
         c = self._status == 'COMPLETED'
         self._stopped_sentinel.write(job.COMPLETED if c else job.ERROR)
         if not c:


### PR DESCRIPTION
Make the number of concurrent OP_RUN per user configurable.

Also, make it so jobs in squeue (pending) can be cancelled (fix #3371).

~~This PR lead to a change in behavior. computeJobStart will now be the time the job is submitted to the queue (roughly) not the time the job actually starts. To make it the time the job actually starts running would involve more of a refactor and I think is worth a discussion.~~ With https://github.com/radiasoft/sirepo/pull/3372/commits/3f3de31188f07f2daf8e5ac68d3dd746d2d8967a this is no longer true.