### PR TITLE
Example improvements

### DIFF
--- a/sirepo/package_data/template/radia/examples/undulator.json
+++ b/sirepo/package_data/template/radia/examples/undulator.json
@@ -9,11 +9,11 @@
             "paths": [
                 {
                     "_super": "fieldPath",
-                    "begin": "-0.0,-57.5,-0.0",
-                    "end": "0.0,57.5,0.0",
+                    "begin": "-0.0,-150,-0.0",
+                    "end": "0.0,150,0.0",
                     "id": "6233b2ae-cc3e-4ec8-a746-b1e947a67ca0",
                     "name": "y axis",
-                    "numPoints": 59,
+                    "numPoints": 301,
                     "type": "line"
                 }
             ]

--- a/sirepo/package_data/template/radia/examples/wiggler.json
+++ b/sirepo/package_data/template/radia/examples/wiggler.json
@@ -1,8 +1,22 @@
 {
     "models": {
-         "fieldPaths": {
+        "fieldDisplay": {
+            "colorMap": "viridis",
+            "scaling": "linear"
+        },
+        "fieldPaths": {
             "path": "line",
-            "paths": []
+            "paths": [
+                {
+                    "_super": "fieldPath",
+                    "begin": "0, -225, 0",
+                    "end": "0, 225, 0",
+                    "id": 0,
+                    "name": "y axis",
+                    "numPoints": 101,
+                    "type": "line"
+                }
+            ]
         },
         "geometry": {
             "isSolvable": "0",
@@ -20,7 +34,7 @@
         "magnetDisplay": {
             "bgColor": "#ffffff",
             "fieldPoints": [],
-            "fieldType": "M",
+            "fieldType": "B",
             "notes": "",
             "viewType": "objects"
         },

--- a/sirepo/sim_data/radia.py
+++ b/sirepo/sim_data/radia.py
@@ -50,6 +50,16 @@ class SimData(sirepo.sim_data.SimDataBase):
                 dm.simulation.exampleName = dm.simulation.name
             if dm.simulation.name == 'Wiggler':
                 dm.geometry.isSolvable = '0'
+                if not len(dm.fieldPaths.paths):
+                    dm.fieldPaths.paths.append(PKDict(
+                        _super='fieldPath',
+                        begin='0, -225, 0',
+                        end='0, 225, 0',
+                        id= 0,
+                        name='y axis',
+                        numPoints=101,
+                        type='line'
+                    ))
         if dm.simulation.magnetType == 'undulator':
             if not dm.hybridUndulator.get('magnetBaseObjectId'):
                 dm.hybridUndulator.magnetBaseObjectId = _find_obj_by_name(dm.geometry.objects, 'Magnet Block').id


### PR DESCRIPTION
Notes:

- adds a field evaluation path along the y axis to the wiggler example to avoid an empty field view.  Fixes up existing sims if the user has not added a path yet
- extends the y axis path for the undulator example and adds points.  Does NOT fix up existing sims to avoid clobbering user changes
