### PR TITLE
Fix #3505: Put sqlalchemy session on srcontext

### DIFF
--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -119,7 +119,7 @@ def api_authLogout(simulation_type=None):
 
 
 def check_user_has_role(uid, role, raise_forbidden=True):
-    if sirepo.auth_db.UserRole.has_role(uid, role):
+    if auth_db.UserRole.has_role(uid, role):
         return True
     if raise_forbidden:
         sirepo.util.raise_forbidden('uid={} role={} not found'.format(uid, role))
@@ -311,7 +311,7 @@ def need_complete_registration(model):
 
 @contextlib.contextmanager
 def process_request(unit_test=None):
-    with cookie.process_header(unit_test):
+    with auth_db.session_context(), cookie.process_header(unit_test):
         # Logging happens after the return to Flask so the log user must persist
         # beyond the life of process_request
         _set_log_user()

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -311,7 +311,7 @@ def need_complete_registration(model):
 
 @contextlib.contextmanager
 def process_request(unit_test=None):
-    with auth_db.session_context(), cookie.process_header(unit_test):
+    with auth_db.session(), cookie.process_header(unit_test):
         # Logging happens after the return to Flask so the log user must persist
         # beyond the life of process_request
         _set_log_user()

--- a/sirepo/auth/email.py
+++ b/sirepo/auth/email.py
@@ -150,11 +150,11 @@ def _init_model(base):
         @classmethod
         def delete_changed_email(cls, user):
             with auth_db.thread_lock:
