### PR TITLE
Fix #3649 - accept gap size of 0

### DIFF
--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -570,7 +570,7 @@
         "undulator": {
             "_super": ["_", "model", "radiaObject"],
             "enableKickMaps": ["Enable Kick Maps", "Boolean", "1"],
-            "gap": ["Gap [mm]", "Float", 20.0, "", 1.0],
+            "gap": ["Gap [mm]", "Float", 20.0, "", 0.0],
             "gapAxis": ["Gap Axis", "BeamAxis", "y", "Direction of the magnetic gap - must differ from the beam axis"],
             "numPeriods": ["Number of Periods", "Integer", 2, "", 1],
             "periodLength": ["Period Length [mm]", "Float", 46.0],


### PR DESCRIPTION
Tested against the example that precipitated this issue. Also tested undulators with gap 0 to check that they can be solved.

Oddly, the example was a copy of the dipole example, which does not use and cannot set the gap size.  It may have come from a fairly old build?