### PR TITLE
Fix #3454: Hide "no file chosen" for opal.in when selecting missing f…

### DIFF
--- a/sirepo/package_data/static/js/opal.js
+++ b/sirepo/package_data/static/js/opal.js
@@ -656,6 +656,7 @@ SIREPO.app.directive('opalImportOptions', function(fileUpload, requestSender) {
             $scope.hasMissingFiles = function() {
                 if (parentScope.fileUploadError) {
                     if (parentScope.errorData && parentScope.errorData.missingFiles) {
+                        parentScope.hideMainImportSelector = true;
                         $scope.missingFiles = [];
                         parentScope.errorData.missingFiles.forEach(function(f) {
                             f.file = {};

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -2312,9 +2312,11 @@ SIREPO.app.directive('importDialog', function(appState, fileManager, fileUpload,
                     '<form data-file-loader="" data-file-formats="fileFormats" data-description="description">',
                       '<form name="importForm">',
                         '<div class="form-group">',
-                          '<label>{{ description }}</label>',
-                          '<input id="file-import" type="file" data-file-model="inputFile" data-ng-attr-accept="{{ fileFormats }}">',
-                          '<br />',
+                          '<div data-ng-show="! hideMainImportSelector">',
+                            '<label>{{ description }}</label>',
+                            '<input id="file-import" type="file" data-file-model="inputFile" data-ng-attr-accept="{{ fileFormats }}">',
+                            '<br />',
+                          '</div>',
                           '<div class="text-warning"><strong>{{ fileUploadError }}</strong></div>',
                           '<div data-ng-transclude=""></div>',
                         '</div>',
@@ -2333,6 +2335,8 @@ SIREPO.app.directive('importDialog', function(appState, fileManager, fileUpload,
         ].join(''),
         controller: function($element, $scope) {
             $scope.fileUploadError = '';
+            // used by sub componenets to possibly hide the "main" file import selector
+            $scope.hideMainImportSelector = false;
             $scope.isUploading = false;
             $scope.title = $scope.title || 'Import ZIP File';
             $scope.description = $scope.description || 'Select File';

--- a/sirepo/template/opal_parser.py
+++ b/sirepo/template/opal_parser.py
@@ -47,7 +47,7 @@ class OpalParser(lattice.LatticeParser):
         input_files = self.__update_filenames()
         self.__set_element_positions(cv)
         self.__sort_element_positions(cv)
-        self._set_default_beamline('select', 'line')
+        self._set_default_beamline('track', 'line')
         self.__legacy_fixups()
         self.__convert_references_to_ids()
         self.__combine_options()


### PR DESCRIPTION
…iles

This hides the "main" file selector (opal.in) when selecting the missing
files identified in the import of opal.in