### PR TITLE
Fix #3484 radia bad boolean and others

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -3271,7 +3271,10 @@ SIREPO.app.factory('radiaVtkUtils', function(utilities) {
             // may not always be colors in the data
             var c = t.colors || [];
             for (var i = 0; i < c.length; i++) {
-                var cc = (color || [])[i % 3] || c[i];
+                let cc = (color || [])[i % 3];
+                if (! cc && cc !== 0) {
+                    cc = c[i];
+                }
                 colors.push(Math.floor(255 * cc));
                 if (i % 3 === 2) {
                     colors.push(255);

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -2443,26 +2443,6 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
                         bundle.actor.getProperty().setLighting(isPoly);
                         let info = addActor(objId, gname, bundle.actor, t, PICKABLE_TYPES.indexOf(t) >= 0);
                         gColor = getColor(info);
-                        if (isPoly && $.isEmptyObject(gObj)) {
-                            //srdbg('add poly obj', gObj);
-                            gObj = appState.setModelDefaults(gObj, 'radiaObject');
-                            gObj.name = `${gname}.radiaObject`;  //id;
-                            gObj.id = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);  //id;
-                            if (gColor) {
-                                // **IF GROUP COLOR USE IF NOT USE OBJECT COLOR**
-                                gObj.color = vtk.Common.Core.vtkMath.floatRGB2HexCode(vtkUtils.rgbToFloat(gColor));
-                            }
-                            // temporary handling of examples until they are "buildaable"
-                            // ***KEEPS ADDING OVER AND OVER***
-                            if (appState.models.simulation.isExample || appState.models.simulation.dmpImportFile) {
-                                if (! appState.models.geometry.objects) {
-                                    appState.models.geometry.objects = [];
-                                }
-                                appState.models.geometry.objects.push(gObj);
-                            }
-
-                            didModifyGeom = true;
-                        }
                         if (! gObj.center || ! gObj.size) {
                             var b = bundle.actor.getBounds();
                             gObj.center = [0.5 * (b[1] + b[0]), 0.5 * (b[3] + b[2]), 0.5 * (b[5] + b[4])].join(',');

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1146,13 +1146,13 @@ SIREPO.app.directive('appHeader', function(appState, requestSender) {
                 $('#simulation-import').modal('show');
             };
             $scope.isImported = function() {
-                return ((appState.models.simulation || {}).isExample && isRawExample($scope.nav.simulationName())) ||
-                    (appState.models.simulation || {}).dmpImportFile;
+                let sim = appState.models.simulation || {};
+                return isRawExample(sim.exampleName) || sim.dmpImportFile;
             };
 
             // "raw" examples are from radia_examples.py - a temporary repository
             function isRawExample(name) {
-                return SIREPO.APP_SCHEMA.constants.rawExamples.indexOf(name) > 0;
+                return SIREPO.APP_SCHEMA.constants.rawExamples.indexOf(name) >= 0;
             }
         }
     };

--- a/sirepo/package_data/template/radia/examples/dipole.json
+++ b/sirepo/package_data/template/radia/examples/dipole.json
@@ -31,12 +31,14 @@
             "objects": [
                 {
                     "color": "#ff0000",
+                    "id": "1c3a32be-c19b-42f8-a303-28fecaa5c1f0",
                     "material": "",
                     "name": "Dipole.Geom.0.polygons",
                     "type": ""
                 },
                 {
                     "color": "#0000ff",
+                    "id": "f904f1d1-93d5-4a84-bafb-cebf9efa0b35",
                     "material": "",
                     "name": "Dipole.Geom.1.polygons",
                     "type": ""

--- a/sirepo/package_data/template/radia/examples/dipole.json
+++ b/sirepo/package_data/template/radia/examples/dipole.json
@@ -47,7 +47,8 @@
         "simulation": {
             "beamAxis": "x",
             "documentationUrl": "",
-            "enableKickMaps": false,
+            "enableKickMaps": "0",
+            "exampleName": "Dipole",
             "folder": "/Examples",
             "isExample": true,
             "name": "Dipole",

--- a/sirepo/package_data/template/radia/examples/wiggler.json
+++ b/sirepo/package_data/template/radia/examples/wiggler.json
@@ -51,7 +51,8 @@
         "simulation": {
             "beamAxis": "z",
             "documentationUrl": "",
-            "enableKickMaps": false,
+            "enableKickMaps": "0",
+            "exampleName": "Wiggler",
             "folder": "/Examples",
             "isExample": true,
             "name": "Wiggler",

--- a/sirepo/package_data/template/radia/examples/wiggler.json
+++ b/sirepo/package_data/template/radia/examples/wiggler.json
@@ -9,33 +9,9 @@
             "beamAxis": "z",
             "objects": [
                 {
-                    "color": "#00ffff",
+                    "id": "48022af9-3b43-424f-b43b-5cbeb0d36bd6",
                     "material": "",
                     "name": "Wiggler.Geom.0.polygons",
-                    "type": ""
-                },
-                {
-                    "color": "#ff6600",
-                    "material": "",
-                    "name": "Wiggler.Geom.1.polygons",
-                    "type": ""
-                },
-                {
-                    "color": "#00ffff",
-                    "material": "",
-                    "name": "Wiggler.Geom.2.polygons",
-                    "type": ""
-                },
-                {
-                    "color": "#ff6600",
-                    "material": "",
-                    "name": "Wiggler.Geom.3.polygons",
-                    "type": ""
-                },
-                {
-                    "color": "#ff6600",
-                    "material": "",
-                    "name": "Wiggler.Geom.4.polygons",
                     "type": ""
                 }
             ]

--- a/sirepo/package_data/template/radia/geometry.py.jinja
+++ b/sirepo/package_data/template/radia/geometry.py.jinja
@@ -59,8 +59,8 @@ def _add_object(o):
     return g_id
 
 id_map = PKDict()
-{% if isExample %}
-g_id = radia_examples.EXAMPLES['{{ geomName }}']()
+{% if isRaw %}
+g_id = radia_examples.EXAMPLES['{{ exampleName }}']()
 {% elif dmpImportFile %}
 with open('{{ dmpImportFile }}', 'rb') as f:
     b = f.read()

--- a/sirepo/package_data/template/radia/geometry.py.jinja
+++ b/sirepo/package_data/template/radia/geometry.py.jinja
@@ -60,7 +60,7 @@ def _add_object(o):
 
 id_map = PKDict()
 {% if isRaw %}
-g_id = radia_examples.EXAMPLES['{{ exampleName }}']()
+g_id, id_map = radia_examples.EXAMPLES['{{ exampleName }}']()
 {% elif dmpImportFile %}
 with open('{{ dmpImportFile }}', 'rb') as f:
     b = f.read()

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -737,10 +737,8 @@ def _read_data(sim_id, view_type, field_type):
 
 def _read_id_map(sim_id):
     m = _read_h5_path(sim_id, _GEOM_FILE, 'idMap')
-    if not m:
-        return PKDict()
-    return PKDict(
-        {k:v.decode('ascii') for k, v in m.items()}
+    return PKDict() if not m else PKDict(
+        {k:(v if isinstance(v, int) else v.decode('ascii')) for k, v in m.items()}
     )
 
 

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -584,6 +584,8 @@ def _generate_parameters_file(data, for_export):
             )
     v.isExample = data.models.simulation.get('isExample', False) and \
         data.models.simulation.name in radia_examples.EXAMPLES
+    v.exampleName = data.models.simulation.get('exampleName', None)
+    v.isRaw = v.exampleName in _SCHEMA.constants.rawExamples
     v.magnetType = data.models.simulation.get('magnetType', 'freehand')
     if v.magnetType == 'undulator':
         _update_geom_from_undulator(g, data.models.hybridUndulator, data.models.simulation.beamAxis)
@@ -734,8 +736,11 @@ def _read_data(sim_id, view_type, field_type):
 
 
 def _read_id_map(sim_id):
+    m = _read_h5_path(sim_id, _GEOM_FILE, 'idMap')
+    if not m:
+        return PKDict()
     return PKDict(
-        {k:v.decode('ascii') for k, v in _read_h5_path(sim_id, _GEOM_FILE, 'idMap').items()}
+        {k:v.decode('ascii') for k, v in m.items()}
     )
 
 

--- a/sirepo/template/radia_examples.py
+++ b/sirepo/template/radia_examples.py
@@ -140,12 +140,16 @@ def dipole_example():
         # Define the symmetries
         radia.TrfZerPerp(g, [0, 0, 0], [1, 0, 0])
         radia.TrfZerPara(g, [0, 0, 0], [0, 0, 1])
-        return t
+        return t, {
+            g: '1c3a32be-c19b-42f8-a303-28fecaa5c1f0',
+            coil: 'f904f1d1-93d5-4a84-bafb-cebf9efa0b35',
+        }
 
     # Define full magnet
     return geom(1)
 
 
+# DEPRECATED
 def undulator_example():
     mu0 = 4 * math.pi / 1e7
 
@@ -216,8 +220,8 @@ def undulator_example():
         zero = [0, 0, 0]
 
         # colors
-        c_pole = [1, 0, 1]
-        c_block = [0, 1, 1]
+        c_pole = [1, 0, 0]
+        c_block = [0, 0, 1]
 
         # full magnet will be assembled into this Radia group
         grp = radia.ObjCnt([])
@@ -341,7 +345,9 @@ def wiggler_example():
     # and reflect in the (x,y) plane [plane through (0,0,0) with normal (0,0,1)]
     radia.TrfZerPara(geom, [0, 0, 0], [0, 0, 1])
 
-    return geom
+    return geom, {
+        geom: '48022af9-3b43-424f-b43b-5cbeb0d36bd6',
+    }
 
 
 EXAMPLES = {

--- a/sirepo/template/radia_tk.py
+++ b/sirepo/template/radia_tk.py
@@ -170,6 +170,7 @@ def geom_to_data(g_id, name=None, divide=True):
     c = radia.ObjCntStuf(g_id)
     l = len(c)
     if not divide or l == 0:
+        d.id = g_id
         pd.data = [d]
     else:
         d_arr = []
@@ -187,6 +188,7 @@ def geom_to_data(g_id, name=None, divide=True):
         # across its elements, a symmetry or other "additive" transformation has
         # been applied and we cannot get at the individual elements
         if n_verts > n_s_verts:
+            d.id = g_id
             d_arr = [d]
         pd.data = d_arr
     pd.bounds = radia.ObjGeoLim(g_id)


### PR DESCRIPTION
Other items fixed:

- Code meant to create sirepo model objects from python-generated examples was outdated and causing problems
- Colors of objects would get mixed between "local" and Radia-defined colors
- Copies of examples would show the (useless) 2d design tab
