### PR TITLE
Fix #3913 - example objs have empty types on purpose

### DIFF
--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -720,7 +720,7 @@ def _generate_parameters_file(data, is_parallel, for_export=False, run_dir=None)
     _validate_objects(v.objects)
 
     for o in v.objects:
-        if 'type' in o:
+        if o.get('type'):
             o.super_classes = _SCHEMA.model[o.type]._super
         # read in h-m curves if applicable
         o.h_m_curve = _read_h_m_file(o.materialFile) if \


### PR DESCRIPTION
The "fix" to "pythonify" the offending line broke the dipole and wiggler examples, whose objects are artificially crafted and have no meaningful type. Since they will be replaced by parameterized versions shortly, this reversion will serve.