### PR TITLE
Fix  #3555 to allow radia zip import

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1154,7 +1154,7 @@ SIREPO.app.directive('appFooter', function() {
         },
         template: [
             '<div data-common-footer="nav"></div>',
-            `<div data-dmp-import-dialog="" data-title="Import File" data-description="Select Radia dmp (.dat) or ${SIREPO.APP_SCHEMA.productInfo.shortName} Export (.zip)"></div>`,
+            `<div data-dmp-import-dialog="" data-title="Import File" data-description="Select Radia dump (.dat) or ${SIREPO.APP_SCHEMA.productInfo.shortName} Export (.zip)"></div>`,
         ].join(''),
     };
 });
@@ -1260,7 +1260,7 @@ SIREPO.app.directive('dmpImportDialog', function(appState, fileManager, fileUplo
                 let data = null;
                 let a = inputFile.name.split('.');
                 let t = `${a[a.length - 1]}`;
-                if (RADIA_IMPORT_FORMATS.indexOf(`.${t}`) >= 0) {
+                if (isRadiaImport(t)) {
                     data = newSimFromImport(inputFile);
                 }
                 importFile(inputFile, t, data);
@@ -1300,7 +1300,7 @@ SIREPO.app.directive('dmpImportDialog', function(appState, fileManager, fileUplo
                         }),
                     function(d) {
                         let simId = d.models.simulation.simulationId;
-                        if (RADIA_IMPORT_FORMATS.indexOf(fileType) < 0) {
+                        if (! isRadiaImport(fileType)) {
                             cleanup(simId);
                             return;
                         }
@@ -1319,6 +1319,10 @@ SIREPO.app.directive('dmpImportDialog', function(appState, fileManager, fileUplo
                     s += `${k}${d.item}${o[k]}${d.list}`;
                 }
                 return s;
+            }
+
+            function isRadiaImport(fileType) {
+                return RADIA_IMPORT_FORMATS.indexOf(`.${fileType}`) >= 0;
             }
 
             function upload(inputFile, fileType, simId) {

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1279,6 +1279,7 @@ SIREPO.app.directive('dmpImportDialog', function(appState, fileManager, fileUplo
                 model.name = inputFile.name.substring(0, inputFile.name.indexOf('.'));
                 model.folder = fileManager.getActiveFolderPath();
                 model.dmpImportFile = inputFile.name;
+                model.notes = `Imported from ${inputFile.name}`;
                 return model;
             }
 

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1154,7 +1154,7 @@ SIREPO.app.directive('appFooter', function() {
         },
         template: [
             '<div data-common-footer="nav"></div>',
-            `<div data-dmp-import-dialog="" data-title="Import File" data-description="Select Radia dmp (.dat), STL (.stl), or ${SIREPO.APP_SCHEMA.productInfo.shortName} Export (.zip)"></div>`,
+            `<div data-dmp-import-dialog="" data-title="Import File" data-description="Select Radia dmp (.dat) or ${SIREPO.APP_SCHEMA.productInfo.shortName} Export (.zip)"></div>`,
         ].join(''),
     };
 });

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1261,7 +1261,7 @@ SIREPO.app.directive('dmpImportDialog', function(appState, fileManager, fileUplo
                 let a = inputFile.name.split('.');
                 let t = `${a[a.length - 1]}`;
                 if (RADIA_IMPORT_FORMATS.indexOf(`.${t}`) >= 0) {
-                    data = newSimFromRadia(inputFile);
+                    data = newSimFromImport(inputFile);
                 }
                 importFile(inputFile, t, data);
             };
@@ -1274,7 +1274,7 @@ SIREPO.app.directive('dmpImportDialog', function(appState, fileManager, fileUplo
                 requestSender.localRedirectHome(simId);
             }
 
-            function newSimFromRadia(inputFile) {
+            function newSimFromImport(inputFile) {
                 let model = appState.setModelDefaults(appState.models.simulation, 'simulation');
                 model.name = inputFile.name.substring(0, inputFile.name.indexOf('.'));
                 model.folder = fileManager.getActiveFolderPath();

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1263,7 +1263,7 @@ SIREPO.app.directive('dmpImportDialog', function(appState, fileManager, fileUplo
                 if (RADIA_IMPORT_FORMATS.indexOf(t) >= 0) {
                     data = newSimFromRadia(inputFile);
                 }
-                upload(inputFile, data);
+                import(inputFile, data);
             };
 
             // turn a dict into a delimited string so it can be added to the FormData.
@@ -1285,7 +1285,7 @@ SIREPO.app.directive('dmpImportDialog', function(appState, fileManager, fileUplo
                 return model;
             }
 
-            function upload(inputFile, data={}) {
+            function import(inputFile, data={}) {
                 let f = fileManager.getActiveFolderPath();
                 if (fileManager.isFolderExample(f)) {
                     f = fileManager.rootFolder();
@@ -1302,6 +1302,8 @@ SIREPO.app.directive('dmpImportDialog', function(appState, fileManager, fileUplo
                             '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
                         }),
                     function(d) {
+                        srdbg('GOT D', d);
+
                         $('#simulation-import').modal('hide');
                         $scope.inputFile = null;
                         URL.revokeObjectURL($scope.fileURL);
@@ -1310,6 +1312,10 @@ SIREPO.app.directive('dmpImportDialog', function(appState, fileManager, fileUplo
                     }, function (err) {
                         throw new Error(inputFile + ': Error during upload ' + err);
                     });
+            }
+
+            function upload(inputFile) {
+                
             }
 
         },

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -45,6 +45,10 @@
             "get_field", "get_field_integrals", "get_geom", "get_kick_map_plot", "save_field"
         ],
         "inProgressText": "Solving",
+        "inputFileArgDelims": {
+            "list": ",",
+            "item": ":"
+        },
         "objectScale": 0.001,
         "parameterizedMagnets": {
             "hybridUndulator": {

--- a/sirepo/sim_data/radia.py
+++ b/sirepo/sim_data/radia.py
@@ -47,6 +47,8 @@ class SimData(sirepo.sim_data.SimDataBase):
     @classmethod
     def _lib_file_basenames(cls, data):
         res = []
+        if 'dmpImportFile' in data.models.simulation:
+            res.append(f'{cls.schema().constants.radiaDmpFileType}.{data.models.simulation.dmpImportFile}')
         if 'fieldType' in data:
             res.append(cls.lib_file_name_with_model_field(
                 'fieldPath',


### PR DESCRIPTION
Notes:

- Uses template ```import_file``` to manage importing Radia dump files alongside sirepo zips. That method also replicates some of the work in server's ```api_newSimulation``` since that does not get called for imports
- Uses ```import_file_arguments``` to add Radia-dump-specific model info. I don't see a standardized way to do that, so I used a delimited string of the form ```<key1>:<val1>,...```. 
- Added a simulation note to indicate when a simulation was imported from a Radia dump file
- Omitting STL import for the moment