### PR TITLE
Fix #3390 - allows adding boxes to existing stl

### DIFF
--- a/sirepo/package_data/static/html/warpvnd-source.html
+++ b/sirepo/package_data/static/html/warpvnd-source.html
@@ -15,7 +15,7 @@
       <div class="panel panel-info">
         <div class="panel-heading"><span class="sr-panel-heading">Conductor Types</span></div>
         <div class="panel-body">
-          <div data-ng-show="! source.usesSTL()" class="pull-right">
+          <div class="pull-right">
             <button class="btn btn-info btn-xs" data-ng-click="source.createConductorType('box')" accesskey="N"><span class="glyphicon glyphicon-plus"></span> <u>N</u>ew Conductor Type</button>
           </div>
           <div data-conductor-table="" data-controller="source"></div>

--- a/sirepo/package_data/template/warpvnd/base.py.jinja
+++ b/sirepo/package_data/template/warpvnd/base.py.jinja
@@ -375,7 +375,7 @@ conductors = [
 {% for c in conductors %}
 {% if c.conductor_type.type == 'stl' %}
     # add scale when available in rswarp
-    stlconductor.STLconductor("{{ c.conductor_type.file }}", voltage={{ c.conductor_type.voltage }}, xcent={{ c.xCenter }}, ycent={{ c.yCenter }}, zcent={{ c.zCenter }}, raytri_scheme="watertight", verbose="on", normalization_factor=dz, condid={{ c.id }})
+    stlconductor.STLconductor("{{ c.conductor_type.file }}", voltage={{ c.conductor_type.voltage }}, xcent={{ c.xCenter }}, ycent={{ c.yCenter }}, zcent={{ c.zCenter }}, raytri_scheme="watertight", verbose="on", normalization_factor=dz, condid={{ c.id }}),
 {% else %}
     wp.Box({{ c.conductor_type.xLength }}, {{ c.conductor_type.yLength }}, {{ c.conductor_type.zLength }}, voltage={{ c.conductor_type.voltage }}, xcent={{ c.xCenter }}, ycent={{ c.yCenter }}, zcent={{ c.zCenter }}, permittivity={{ c.conductor_type.permittivity }}, condid={{ c.id }}),
 {% endif %}


### PR DESCRIPTION
Also fixes a bug where the generated python was invalid if an additional conductor followed an stl in the list