### PR TITLE
Fix #3593: Prevent labels from overlapping with beamline elements

### DIFF
--- a/sirepo/package_data/static/html/controls-controls.html
+++ b/sirepo/package_data/static/html/controls-controls.html
@@ -7,7 +7,7 @@
   <div class="row">
     <div class="col-sm-12">
       <div data-simple-panel="beamline">
-        <div id="sr-lattice" data-lattice="" class="sr-plot" data-model-name="beamlines" data-path-to-models="externalLattice"></div>
+        <div id="sr-lattice" data-lattice="" class="sr-plot" data-margin="25" data-model-name="beamlines" data-path-to-models="externalLattice"></div>
       </div>
     </div>
   </div>

--- a/sirepo/package_data/static/js/sirepo-lattice.js
+++ b/sirepo/package_data/static/js/sirepo-lattice.js
@@ -1248,6 +1248,7 @@ SIREPO.app.directive('lattice', function(appState, latticeService, panelState, p
     return {
         restrict: 'A',
         scope: {
+            margin: '<',
             modelName: '@',
             flatten: '@',
             pathToModels: '@',
@@ -1263,7 +1264,7 @@ SIREPO.app.directive('lattice', function(appState, latticeService, panelState, p
             const ABSOLUTE_POSITION_TYPE = 'absolutePosition';
             $scope.plotStyle = $scope.flatten ? '' : 'cursor: zoom-in;';
             $scope.isClientOnly = true;
-            $scope.margin = $scope.flatten ? 0 : 3;
+            $scope.margin = $scope.margin || ($scope.flatten ? 0 : 3);
             $scope.width = 1;
             $scope.height = 1;
             $scope.xScale = 1;


### PR DESCRIPTION
In testing it seemed that calling `getBoundingClientRect()` on the label
div multiple times yielded different results so I could eliminate
keeping track of `yOffset`.