-                cls._session.query(cls).filter(
+                cls._session().query(cls).filter(
                     (cls.user_name == user.unverified_email),
                     cls.unverified_email != user.unverified_email
                 ).delete()
-                cls._session.commit()
+                cls._session().commit()
 
     UserModel = AuthEmailUser
 

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -263,7 +263,7 @@ def init_model(callback):
 
 
 @contextlib.contextmanager
-def session_context():
+def session():
     init()
     with sirepo.srcontext.create():
         yield

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -269,6 +269,13 @@ def session():
         yield
 
 
+@contextlib.contextmanager
+def session_and_lock():
+    # TODO(e-carlin): Need locking across processes
+    # git.radiasoft.org/sirepo/issues/3516
+    with session():
+        yield
+
 def _create_session(_):
     s = sirepo.srcontext.get(_SRCONTEXT_SESSION_KEY)
     assert not s, \

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -117,18 +117,6 @@ def db_filename():
 
 
 def init():
-    def _create_session(_):
-        s = sirepo.srcontext.get(_SRCONTEXT_SESSION_KEY)
-        assert not s, \
-            f'existing session={s}'
-        sirepo.srcontext.set(
-            _SRCONTEXT_SESSION_KEY,
-            sqlalchemy.orm.Session(bind=_engine),
-        )
-
-    def _destroy_session(kwargs):
-        kwargs.srcontext.pop(_SRCONTEXT_SESSION_KEY).rollback()
-
     global _engine, DbUpgrade, UserDbBase, UserRegistration, UserRole
 
     if _engine:
@@ -279,6 +267,20 @@ def session_context():
     init()
     with sirepo.srcontext.create():
         yield
+
+
+def _create_session(_):
+    s = sirepo.srcontext.get(_SRCONTEXT_SESSION_KEY)
+    assert not s, \
+        f'existing session={s}'
+    sirepo.srcontext.set(
+        _SRCONTEXT_SESSION_KEY,
+        sqlalchemy.orm.Session(bind=_engine),
+    )
+
+
+def _destroy_session(kwargs):
+    kwargs.srcontext.pop(_SRCONTEXT_SESSION_KEY).rollback()
 
 
 def _migrate_db_file(fn):

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -5,24 +5,27 @@ u"""Auth database
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from __future__ import absolute_import, division, print_function
+from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdc, pkdexc, pkdlog, pkdp
+import contextlib
 import sqlalchemy
 import sqlalchemy.ext.declarative
 import sqlalchemy.orm
 import threading
 # limit imports here
 import sirepo.auth_role
+import sirepo.srcontext
+import sirepo.events
 import sirepo.srdb
 
 
 #: sqlite file located in sirepo_db_dir
 _SQLITE3_BASENAME = 'auth.db'
 
+_SRCONTEXT_SESSION_KEY = 'auth_db_session'
+
 #: SQLAlchemy database engine
 _engine = None
-
-#: SQLAlchemy session instance
-_session = None
 
 #: Keeps track of upgrades applied to the database
 DbUpgrade = None
@@ -114,9 +117,21 @@ def db_filename():
 
 
 def init():
-    global _session, _engine, DbUpgrade, UserDbBase, UserRegistration, UserRole
+    def _create_session(_):
+        s = sirepo.srcontext.get(_SRCONTEXT_SESSION_KEY)
+        assert not s, \
+            f'existing session={s}'
+        sirepo.srcontext.set(
+            _SRCONTEXT_SESSION_KEY,
+            sqlalchemy.orm.Session(bind=_engine),
+        )
 
-    if _session:
+    def _destroy_session(kwargs):
+        kwargs.srcontext.pop(_SRCONTEXT_SESSION_KEY).rollback()
+
+    global _engine, DbUpgrade, UserDbBase, UserRegistration, UserRole
+
+    if _engine:
         return
     f = db_filename()
     _migrate_db_file(f)
@@ -126,13 +141,15 @@ def init():
         # we access a single connection across threads
         connect_args={'check_same_thread': False},
     )
-    _session = sqlalchemy.orm.Session(bind=_engine)
+    sirepo.events.register(PKDict(
+        srcontext_created=_create_session,
+        srcontext_destroyed=_destroy_session,
+    ))
 
     @sqlalchemy.ext.declarative.as_declarative()
     class UserDbBase(object):
         STRING_ID = sqlalchemy.String(8)
         STRING_NAME =  sqlalchemy.String(100)
-        _session = _session
 
         def __init__(self, **kwargs):
             for k, v in kwargs.items():
@@ -140,45 +157,50 @@ def init():
 
         def delete(self):
             with thread_lock:
-                self._session.delete(self)
-                self._session.commit()
+                self._session().delete(self)
+                self._session().commit()
 
         @classmethod
         def delete_all(cls):
             with thread_lock:
-                cls._session.query(cls).delete()
-                cls._session.commit()
+                cls._session().query(cls).delete()
+                cls._session().commit()
 
         def save(self):
             with thread_lock:
-                self._session.add(self)
-                self._session.commit()
+                self._session().add(self)
+                self._session().commit()
 
         @classmethod
         def search_all_by(cls, **kwargs):
             with thread_lock:
-                return cls._session.query(cls).filter_by(**kwargs).all()
+                return cls._session().query(cls).filter_by(**kwargs).all()
 
         @classmethod
         def search_by(cls, **kwargs):
             with thread_lock:
-                return cls._session.query(cls).filter_by(**kwargs).first()
+                return cls._session().query(cls).filter_by(**kwargs).first()
 
         @classmethod
         def search_all_for_column(cls, column, **filter_by):
             with thread_lock:
                 return [
                     getattr(r, column) for r
-                    in cls._session.query(cls).filter_by(**filter_by)
+                    in cls._session().query(cls).filter_by(**filter_by)
                 ]
 
         @classmethod
         def delete_all_for_column_by_values(cls, column, values):
             with thread_lock:
-                cls._session.query(cls).filter(
+                cls._session().query(cls).filter(
                     getattr(cls, column).in_(values),
                 ).delete(synchronize_session='fetch')
-                cls._session.commit()
+                cls._session().commit()
+
+        @classmethod
+        def _session(cls):
+            return sirepo.srcontext.get(_SRCONTEXT_SESSION_KEY)
+
 
     class DbUpgrade(UserDbBase):
         __tablename__ = 'db_upgrade_t'
@@ -201,7 +223,7 @@ def init():
         def all_roles(cls):
             with thread_lock:
                 return [
-                    r[0] for r in cls._session.query(cls.role.distinct()).all()
+                    r[0] for r in cls._session().query(cls.role.distinct()).all()
                 ]
 
         @classmethod
@@ -214,12 +236,12 @@ def init():
         @classmethod
         def delete_roles(cls, uid, roles):
             with thread_lock:
-                cls._session.query(cls).filter(
+                cls._session().query(cls).filter(
                     cls.uid == uid,
                 ).filter(
                     cls.role.in_(roles),
                 ).delete(synchronize_session='fetch')
-                cls._session.commit()
+                cls._session().commit()
                 audit_proprietary_lib_files(uid)
 
         @classmethod
@@ -239,7 +261,7 @@ def init():
         @classmethod
         def uids_of_paid_users(cls):
             return [
-                x[0] for x in cls._session.query(cls).with_entities(cls.uid).filter(
+                x[0] for x in cls._session().query(cls).with_entities(cls.uid).filter(
                     cls.role.in_(sirepo.auth_role.PAID_USER_ROLES),
                 ).distinct().all()
             ]
@@ -250,6 +272,13 @@ def init_model(callback):
     with thread_lock:
         callback(UserDbBase)
         UserDbBase.metadata.create_all(_engine)
+
+
+@contextlib.contextmanager
+def session_context():
+    init()
+    with sirepo.srcontext.create():
+        yield
 
 
 def _migrate_db_file(fn):

--- a/sirepo/db_upgrade.py
+++ b/sirepo/db_upgrade.py
@@ -28,7 +28,7 @@ def do_all():
     assert not _prevent_db_upgrade_file().exists(), \
         f'prevent_db_upgrade_file={_prevent_db_upgrade_file()} found'
 
-    with sirepo.auth_db.session_context():
+    with sirepo.auth_db.session():
         a = sirepo.auth_db.DbUpgrade.search_all_for_column('name')
         f = pkinspect.module_functions('_2')
         for n in sorted(set(f.keys()) - set(a)):

--- a/sirepo/db_upgrade.py
+++ b/sirepo/db_upgrade.py
@@ -27,16 +27,18 @@ _PREVENT_DB_UPGRADE_FILE = 'prevent-db-upgrade'
 def do_all():
     assert not _prevent_db_upgrade_file().exists(), \
         f'prevent_db_upgrade_file={_prevent_db_upgrade_file()} found'
-    a = sirepo.auth_db.DbUpgrade.search_all_for_column('name')
-    f = pkinspect.module_functions('_2')
-    for n in sorted(set(f.keys()) - set(a)):
-        with _backup_db_and_prevent_upgrade_on_error():
-            pkdlog('running upgrade {}', n)
-            f[n]()
-            sirepo.auth_db.DbUpgrade(
-                name=n,
-                created=sirepo.srtime.utc_now(),
-            ).save()
+
+    with sirepo.auth_db.session_context():
+        a = sirepo.auth_db.DbUpgrade.search_all_for_column('name')
+        f = pkinspect.module_functions('_2')
+        for n in sorted(set(f.keys()) - set(a)):
+            with _backup_db_and_prevent_upgrade_on_error():
+                pkdlog('running upgrade {}', n)
+                f[n]()
+                sirepo.auth_db.DbUpgrade(
+                    name=n,
+                    created=sirepo.srtime.utc_now(),
+                ).save()
 
 
 

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -19,12 +19,14 @@ The events:
 - 'github_authorized' emitted once the authorized github user is retrieved and
   confirmed valid but before that user is logged in or the github db is updated.
   kwargs contains user_name, the github handle.
+- 'srcontext_created' emitted when the srcontext object is populated.
+- 'srcontext_destroyed' emitted when the srcontext object is destroyed.
 
 :copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+# Limit imports
 from pykern.pkcollections import PKDict
-from pykern.pkdebug import pkdp
 import aenum
 
 #: Map of events to handlers. Note: this is the list of all possible events.
@@ -32,10 +34,12 @@ _MAP = PKDict(
     auth_logout=[],
     end_api_call=[],
     github_authorized=[],
+    srcontext_created=[],
+    srcontext_destroyed=[],
 )
 
 
-def emit(event, kwargs):
+def emit(event, kwargs=None):
     """Call the handlers for `event` with `kwargs`
 
     Handlers will be called in registration order (FIFO).

--- a/sirepo/events.py
+++ b/sirepo/events.py
@@ -19,8 +19,6 @@ The events:
 - 'github_authorized' emitted once the authorized github user is retrieved and
   confirmed valid but before that user is logged in or the github db is updated.
   kwargs contains user_name, the github handle.
-- 'srcontext_created' emitted when the srcontext object is populated.
-- 'srcontext_destroyed' emitted when the srcontext object is destroyed.
 
 :copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
@@ -34,8 +32,6 @@ _MAP = PKDict(
     auth_logout=[],
     end_api_call=[],
     github_authorized=[],
-    srcontext_created=[],
-    srcontext_destroyed=[],
 )
 
 

--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -129,7 +129,7 @@ class DriverBase(PKDict):
     def make_lib_dir_symlink(self, op):
         import sirepo.auth_db
         m = op.msg
-        with sirepo.auth_db.session_context(), \
+        with sirepo.auth_db.session(), \
              sirepo.auth.set_user_outside_of_http_request(m.uid):
             d = sirepo.simulation_db.simulation_lib_dir(m.simulationType)
             op.lib_dir_symlink = job.LIB_FILE_ROOT.join(

--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -16,6 +16,7 @@ import sirepo.auth
 import sirepo.events
 import sirepo.sim_db_file
 import sirepo.simulation_db
+import sirepo.srcontext
 import sirepo.srdb
 import sirepo.tornado
 import time
@@ -126,8 +127,10 @@ class DriverBase(PKDict):
         )
 
     def make_lib_dir_symlink(self, op):
+        import sirepo.auth_db
         m = op.msg
-        with sirepo.auth.set_user_outside_of_http_request(m.uid):
+        with sirepo.auth_db.session_context(), \
+             sirepo.auth.set_user_outside_of_http_request(m.uid):
             d = sirepo.simulation_db.simulation_lib_dir(m.simulationType)
             op.lib_dir_symlink = job.LIB_FILE_ROOT.join(
                 job.unique_key()

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -290,7 +290,7 @@ class _ComputeJob(PKDict):
                 sirepo.srtime.utc_now_as_int()
                 - cfg.purge_non_premium_after_secs
             )
-            with sirepo.auth_db.session_context():
+            with sirepo.auth_db.session():
                 for u, v in _get_uids_and_files():
                     with sirepo.auth.set_user_outside_of_http_request(u):
                         for f in v:

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -290,11 +290,12 @@ class _ComputeJob(PKDict):
                 sirepo.srtime.utc_now_as_int()
                 - cfg.purge_non_premium_after_secs
             )
