### PR TITLE
Fix #3704 h5py type error

### DIFF
--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -382,7 +382,7 @@ def h5_to_dict(hf, path=None):
                 # in each case we recurse one step deeper into the path
                 p = '{}/{}'.format(path, k)
                 d[k] = h5_to_dict(hf, path=p)
-    except TypeError as te:
+    except TypeError:
         # this TypeError occurs when hf[path] is not iterable (e.g. a string)
         # assume this is a single-valued entry and run it through pkcompat
         return pkcompat.from_bytes(hf[path][()])
@@ -393,10 +393,10 @@ def h5_to_dict(hf, path=None):
         for i in indices:
             d_arr[i] = d[str(i)]
         d = d_arr
-    except IndexError as ie:
+    except IndexError:
         # integer keys but not an array
         pass
-    except ValueError as ve:
+    except ValueError:
         # keys not all integers, we're done
         pass
     return d

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -379,13 +379,13 @@ def h5_to_dict(hf, path=None):
             except (AttributeError, TypeError):
                 # AttributeErrors occur when invoking tolist() on non-arrays
                 # TypeErrors occur when accessing a group with [()]
-                # In each case we recurse one step deeper into the path
+                # in each case we recurse one step deeper into the path
                 p = '{}/{}'.format(path, k)
                 d[k] = h5_to_dict(hf, path=p)
     except TypeError as te:
-        # This TypeError occurs when hf[path] is not iterable (e.g. a string)
-        # assume this is a single-valued entry
-        return hf[path][()]
+        # this TypeError occurs when hf[path] is not iterable (e.g. a string)
+        # assume this is a single-valued entry and run it through pkcompat
+        return pkcompat.from_bytes(hf[path][()])
     # replace dicts with arrays on a 2nd pass
     try:
         indices = [int(k) for k in d.keys()]

--- a/tests/template_common_test.py
+++ b/tests/template_common_test.py
@@ -10,6 +10,9 @@ import zipfile
 
 from pykern import pkresource
 from pykern import pkunit
+from pykern.pkcollections import PKDict
+from sirepo.template import template_common
+
 
 def test_validate_safe_zip():
     from sirepo.template import srw
@@ -34,3 +37,28 @@ def test_validate_safe_zip():
 
     # Finally, accept a zip file known to be safe
     srw._validate_safe_zip(zip_dir + '/good_zip.zip', zip_dir, srw.validate_magnet_data_file)
+
+
+def test_dict_to_from_h5():
+    from pykern import pkio
+    import h5py
+
+    # _TEST_DICT includes single-valued entries (str and int), an array,
+    # and keys that evaluate to ints
+    _TEST_DICT = PKDict(
+        a_str='A',
+        b_dict=PKDict(
+            b_str='B',
+            b_arr=[0, 1, 2]
+        )
+    )
+    _TEST_DICT['999'] = '999'
+    _TEST_DICT['998'] = 998
+    _TEST_H5_FILE = 'test.h5'
+
+    pkio.unchecked_remove(_TEST_H5_FILE)
+    template_common.write_dict_to_h5(_TEST_DICT, _TEST_H5_FILE)
+    d = None
+    with h5py.File(_TEST_H5_FILE, 'r') as f:
+        d = template_common.h5_to_dict(f)
+    pkunit.pkeq(_TEST_DICT, d)

--- a/tests/template_common_test.py
+++ b/tests/template_common_test.py
@@ -10,7 +10,6 @@ import zipfile
 
 from pykern import pkresource
 from pykern import pkunit
-from pykern.pkcollections import PKDict
 from sirepo.template import template_common
 
 
@@ -41,6 +40,7 @@ def test_validate_safe_zip():
 
 def test_dict_to_from_h5():
     from pykern import pkio
+    from pykern.pkcollections import PKDict
     import h5py
 
     # _TEST_DICT includes single-valued entries (str and int), an array,


### PR DESCRIPTION
- catches the new TypeError raised when accessing groups with [()]
- adds ```pkcompat.from_bytes()``` around single-values entries 
- adds a test to ```template_common_test``` to write a dict to h5, read the file into a new dict, and compare the two