### PR TITLE
Fix #3528: bluesky user not registered

### DIFF
--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -425,8 +425,6 @@ def set_user_outside_of_http_request(uid):
 
     assert not util.in_flask_request(), \
         'Only call from outside a flask request context'
-    assert auth_db.UserRegistration.search_by(uid=uid), \
-        f'no registered user with uid={uid}'
     with cookie.set_cookie_outside_of_flask_request():
         _login_user(
             _auth_module(),


### PR DESCRIPTION
The bluesky user is not registered. That is, it doesn't have a record
in the UserRegistration table.

The assert for registered user was added as a fail fast mechanism in
PR #3481 under the misguided assumption that all users were registered.