-            for u, v in _get_uids_and_files():
-                with sirepo.auth.set_user_outside_of_http_request(u):
-                    for f in v:
-                        _purge_sim(jid=f.purebasename)
-                await tornado.gen.sleep(0)
+            with sirepo.auth_db.session_context():
+                for u, v in _get_uids_and_files():
+                    with sirepo.auth.set_user_outside_of_http_request(u):
+                        for f in v:
+                            _purge_sim(jid=f.purebasename)
+                    await tornado.gen.sleep(0)
         except Exception as e:
             pkdlog('u={} f={} error={} stack={}', u, f, e, pkdexc())
         finally:

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -69,7 +69,9 @@ class Authenticator(jupyterhub.auth.Authenticator):
 
 @contextlib.contextmanager
 def _set_cookie(handler):
-    with sirepo.cookie.set_cookie_outside_of_flask_request(
-        handler.get_cookie(sirepo.cookie.cfg.http_name),
-    ):
+    import sirepo.auth_db
+    with sirepo.auth_db.session_context(), \
+         sirepo.cookie.set_cookie_outside_of_flask_request(
+             handler.get_cookie(sirepo.cookie.cfg.http_name),
+         ):
         yield

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -70,7 +70,7 @@ class Authenticator(jupyterhub.auth.Authenticator):
 @contextlib.contextmanager
 def _set_cookie(handler):
     import sirepo.auth_db
