### PR TITLE
Fix #3576 - disable invalid madx lattices

### DIFF
--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -4154,13 +4154,19 @@ SIREPO.app.directive('simList', function(appState, requestSender) {
         },
         template: [
             '<div style="white-space: nowrap">',
-              '<select style="display: inline-block" class="form-control" data-ng-model="model[field]" data-ng-options="item.simulationId as item.name disable when item.invalid for item in simList"></select>',
+              '<select style="display: inline-block" class="form-control" data-ng-model="model[field]" data-ng-options="item.simulationId as itemName(item) disable when item.invalidMsg for item in simList"></select>',
               ' ',
               '<button type="button" title="View Simulation" class="btn btn-default" data-ng-click="openSimulation()"><span class="glyphicon glyphicon-eye-open"></span></button>',
             '</div>',
         ].join(''),
         controller: function($scope) {
             $scope.simList = null;
+
+            // special processing of the item's name if necessary
+            $scope.itemName = function(item) {
+                return item.invalidMsg ? `${item.name} <${item.invalidMsg}>` : item.name;
+            };
+
             $scope.openSimulation = function() {
                 if ($scope.model && $scope.model[$scope.field]) {
                     //TODO(e-carlin): this depends on the visualization route

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -4154,7 +4154,7 @@ SIREPO.app.directive('simList', function(appState, requestSender) {
         },
         template: [
             '<div style="white-space: nowrap">',
-              '<select style="display: inline-block" class="form-control" data-ng-model="model[field]" data-ng-options="item.simulationId as item.name for item in simList"></select>',
+              '<select style="display: inline-block" class="form-control" data-ng-model="model[field]" data-ng-options="item.simulationId as item.name disable when item.invalid for item in simList"></select>',
               ' ',
               '<button type="button" title="View Simulation" class="btn btn-default" data-ng-click="openSimulation()"><span class="glyphicon glyphicon-eye-open"></span></button>',
             '</div>',

--- a/sirepo/template/controls.py
+++ b/sirepo/template/controls.py
@@ -51,7 +51,7 @@ def get_application_data(data, **kwargs):
             res.append(PKDict(
                 name=m.simulation.name,
                 simulationId=m.simulation.simulationId,
-                invalid=not (m.beamlines and _has_kickers(m))
+                invalid=not _has_kickers(m)
             ))
         return PKDict(simList=res)
     elif data.method == 'get_external_lattice':
@@ -184,8 +184,6 @@ def _get_external_lattice(simulation_id):
             sirepo.simulation_db.SIMULATION_DATA_FILE,
         ),
     )
-    if not d.models.beamlines:
-        return PKDict()
     _delete_unused_madx_models(d)
     _delete_unused_madx_commands(d)
     _unique_madx_elements(d)

--- a/sirepo/template/controls.py
+++ b/sirepo/template/controls.py
@@ -51,7 +51,7 @@ def get_application_data(data, **kwargs):
             res.append(PKDict(
                 name=m.simulation.name,
                 simulationId=m.simulation.simulationId,
-                invalid=not _has_kickers(m)
+                invalidMsg=None if _has_kickers(m) else 'No beamlines' if not _has_beamline(m) else 'No kickers'
             ))
         return PKDict(simList=res)
     elif data.method == 'get_external_lattice':
@@ -195,8 +195,12 @@ def _get_external_lattice(simulation_id):
     )
 
 
+def _has_beamline(model):
+    return model.elements and model.beamlines
+
+
 def _has_kickers(model):
-    if not model.elements or not model.beamlines:
+    if not _has_beamline(model):
         return False
     k_ids = [e._id for e in model.elements if 'KICKER' in e.type]
     if not k_ids:


### PR DESCRIPTION
Notes:

- Rather than allow the user to select a kicker-less lattice (or indeed a latttice-less sim) and then get an error, I added an "invalid" property to the items in the sim list and disabled them in the dropdown
-  The name in the dropdown includes the reason why it is invalid.  I like this better than a tooltip because the feedback is immediate
