### PR TITLE
WIP #3505: srcontext

### DIFF
--- a/sirepo/auth/email.py
+++ b/sirepo/auth/email.py
@@ -150,11 +150,11 @@ def _init_model(base):
         @classmethod
         def delete_changed_email(cls, user):
             with auth_db.thread_lock:
-                cls._session.query(cls).filter(
+                cls._session().query(cls).filter(
                     (cls.user_name == user.unverified_email),
                     cls.unverified_email != user.unverified_email
                 ).delete()
-                cls._session.commit()
+                cls._session().commit()
 
     UserModel = AuthEmailUser
 

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -5,6 +5,7 @@ u"""Auth database
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from __future__ import absolute_import, division, print_function
+from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdc, pkdexc, pkdlog, pkdp
 import sqlalchemy
 import sqlalchemy.ext.declarative
@@ -12,17 +13,18 @@ import sqlalchemy.orm
 import threading
 # limit imports here
 import sirepo.auth_role
+import sirepo.srcontext
+import sirepo.events
 import sirepo.srdb
 
 
 #: sqlite file located in sirepo_db_dir
 _SQLITE3_BASENAME = 'auth.db'
 
+_SRCONTEXT_SESSION_KEY = 'auth_db_session'
+
 #: SQLAlchemy database engine
 _engine = None
-
-#: SQLAlchemy session instance
-_session = None
 
 #: Keeps track of upgrades applied to the database
 DbUpgrade = None
@@ -114,9 +116,21 @@ def db_filename():
 
 
 def init():
-    global _session, _engine, DbUpgrade, UserDbBase, UserRegistration, UserRole
+    def _create_session(_):
+        s = sirepo.srcontext.get(_SRCONTEXT_SESSION_KEY)
+        assert not s, \
+            f'existing session={s}'
+        sirepo.srcontext.set(
+            _SRCONTEXT_SESSION_KEY,
+            sqlalchemy.orm.Session(bind=_engine),
+        )
 
-    if _session:
+    def _destroy_session(kwargs):
+        kwargs.srcontext.pop(_SRCONTEXT_SESSION_KEY).rollback()
+
+    global _engine, DbUpgrade, UserDbBase, UserRegistration, UserRole
+
+    if _engine:
         return
     f = db_filename()
     _migrate_db_file(f)
@@ -126,13 +140,15 @@ def init():
         # we access a single connection across threads
         connect_args={'check_same_thread': False},
     )
-    _session = sqlalchemy.orm.Session(bind=_engine)
+    sirepo.events.register(PKDict(
+        srcontext_created=_create_session,
+        srcontext_destroyed=_destroy_session,
+    ))
 
     @sqlalchemy.ext.declarative.as_declarative()
     class UserDbBase(object):
         STRING_ID = sqlalchemy.String(8)
         STRING_NAME =  sqlalchemy.String(100)
-        _session = _session
 
         def __init__(self, **kwargs):
             for k, v in kwargs.items():
@@ -140,45 +156,50 @@ def init():
 
         def delete(self):
             with thread_lock:
-                self._session.delete(self)
-                self._session.commit()
+                self._session().delete(self)
+                self._session().commit()
 
         @classmethod
         def delete_all(cls):
             with thread_lock:
-                cls._session.query(cls).delete()
-                cls._session.commit()
+                cls._session().query(cls).delete()
+                cls._session().commit()
 
         def save(self):
             with thread_lock:
-                self._session.add(self)
-                self._session.commit()
+                self._session().add(self)
+                self._session().commit()
 
         @classmethod
         def search_all_by(cls, **kwargs):
             with thread_lock:
-                return cls._session.query(cls).filter_by(**kwargs).all()
+                return cls._session().query(cls).filter_by(**kwargs).all()
 
         @classmethod
         def search_by(cls, **kwargs):
             with thread_lock:
-                return cls._session.query(cls).filter_by(**kwargs).first()
+                return cls._session().query(cls).filter_by(**kwargs).first()
 
         @classmethod
         def search_all_for_column(cls, column, **filter_by):
             with thread_lock:
                 return [
                     getattr(r, column) for r
-                    in cls._session.query(cls).filter_by(**filter_by)
+                    in cls._session().query(cls).filter_by(**filter_by)
                 ]
 
         @classmethod
         def delete_all_for_column_by_values(cls, column, values):
             with thread_lock:
-                cls._session.query(cls).filter(
+                cls._session().query(cls).filter(
                     getattr(cls, column).in_(values),
                 ).delete(synchronize_session='fetch')
-                cls._session.commit()
+                cls._session().commit()
+
+        @classmethod
+        def _session(cls):
+            return sirepo.srcontext.get(_SRCONTEXT_SESSION_KEY)
+
 
     class DbUpgrade(UserDbBase):
         __tablename__ = 'db_upgrade_t'
@@ -201,7 +222,7 @@ def init():
         def all_roles(cls):
             with thread_lock:
                 return [
-                    r[0] for r in cls._session.query(cls.role.distinct()).all()
+                    r[0] for r in cls._session().query(cls.role.distinct()).all()
                 ]
 
         @classmethod
@@ -214,12 +235,12 @@ def init():
         @classmethod
         def delete_roles(cls, uid, roles):
             with thread_lock:
-                cls._session.query(cls).filter(
+                cls._session().query(cls).filter(
                     cls.uid == uid,
                 ).filter(
                     cls.role.in_(roles),
                 ).delete(synchronize_session='fetch')
-                cls._session.commit()
+                cls._session().commit()
                 audit_proprietary_lib_files(uid)
 
         @classmethod
@@ -239,7 +260,7 @@ def init():
         @classmethod
         def uids_of_paid_users(cls):
             return [
-                x[0] for x in cls._session.query(cls).with_entities(cls.uid).filter(
+                x[0] for x in cls._session().query(cls).with_entities(cls.uid).filter(
                     cls.role.in_(sirepo.auth_role.PAID_USER_ROLES),
                 ).distinct().all()
             ]

--- a/sirepo/db_upgrade.py
+++ b/sirepo/db_upgrade.py
@@ -15,6 +15,7 @@ import sirepo.auth_db
 import sirepo.job
 import sirepo.sim_data
 import sirepo.simulation_db
+import sirepo.srcontext
 import sirepo.srdb
 import sirepo.srtime
 import sirepo.template
@@ -27,16 +28,18 @@ _PREVENT_DB_UPGRADE_FILE = 'prevent-db-upgrade'
 def do_all():
     assert not _prevent_db_upgrade_file().exists(), \
         f'prevent_db_upgrade_file={_prevent_db_upgrade_file()} found'
-    a = sirepo.auth_db.DbUpgrade.search_all_for_column('name')
-    f = pkinspect.module_functions('_2')
-    for n in sorted(set(f.keys()) - set(a)):
-        with _backup_db_and_prevent_upgrade_on_error():
-            pkdlog('running upgrade {}', n)
-            f[n]()
-            sirepo.auth_db.DbUpgrade(
-                name=n,
-                created=sirepo.srtime.utc_now(),
-            ).save()
+
+    with sirepo.srcontext.create():
+        a = sirepo.auth_db.DbUpgrade.search_all_for_column('name')
+        f = pkinspect.module_functions('_2')
+        for n in sorted(set(f.keys()) - set(a)):
+            with _backup_db_and_prevent_upgrade_on_error():
+                pkdlog('running upgrade {}', n)
+                f[n]()
+                sirepo.auth_db.DbUpgrade(
+                    name=n,
+                    created=sirepo.srtime.utc_now(),
+                ).save()
 
 
 

--- a/sirepo/db_upgrade.py
+++ b/sirepo/db_upgrade.py
@@ -29,6 +29,9 @@ def do_all():
     assert not _prevent_db_upgrade_file().exists(), \
         f'prevent_db_upgrade_file={_prevent_db_upgrade_file()} found'
 
+    # TODO(e-carlin): this doesn't actually work. audit_proprietary_lib_files
+    # will also create a context (needs to be reentrant or moved to protect)
+    # just relevant bits
     with sirepo.srcontext.create():
         a = sirepo.auth_db.DbUpgrade.search_all_for_column('name')
         f = pkinspect.module_functions('_2')

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -25,8 +25,8 @@ The events:
 :copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+# Limit imports
 from pykern.pkcollections import PKDict
-from pykern.pkdebug import pkdp
 import aenum
 
 #: Map of events to handlers. Note: this is the list of all possible events.

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -19,6 +19,8 @@ The events:
 - 'github_authorized' emitted once the authorized github user is retrieved and
   confirmed valid but before that user is logged in or the github db is updated.
   kwargs contains user_name, the github handle.
+- 'srcontext_created' emitted when the srcontext object is populated.
+- 'srcontext_destroyed' emitted when the srcontext object is destroyed.
 
 :copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
@@ -32,10 +34,12 @@ _MAP = PKDict(
     auth_logout=[],
     end_api_call=[],
     github_authorized=[],
+    srcontext_created=[],
+    srcontext_destroyed=[],
 )
 
 
-def emit(event, kwargs):
+def emit(event, kwargs=None):
     """Call the handlers for `event` with `kwargs`
 
     Handlers will be called in registration order (FIFO).

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -69,7 +69,8 @@ class Authenticator(jupyterhub.auth.Authenticator):
 
 @contextlib.contextmanager
 def _set_cookie(handler):
-    with sirepo.cookie.set_cookie_outside_of_flask_request(
-        handler.get_cookie(sirepo.cookie.cfg.http_name),
-    ):
+    with sirepo.srcontext.create(), \
+         sirepo.cookie.set_cookie_outside_of_flask_request(
+             handler.get_cookie(sirepo.cookie.cfg.http_name),
+         ):
         yield

--- a/sirepo/pkcli/jupyterhublogin.py
+++ b/sirepo/pkcli/jupyterhublogin.py
@@ -22,6 +22,7 @@ def create_user(email):
     import sirepo.auth
     import sirepo.server
     import sirepo.sim_api.jupyterhublogin
+    import sirepo.srcontext
     import sirepo.template
 
 
@@ -29,7 +30,8 @@ def create_user(email):
         pykern.pkcli.command_error('invalid email={}', email)
     sirepo.server.init()
     sirepo.template.assert_sim_type('jupyterhublogin')
-    u = sirepo.auth.get_module('email').unchecked_user_by_user_name(email)
+    with sirepo.srcontext.create():
+        u = sirepo.auth.get_module('email').unchecked_user_by_user_name(email)
     if not u:
         pykern.pkcli.command_error('no sirepo user with email={}', email)
     with sirepo.auth.set_user_outside_of_http_request(u):

--- a/sirepo/pkcli/roles.py
+++ b/sirepo/pkcli/roles.py
@@ -8,11 +8,13 @@ from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdc, pkdexc, pkdlog, pkdp
 from sirepo.pkcli import admin
+import contextlib
 import pykern.pkcli
 import sirepo.auth
 import sirepo.auth_role
 import sirepo.auth_db
 import sirepo.server
+import sirepo.srcontext
 
 
 def add(uid_or_email, *roles):
@@ -22,8 +24,8 @@ def add(uid_or_email, *roles):
         *roles: The roles to assign to the user
     """
 
-    u = _parse_args(uid_or_email, roles)
-    sirepo.auth_db.UserRole.add_roles(u, roles)
+    with _parse_args(uid_or_email, roles) as u:
+        sirepo.auth_db.UserRole.add_roles(u, roles)
 
 
 def add_roles(*args):
@@ -38,8 +40,8 @@ def delete(uid_or_email, *roles):
         *roles (args): The roles to delete
     """
 
-    u = _parse_args(uid_or_email, roles)
-    sirepo.auth_db.UserRole.delete_roles(u, roles)
+    with _parse_args(uid_or_email, roles) as u:
+        sirepo.auth_db.UserRole.delete_roles(u, roles)
 
 
 def delete_roles(*args):
@@ -53,8 +55,8 @@ def list(uid_or_email):
         uid_or_email (str): Uid or email of the user
     """
 
-    u = _parse_args(uid_or_email, [])
-    return sirepo.auth_db.UserRole.get_roles(u)
+    with _parse_args(uid_or_email, []) as u:
+        return sirepo.auth_db.UserRole.get_roles(u)
 
 
 def list_roles(*args):
@@ -65,20 +67,21 @@ def list_roles(*args):
 
 # TODO(e-carlin): This only works for email auth or using a uid
 # doesn't work for other auth methods (ex GitHub)
+@contextlib.contextmanager
 def _parse_args(uid_or_email, roles):
     sirepo.server.init()
-
-    # POSIT: Uid's are from the base62 charset so an '@' implies an email.
-    if '@' in uid_or_email:
-        u = sirepo.auth.get_module(
-            'email',
-        ).unchecked_user_by_user_name(uid_or_email)
-    else:
-        u = sirepo.auth.unchecked_get_user(uid_or_email)
-    if not u:
-        pykern.pkcli.command_error('uid_or_email={} not found', uid_or_email)
-    if roles:
-        a = sirepo.auth_role.get_all()
-        assert set(roles).issubset(a), \
-            'roles={} not a subset of all_roles={}'.format(roles, a)
-    return u
+    with sirepo.srcontext.create():
+        # POSIT: Uid's are from the base62 charset so an '@' implies an email.
+        if '@' in uid_or_email:
+            u = sirepo.auth.get_module(
+                'email',
+            ).unchecked_user_by_user_name(uid_or_email)
+        else:
+            u = sirepo.auth.unchecked_get_user(uid_or_email)
+        if not u:
+            pykern.pkcli.command_error('uid_or_email={} not found', uid_or_email)
+        if roles:
+            a = sirepo.auth_role.get_all()
+            assert set(roles).issubset(a), \
+                'roles={} not a subset of all_roles={}'.format(roles, a)
+        yield u

--- a/sirepo/sirepo_console.py
+++ b/sirepo/sirepo_console.py
@@ -15,6 +15,7 @@ from pykern import pkcli
 
 
 def main():
+    # TODO(e-carlin): create context here
     return pkcli.main('sirepo')
 
 

--- a/sirepo/srcontext.py
+++ b/sirepo/srcontext.py
@@ -7,11 +7,42 @@ u"""Manage global context in threaded (Flask) and non-threaded (Tornado) applica
 from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp
+import contextlib
 import sirepo.util
 
 _FLASK_G_SR_CONTEXT_KEY = 'srcontext'
 
-_NON_THREADED_CONTEXT = PKDict()
+_non_threaded_context = None
+
+
+@contextlib.contextmanager
+def create():
+    """Create an srcontext approprieate for our current state (flask or not)
+
+    It is possible to have both _non_threaded_context and flask.g set
+    (ex in tests, supervisor).
+    """
+    try:
+        if sirepo.util.in_flask_request():
+            import flask
+            assert not flask.g.get(_FLASK_G_SR_CONTEXT_KEY), \
+                f'existing srcontext on flask.g={flask.g}'
+            flask.g.setdefault(_FLASK_G_SR_CONTEXT_KEY, PKDict())
+        else:
+            global _non_threaded_context
+            assert not _non_threaded_context, \
+                'existing _non_threaded_context{_non_threaded_context}'
+            _non_threaded_context = PKDict()
+        sirepo.events.emit('srcontext_created')
+        yield
+    finally:
+        if sirepo.util.in_flask_request():
+            import flask
+            c = flask.g.pop(_FLASK_G_SR_CONTEXT_KEY)
+        else:
+            c = _non_threaded_context
+            _non_threaded_context = None
+        sirepo.events.emit('srcontext_destroyed', PKDict(srcontext=c))
 
 
 def get(key, default=None):
@@ -33,5 +64,5 @@ def setdefault(key, default=None):
 def _context():
     if sirepo.util.in_flask_request():
         import flask
-        return flask.g.setdefault(_FLASK_G_SR_CONTEXT_KEY, default=PKDict())
-    return _NON_THREADED_CONTEXT
+        return flask.g.get(_FLASK_G_SR_CONTEXT_KEY)
+    return _non_threaded_context

--- a/sirepo/srcontext.py
+++ b/sirepo/srcontext.py
@@ -4,10 +4,11 @@ u"""Manage global context in threaded (Flask) and non-threaded (Tornado) applica
 :copyright: Copyright (c) 2021 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+# Limit imports
 from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
-from pykern.pkdebug import pkdp
 import contextlib
+import sirepo.events
 import sirepo.util
 
 _FLASK_G_SR_CONTEXT_KEY = 'srcontext'
@@ -20,7 +21,7 @@ def create():
     """Create an srcontext approprieate for our current state (flask or not)
 
     It is possible to have both _non_threaded_context and flask.g set
-    (ex in tests, supervisor).
+    (ex in tests).
     """
     try:
         if sirepo.util.in_flask_request():

--- a/sirepo/srunit.py
+++ b/sirepo/srunit.py
@@ -12,6 +12,11 @@ import flask.testing
 import json
 import re
 
+# TODO(e-carlin): create fn that is hook for creating srcontext
+# just provides a one stop where this happens
+@contextlib.contextmanager
+def srcontext_create():
+
 
 #: Default "app"
 MYAPP = 'myapp'

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -187,6 +187,7 @@ def flask_app():
     return flask.current_app or None
 
 def in_flask_request():
+    # TODO(e-carlin): instead of import check sys.modules
     import flask
 
     return flask.request or None

--- a/tests/adm_and_own_jobs_test.py
+++ b/tests/adm_and_own_jobs_test.py
@@ -121,10 +121,11 @@ def test_srw_user_see_only_own_jobs(auth_fc):
 
     def _make_user_adm(uid):
         import sirepo.pkcli.roles
-        sirepo.pkcli.roles.add_roles(
-            uid,
-            sirepo.auth_role.ROLE_ADM,
-        )
+        with sirepo.srcontext.create():
+            sirepo.pkcli.roles.add_roles(
+                uid,
+                sirepo.auth_role.ROLE_ADM,
+            )
         with sirepo.srcontext.create():
             r = sirepo.auth_db.UserRole.search_all_for_column('uid')
         pkunit.pkeq(1, len(r), 'One user with role adm r={}', r)

--- a/tests/adm_and_own_jobs_test.py
+++ b/tests/adm_and_own_jobs_test.py
@@ -38,7 +38,12 @@ def test_adm_jobs_forbidden(auth_fc):
 
     def _op(fc, sim_type):
         import sirepo.auth_db
-        sirepo.auth_db.UserRole.delete_all_for_column_by_values('uid', [fc.sr_auth_state().uid, ])
+
+        with sirepo.srcontext.create():
+            sirepo.auth_db.UserRole.delete_all_for_column_by_values(
+                'uid',
+                [fc.sr_auth_state().uid, ],
+            )
         r = fc.sr_post(
             'admJobs',
             PKDict(simulationType=sim_type),
@@ -69,13 +74,15 @@ def test_srw_user_see_only_own_jobs(auth_fc):
     from pykern.pkdebug import pkdp
     import sirepo.auth_db
     import sirepo.auth_role
+    import sirepo.srcontext
 
     def _cancel_job(user, cancel_req):
         _login_as_user(user)
         fc.sr_post('runCancel', cancel_req)
 
     def _clear_role_db():
-        sirepo.auth_db.UserRole.delete_all()
+        with sirepo.srcontext.create():
+            sirepo.auth_db.UserRole.delete_all()
 
     def _get_jobs(adm, job_count):
         r = fc.sr_post(
@@ -118,7 +125,8 @@ def test_srw_user_see_only_own_jobs(auth_fc):
             uid,
             sirepo.auth_role.ROLE_ADM,
         )
-        r = sirepo.auth_db.UserRole.search_all_for_column('uid')
+        with sirepo.srcontext.create():
+            r = sirepo.auth_db.UserRole.search_all_for_column('uid')
         pkunit.pkeq(1, len(r), 'One user with role adm r={}', r)
         pkunit.pkeq(r[0], uid, 'Expected same uid as user')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,13 +8,14 @@ import subprocess
 MAX_CASE_RUN_SECS = int(os.getenv('SIREPO_CONFTEST_MAX_CASE_RUN_SECS', 120))
 
 
-@pytest.fixture
+@pytest.fixture(scope='function')
 def auth_fc(auth_fc_module):
     # set the sentinel
     auth_fc_module.cookie_jar.clear()
     auth_fc_module.sr_get_root()
     auth_fc_module.sr_email_confirm = email_confirm
-    return auth_fc_module
+    with sirepo.srcontext.create():
+        yield auth_fc_module
 
 
 @pytest.fixture


### PR DESCRIPTION
This is not ready to be merged but I want to discuss some of the tricky bits. It works clicking around the GUI and fixes the session.rollback bug from #3505.

Things not working:
- pkcli: pkcli's that interact with the db will need to have an srcontext created. We can do this by hand in each pkcli that needs it (see example in pkcli/roles.py) or we could abstract away the details by fixing #3462.
- tests: same thing. Some tests need to interact with the db from within the test function so we will need to create a context. We can do this by hand in each relevant test function (see example in adm_own_jobs_test.py). We could also abstract the details away in conftest. pytest allows fixtures to yield so we can create the context within the fixture. But, srcontext.create will need to be reentrant for this to work (ex adm_own_jobs_test will need a context and it calls pkcli.roles.add which creates a context). Not a big deal to make it reentrant but before going down that road wanted to discuss.
- db_upgrade: If we made srcontext.create() reentrant then it would work as is. If not we will need to move the with to protect just the calls to auth_db.