-    with sirepo.auth_db.session_context(), \
+    with sirepo.auth_db.session(), \
          sirepo.cookie.set_cookie_outside_of_flask_request(
              handler.get_cookie(sirepo.cookie.cfg.http_name),
          ):

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -52,7 +52,7 @@ def create_examples():
         if _is_src_dir(d):
             continue;
         uid = simulation_db.uid_from_dir_name(d)
-        with sirepo.auth_db.session_context(), \
+        with sirepo.auth_db.session(), \
              auth.set_user_outside_of_http_request(uid):
             for sim_type in feature_config.cfg().sim_types:
                 simulation_db.verify_app_directory(sim_type)

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -37,9 +37,9 @@ def audit_proprietary_lib_files(*uid):
     import sirepo.auth_db
     import sirepo.auth
 
-    #TODO(robnagler) locking
-    for u in uid or sirepo.auth_db.all_uids():
-        sirepo.auth_db.audit_proprietary_lib_files(u)
+    with sirepo.auth_db.session_and_lock():
+        for u in uid or sirepo.auth_db.all_uids():
+            sirepo.auth_db.audit_proprietary_lib_files(u)
 
 
 def create_examples():
@@ -52,7 +52,7 @@ def create_examples():
         if _is_src_dir(d):
             continue;
         uid = simulation_db.uid_from_dir_name(d)
