### PR TITLE
WIP radiasoft/ops#645: ENOENT when trying to rename flash.tar.gz

### DIFF
--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -53,8 +53,6 @@ def audit_proprietary_lib_files(uid, force=False, sim_types=None):
       force (bool): Overwrite existing lib files with the same name as new ones
       sim_types (set): Set of sim_types to audit (proprietary_sim_types if None)
     """
-    import contextlib
-    import py
     import pykern.pkconfig
     import pykern.pkio
     import sirepo.feature_config
@@ -79,6 +77,9 @@ def audit_proprietary_lib_files(uid, force=False, sim_types=None):
                 stderr=subprocess.STDOUT,
             )
             l = sirepo.simulation_db.simulation_lib_dir(sim_type, uid=uid)
+            # See git.radiasoft.org/ops/issues/645
+            assert l.check(), \
+                'app dir for sim_type={sim_type} but no lib_dir={l}'
             e = [f.basename for f in pykern.pkio.sorted_glob(l.join('*'))]
             for f in sim_data_class.proprietary_code_lib_file_basenames():
                 if force or f not in e:

--- a/sirepo/auth_db.py
+++ b/sirepo/auth_db.py
@@ -76,10 +76,10 @@ def audit_proprietary_lib_files(uid, force=False, sim_types=None):
                 ],
                 stderr=subprocess.STDOUT,
             )
-            l = sirepo.simulation_db.simulation_lib_dir(sim_type, uid=uid)
-            # See git.radiasoft.org/ops/issues/645
-            assert l.check(), \
-                'app dir for sim_type={sim_type} but no lib_dir={l}'
+            # lib_dir may not exist: git.radiasoft.org/ops/issues/645
+            l = pykern.pkio.mkdir_parent(
+                sirepo.simulation_db.simulation_lib_dir(sim_type, uid=uid),
+            )
             e = [f.basename for f in pykern.pkio.sorted_glob(l.join('*'))]
             for f in sim_data_class.proprietary_code_lib_file_basenames():
                 if force or f not in e:


### PR DESCRIPTION
https://github.com/radiasoft/sirepo/blob/ce452bff87ce8f3e44894c96bcb5d8ea4d95ca6b/sirepo/simulation_db.py#L780
`verify_app_directory` ensures that the app dir exists but not that
the lib dir exists. Maybe we were in a state where the app dir existed
but not the lib dir.  This should alert us if we encounter this again.