### PR TITLE
Fix radiasoft/rsdockerspawner#25: prevent blocked jupyterhublogin use…

### DIFF
--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -334,8 +334,7 @@ def require_auth_basic():
 
 
 def require_sim_type(sim_type):
-    if sim_type not in sirepo.feature_config.cfg().proprietary_sim_types:
-        # only check role for proprietary_sim_types
+    if sim_type not in sirepo.feature_config.cfg().all_proprietary_sim_types:
         return
     if not _is_logged_in():
         # If a user is not logged in, we allow any sim_type, because

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -51,7 +51,7 @@ def audit_proprietary_lib_files(uid, force=False, sim_types=None):
     Args:
       uid (str): The uid of the user to audit
       force (bool): Overwrite existing lib files with the same name as new ones
-      sim_types (set): Set of sim_types to audit (all proprietary_sim_types if None)
+      sim_types (set): Set of sim_types to audit (proprietary_sim_types if None)
     """
     import contextlib
     import py

--- a/sirepo/auth_role.py
+++ b/sirepo/auth_role.py
@@ -24,7 +24,7 @@ def for_new_user(is_guest):
 def get_all():
     c = sirepo.feature_config.cfg()
     return [
-        for_sim_type(t) for t in c.proprietary_sim_types.union(c.default_proprietary_sim_types)
+        for_sim_type(t) for t in c.all_proprietary_sim_types
     ] + [
         ROLE_ADM,
         ROLE_PAYMENT_PLAN_ENTERPRISE,

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -121,6 +121,9 @@ def _init():
     i = _cfg.proprietary_sim_types.intersection(_cfg.default_proprietary_sim_types)
     assert not i, \
         f'{i}: cannot be in proprietary_sim_types and default_proprietary_sim_types'
+    _cfg.all_proprietary_sim_types = frozenset(
+        _cfg.proprietary_sim_types.union(_cfg.default_proprietary_sim_types),
+    )
     s = set(
         _cfg.sim_types or (
             _PROD_FOSS_CODES if pkconfig.channel_in('prod') else _FOSS_CODES

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -35,8 +35,7 @@ class Authenticator(jupyterhub.auth.Authenticator):
     async def authenticate(self, handler, data):
         with _set_cookie(handler):
             try:
-                sirepo.auth.require_user()
-                sirepo.auth.require_sim_type('jupyterhublogin')
+                self._check_permissions()
             except werkzeug.exceptions.Forbidden:
                 # returning None means the user is forbidden (403)
                 # https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.authenticate
@@ -58,13 +57,19 @@ class Authenticator(jupyterhub.auth.Authenticator):
     async def refresh_user(self, user, handler=None):
         with _set_cookie(handler):
             try:
-                sirepo.auth.require_user()
+                self._check_permissions()
             except sirepo.util.SRException:
                 # Returning False is what the jupyterhub API expects and jupyterhub
                 # will handle re-authenticating the user.
                 # https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.refresh_user
                 return False
             return True
+
+    def _check_permissions(self):
+        sirepo.auth.require_user()
+        sirepo.auth.require_sim_type('jupyterhublogin')
+
+
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
…rs from accessing the system

There were a couple problems that made it so blocked users could still
access the system:
1. In sirepo.jupyterhub.Authenticator.refresh_user we validated the user but we
did not validate that they still had the sim_type_jupyterhublogin role
2. In require_sim_type (which is how we validated the user has the role for the
sim type) we only checked proprietary_sim_types. jupyterhublogin is a
default_proprietary_sim_type

@robnagler when we delete the `jupyterhublogin` role from a user we need to also stop the user's server. This is the only way I've found that guranteees that they can no longer access the system.