-        with sirepo.auth_db.session(), \
+        with sirepo.auth_db.session_and_lock(), \
              auth.set_user_outside_of_http_request(uid):
             for sim_type in feature_config.cfg().sim_types:
                 simulation_db.verify_app_directory(sim_type)

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -44,6 +44,7 @@ def audit_proprietary_lib_files(*uid):
 
 def create_examples():
     """Adds missing app examples to all users"""
+    import sirepo.auth_db
     import sirepo.server
 
     sirepo.server.init()
@@ -51,7 +52,8 @@ def create_examples():
         if _is_src_dir(d):
             continue;
         uid = simulation_db.uid_from_dir_name(d)
-        with auth.set_user_outside_of_http_request(uid):
+        with sirepo.auth_db.session_context(), \
+             auth.set_user_outside_of_http_request(uid):
             for sim_type in feature_config.cfg().sim_types:
                 simulation_db.verify_app_directory(sim_type)
                 names = [x.name for x in simulation_db.iterate_simulation_datafiles(

--- a/sirepo/pkcli/jupyterhublogin.py
+++ b/sirepo/pkcli/jupyterhublogin.py
@@ -30,12 +30,11 @@ def create_user(email):
         pykern.pkcli.command_error('invalid email={}', email)
     sirepo.server.init()
     sirepo.template.assert_sim_type('jupyterhublogin')
-    with sirepo.auth_db.session():
+    with sirepo.auth_db.session_and_lock():
         u = sirepo.auth.get_module('email').unchecked_user_by_user_name(email)
         if not u:
             pykern.pkcli.command_error('no sirepo user with email={}', email)
         with sirepo.auth.set_user_outside_of_http_request(u):
-            # TODO(e-carlin): locking
             n = sirepo.sim_api.jupyterhublogin.unchecked_jupyterhub_user_name(
                 have_simulation_db=False,
             )

--- a/sirepo/pkcli/jupyterhublogin.py
+++ b/sirepo/pkcli/jupyterhublogin.py
@@ -30,7 +30,7 @@ def create_user(email):
         pykern.pkcli.command_error('invalid email={}', email)
     sirepo.server.init()
     sirepo.template.assert_sim_type('jupyterhublogin')
-    with sirepo.auth_db.session_context():
+    with sirepo.auth_db.session():
         u = sirepo.auth.get_module('email').unchecked_user_by_user_name(email)
         if not u:
             pykern.pkcli.command_error('no sirepo user with email={}', email)

--- a/sirepo/pkcli/roles.py
+++ b/sirepo/pkcli/roles.py
@@ -70,7 +70,7 @@ def list_roles(*args):
 @contextlib.contextmanager
 def _parse_args(uid_or_email, roles):
     sirepo.server.init()
-    with sirepo.auth_db.session():
+    with sirepo.auth_db.session_and_lock():
         # POSIT: Uid's are from the base62 charset so an '@' implies an email.
         if '@' in uid_or_email:
             u = sirepo.auth.get_module(

--- a/sirepo/pkcli/roles.py
+++ b/sirepo/pkcli/roles.py
@@ -70,7 +70,7 @@ def list_roles(*args):
 @contextlib.contextmanager
 def _parse_args(uid_or_email, roles):
     sirepo.server.init()
-    with sirepo.auth_db.session_context():
+    with sirepo.auth_db.session():
         # POSIT: Uid's are from the base62 charset so an '@' implies an email.
         if '@' in uid_or_email:
             u = sirepo.auth.get_module(

--- a/sirepo/srcontext.py
+++ b/sirepo/srcontext.py
@@ -4,14 +4,46 @@ u"""Manage global context in threaded (Flask) and non-threaded (Tornado) applica
 :copyright: Copyright (c) 2021 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+# Limit imports
 from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
-from pykern.pkdebug import pkdp
+import contextlib
+import sirepo.events
 import sirepo.util
 
 _FLASK_G_SR_CONTEXT_KEY = 'srcontext'
 
-_NON_THREADED_CONTEXT = PKDict()
+_non_threaded_context = None
+
+
+@contextlib.contextmanager
+def create():
+    """Create an srcontext approprieate for our current state (flask or not)
+
+    It is possible to have both _non_threaded_context and flask.g set
+    (ex in tests).
+    """
+    try:
+        if sirepo.util.in_flask_request():
+            import flask
+            assert not flask.g.get(_FLASK_G_SR_CONTEXT_KEY), \
+                f'existing srcontext on flask.g={flask.g}'
+            flask.g.setdefault(_FLASK_G_SR_CONTEXT_KEY, PKDict())
+        else:
+            global _non_threaded_context
+            assert not _non_threaded_context, \
+                'existing _non_threaded_context{_non_threaded_context}'
+            _non_threaded_context = PKDict()
+        sirepo.events.emit('srcontext_created')
+        yield
+    finally:
+        if sirepo.util.in_flask_request():
+            import flask
+            c = flask.g.pop(_FLASK_G_SR_CONTEXT_KEY)
+        else:
+            c = _non_threaded_context
+            _non_threaded_context = None
+        sirepo.events.emit('srcontext_destroyed', PKDict(srcontext=c))
 
 
 def get(key, default=None):
@@ -33,5 +65,5 @@ def setdefault(key, default=None):
 def _context():
     if sirepo.util.in_flask_request():
         import flask
-        return flask.g.setdefault(_FLASK_G_SR_CONTEXT_KEY, default=PKDict())
-    return _NON_THREADED_CONTEXT
+        return flask.g.get(_FLASK_G_SR_CONTEXT_KEY)
+    return _non_threaded_context

--- a/sirepo/srcontext.py
+++ b/sirepo/srcontext.py
@@ -34,8 +34,7 @@ def create():
             assert not _non_threaded_context, \
                 'existing _non_threaded_context{_non_threaded_context}'
             _non_threaded_context = PKDict()
-        sirepo.events.emit('srcontext_created')
-        yield
+        yield _context()
     finally:
         if sirepo.util.in_flask_request():
             import flask
@@ -43,7 +42,6 @@ def create():
         else:
             c = _non_threaded_context
             _non_threaded_context = None
-        sirepo.events.emit('srcontext_destroyed', PKDict(srcontext=c))
 
 
 def get(key, default=None):

--- a/sirepo/srunit.py
+++ b/sirepo/srunit.py
@@ -7,11 +7,11 @@ u"""Support for unit tests
 from __future__ import absolute_import, division, print_function
 from pykern import pkcompat
 from pykern.pkcollections import PKDict
+import contextlib
 import flask
 import flask.testing
 import json
 import re
-
 
 #: Default "app"
 MYAPP = 'myapp'
@@ -97,6 +97,13 @@ def sim_data(sim_name=None, sim_type=None, sim_types=CONFTEST_DEFAULT_CODES, cfg
     fc = flask_client(sim_types=sim_types or [sim_type or MYAPP], cfg=cfg)
     fc.sr_login_as_guest()
     return fc.sr_sim_data(sim_name=sim_name, sim_type=sim_type), fc
+
+
+@contextlib.contextmanager
+def srcontext():
+    import sirepo.auth_db
+    with sirepo.auth_db.session_context():
+        yield
 
 
 def test_in_request(op, cfg=None, before_request=None, headers=None, want_cookie=True, want_user=True, **kwargs):

--- a/sirepo/srunit.py
+++ b/sirepo/srunit.py
@@ -102,7 +102,7 @@ def sim_data(sim_name=None, sim_type=None, sim_types=CONFTEST_DEFAULT_CODES, cfg
 @contextlib.contextmanager
 def srcontext():
     import sirepo.auth_db
-    with sirepo.auth_db.session_context():
+    with sirepo.auth_db.session():
         yield
 
 

--- a/sirepo/srunit.py
+++ b/sirepo/srunit.py
@@ -30,6 +30,13 @@ CONFTEST_DEFAULT_CODES = None
 
 SR_SIM_TYPE_DEFAULT = MYAPP
 
+@contextlib.contextmanager
+def auth_db_session():
+    import sirepo.auth_db
+    with sirepo.auth_db.session():
+        yield
+
+
 def flask_client(cfg=None, sim_types=None, job_run_mode=None):
     """Return FlaskClient with easy access methods.
 
@@ -97,13 +104,6 @@ def sim_data(sim_name=None, sim_type=None, sim_types=CONFTEST_DEFAULT_CODES, cfg
     fc = flask_client(sim_types=sim_types or [sim_type or MYAPP], cfg=cfg)
     fc.sr_login_as_guest()
     return fc.sr_sim_data(sim_name=sim_name, sim_type=sim_type), fc
-
-
-@contextlib.contextmanager
-def srcontext():
-    import sirepo.auth_db
-    with sirepo.auth_db.session():
-        yield
 
 
 def test_in_request(op, cfg=None, before_request=None, headers=None, want_cookie=True, want_user=True, **kwargs):

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -188,10 +188,8 @@ def flask_app():
 
 def in_flask_request():
     import sys
-    if 'flask' not in sys.modules:
-        return None
-    import flask
-    return flask.request or None
+    f = sys.modules.get('flask')
+    return f and f.request or None
 
 
 def init(server_context=False):

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -187,8 +187,10 @@ def flask_app():
     return flask.current_app or None
 
 def in_flask_request():
+    import sys
+    if 'flask' not in sys.modules:
+        return None
     import flask
-
     return flask.request or None
 
 

--- a/tests/adm_and_own_jobs_test.py
+++ b/tests/adm_and_own_jobs_test.py
@@ -39,7 +39,7 @@ def test_adm_jobs_forbidden(auth_fc):
     import sirepo.auth_db
 
     def _op(fc, sim_type):
-        with srunit.srcontext():
+        with srunit.auth_db_session():
             sirepo.auth_db.UserRole.delete_all_for_column_by_values(
                 'uid',
                 [fc.sr_auth_state().uid, ],
@@ -81,7 +81,7 @@ def test_srw_user_see_only_own_jobs(auth_fc):
         fc.sr_post('runCancel', cancel_req)
 
     def _clear_role_db():
-        with srunit.srcontext():
+        with srunit.auth_db_session():
             sirepo.auth_db.UserRole.delete_all()
 
     def _get_jobs(adm, job_count):
@@ -125,7 +125,7 @@ def test_srw_user_see_only_own_jobs(auth_fc):
             uid,
             sirepo.auth_role.ROLE_ADM,
         )
-        with srunit.srcontext():
+        with srunit.auth_db_session():
             r = sirepo.auth_db.UserRole.search_all_for_column('uid')
         pkunit.pkeq(1, len(r), 'One user with role adm r={}', r)
         pkunit.pkeq(r[0], uid, 'Expected same uid as user')

--- a/tests/adm_and_own_jobs_test.py
+++ b/tests/adm_and_own_jobs_test.py
@@ -35,10 +35,15 @@ def test_adm_jobs(auth_fc):
 def test_adm_jobs_forbidden(auth_fc):
     from pykern import pkunit
     from pykern.pkdebug import pkdp
+    from sirepo import srunit
+    import sirepo.auth_db
 
     def _op(fc, sim_type):
-        import sirepo.auth_db
-        sirepo.auth_db.UserRole.delete_all_for_column_by_values('uid', [fc.sr_auth_state().uid, ])
+        with srunit.srcontext():
+            sirepo.auth_db.UserRole.delete_all_for_column_by_values(
+                'uid',
+                [fc.sr_auth_state().uid, ],
+            )
         r = fc.sr_post(
             'admJobs',
             PKDict(simulationType=sim_type),
@@ -67,6 +72,7 @@ def test_srw_get_own_jobs(auth_fc):
 def test_srw_user_see_only_own_jobs(auth_fc):
     from pykern import pkunit
     from pykern.pkdebug import pkdp
+    from sirepo import srunit
     import sirepo.auth_db
     import sirepo.auth_role
 
@@ -75,7 +81,8 @@ def test_srw_user_see_only_own_jobs(auth_fc):
         fc.sr_post('runCancel', cancel_req)
 
     def _clear_role_db():
-        sirepo.auth_db.UserRole.delete_all()
+        with srunit.srcontext():
+            sirepo.auth_db.UserRole.delete_all()
 
     def _get_jobs(adm, job_count):
         r = fc.sr_post(
@@ -118,7 +125,8 @@ def test_srw_user_see_only_own_jobs(auth_fc):
             uid,
             sirepo.auth_role.ROLE_ADM,
         )
-        r = sirepo.auth_db.UserRole.search_all_for_column('uid')
+        with srunit.srcontext():
+            r = sirepo.auth_db.UserRole.search_all_for_column('uid')
         pkunit.pkeq(1, len(r), 'One user with role adm r={}', r)
         pkunit.pkeq(r[0], uid, 'Expected same uid as user')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,16 +57,18 @@ def fc_module(request, cfg=None):
 def import_req(request):
 
     def w(path):
+        import sirepo.srunit
         import sirepo.http_request
-        req = sirepo.http_request.parse_params(
-            filename=path.basename,
-            folder='/import_test',
-            template=True,
-            type=_sim_type(request),
-        )
-        # Supports read() for elegant and zgoubi
-        req.file_stream = path
-        return req
+        with sirepo.srunit.srcontext():
+            req = sirepo.http_request.parse_params(
+                filename=path.basename,
+                folder='/import_test',
+                template=True,
+                type=_sim_type(request),
+            )
+            # Supports read() for elegant and zgoubi
+            req.file_stream = path
+            return req
 
     return w
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def import_req(request):
     def w(path):
         import sirepo.srunit
         import sirepo.http_request
-        with sirepo.srunit.srcontext():
+        with sirepo.srunit.auth_db_session():
             req = sirepo.http_request.parse_params(
                 filename=path.basename,
                 folder='/import_test',

--- a/tests/cookie2_test.py
+++ b/tests/cookie2_test.py
@@ -28,8 +28,10 @@ def test_cookie_outside_of_flask_request():
     from pykern import pkcompat
     from pykern.pkunit import pkeq
     from sirepo import cookie
+    from sirepo import srunit
 
-    with cookie.set_cookie_outside_of_flask_request():
+    with srunit.srcontext(), \
+         cookie.set_cookie_outside_of_flask_request():
         cookie.set_value('hi4', 'hello')
         r = _Response(status_code=200)
         cookie.save_to_cookie(r)

--- a/tests/cookie2_test.py
+++ b/tests/cookie2_test.py
@@ -30,7 +30,7 @@ def test_cookie_outside_of_flask_request():
     from sirepo import cookie
     from sirepo import srunit
 
-    with srunit.srcontext(), \
+    with srunit.auth_db_session(), \
          cookie.set_cookie_outside_of_flask_request():
         cookie.set_value('hi4', 'hello')
         r = _Response(status_code=200)

--- a/tests/supervisor_purge_free_sims_test.py
+++ b/tests/supervisor_purge_free_sims_test.py
@@ -33,12 +33,14 @@ def test_myapp_free_user_sim_purged(auth_fc):
         pkunit.pkeq(should_exist, len(f), 'incorrect file count')
 
     def _make_user_premium(uid):
+        from sirepo import srunit
         import sirepo.pkcli.roles
         sirepo.pkcli.roles.add_roles(
             uid,
             sirepo.auth_role.ROLE_PAYMENT_PLAN_PREMIUM,
         )
-        r = sirepo.auth_db.UserRole.search_all_for_column('uid')
+        with srunit.srcontext():
+            r = sirepo.auth_db.UserRole.search_all_for_column('uid')
         pkunit.pkeq(r, [uid], 'expecting one premium user with same id')
 
     def _run_sim(data):

--- a/tests/supervisor_purge_free_sims_test.py
+++ b/tests/supervisor_purge_free_sims_test.py
@@ -39,7 +39,7 @@ def test_myapp_free_user_sim_purged(auth_fc):
             uid,
             sirepo.auth_role.ROLE_PAYMENT_PLAN_PREMIUM,
         )
-        with srunit.srcontext():
+        with srunit.auth_db_session():
             r = sirepo.auth_db.UserRole.search_all_for_column('uid')
         pkunit.pkeq(r, [uid], 'expecting one premium user with same id')
 


### PR DESCRIPTION
In #3505 the sqlalchemy session was not rolled back after a failed
commit. We were using a global session across the app which brought
Sirepo down.

This puts the sqlalchemy session on srcontext. The seesion is
instantiated and destroyed/rolled back with each request (in
uri_router._dispatch).

Not using a global session means that all code that needs to use the
auth_db needs to have an instantiated session. In Flask it is created
and destroyed with each request (_dispatch). For pkcli, tests, and in
the supervisor we must create the context by hand everywhere we need
it.

For pkcli we considered creating the context in
sirepo_console.py. This works fine in Flask where `sirepo service
http` ends up creating a new process so the context in
sirepo_console.py doesn't conflict with the one created in _dispatch
But, in the case of the job_supervisor we are in the same process as
the "spawning" console process. srcontext is not reentrant so we would
have to use one global context for the whole supervisor. This would
mean if the supervisor had one failed commit then the session is
ruined for the whole process which is a problem.