### PR TITLE
fix #1608 simulation detail pages wait for appState.isLoaded()

### DIFF
--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -15,6 +15,30 @@ SIREPO.INFO_INDEX_MAX = 5;
 SIREPO.ENUM_INDEX_VALUE = 0;
 SIREPO.ENUM_INDEX_LABEL = 1;
 
+SIREPO.app.directive('simulationDetailPage', function(appState, $compile) {
+    return {
+        restrict: 'A',
+        scope: {
+            controller: '@',
+            template: '@',
+            templateUrl: '@',
+        },
+        link: function(scope, element) {
+            scope.appState = appState;
+            let template = '<div data-ng-if="appState.isLoaded()"><div data-ng-controller="'
+                + scope.controller + '"';
+            if (scope.template) {
+                template +=  '>' + scope.template;
+            }
+            else if (scope.templateUrl) {
+                template += ' data-ng-include="templateUrl">';
+            }
+            template += '</div></div>';
+            element.append($compile(template)(scope));
+        },
+    };
+});
+
 SIREPO.app.directive('advancedEditorPane', function(appState, panelState, $compile) {
     return {
         restrict: 'A',

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -170,14 +170,14 @@ SIREPO.app = angular.module('SirepoApp', ['ngDraggable', 'ngRoute', 'ngCookies',
 SIREPO.app.value('localRoutes', {});
 
 SIREPO.app.config(function(localRoutesProvider, $compileProvider, $locationProvider, $routeProvider) {
-    var localRoutes = localRoutesProvider.$get();
+    let localRoutes = localRoutesProvider.$get();
+    let defaultRoute = null;
     $locationProvider.hashPrefix('');
     $compileProvider.debugInfoEnabled(false);
     $compileProvider.commentDirectivesEnabled(false);
     $compileProvider.cssClassDirectivesEnabled(false);
     SIREPO.appFieldEditors = '';
 
-    let defaultRoute = null;
     function addRoute(routeName) {
         var routeInfo = SIREPO.APP_SCHEMA.localRoutes[routeName];
         if (! routeInfo.config) {
@@ -189,6 +189,9 @@ SIREPO.app.config(function(localRoutesProvider, $compileProvider, $locationProvi
         if (cfg.templateUrl) {
             cfg.templateUrl += SIREPO.SOURCE_CACHE_KEY;
         }
+        if (routeInfo.route.search(/:simulationId/) >= 0 && cfg.controller) {
+            cfg.template = simulationDetailTemplate(cfg);
+        }
         $routeProvider.when(routeInfo.route, cfg);
         if (routeName === SIREPO.APP_SCHEMA.appDefaults.route) {
             defaultRoute = routeName;
@@ -198,6 +201,22 @@ SIREPO.app.config(function(localRoutesProvider, $compileProvider, $locationProvi
             cfg.redirectTo = routeInfo.route;
             $routeProvider.otherwise(cfg);
         }
+    }
+
+    function simulationDetailTemplate(cfg) {
+        let res = '<div data-simulation-detail-page="" data-controller="' + cfg.controller + '"';
+        delete cfg.controller;
+        if (cfg.templateUrl) {
+            res += ' data-template-url="' + cfg.templateUrl + '"';
+            delete cfg.templateUrl;
+        }
+        else if (cfg.template) {
+            res += ' data-template="' + cfg.template.replaceAll('"', '&quot;') + '"';
+        }
+        else {
+            throw new Error('route must have template or templateUrl attribute: ' + cfg);
+        }
+        return res + '></div>';
     }
 
     for (var routeName in SIREPO.APP_SCHEMA.localRoutes) {


### PR DESCRIPTION
- controllers and directives on simulation detail pages no longer need to check
  appState.isLoaded() or appState.whenModelsLoaded()
- any server callbacks (such as requestSender.getApplicationData()) still need the
  checks in case the models unloaded before the request completed