### PR TITLE
Fix #3537 - saveQuietly lineouts on path change

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1136,7 +1136,7 @@ SIREPO.app.controller('RadiaVisualizationController', function (appState, errorS
                         continue;
                     }
                     appState.models[rpt].fieldPath = r;
-                    appState.saveChanges(rpt);
+                    appState.saveQuietly(rpt);
                     break;
                 }
             }


### PR DESCRIPTION
Two ```saveChanges()``` were overlapping, causing a race condition