### PR TITLE
Fix #3941: Check for full file path

### DIFF
--- a/sirepo/pkcli/srw.py
+++ b/sirepo/pkcli/srw.py
@@ -25,6 +25,26 @@ def create_predefined(out_dir=None):
     import srwl_uti_src
     import pykern.pkjson
 
+    def lib_file_path(file_type):
+        return sim_data.srw_lib_file_paths_for_type(
+            file_type,
+            lambda f: PKDict(fileName=f.basename),
+            want_user_lib_dir=False,
+        )
+
+    def predefined_json_path(out_dir):
+        b = srw_common.PREDEFINED_JSON
+        if out_dir:
+            return pkio.py_path(out_dir).join(b)
+        from sirepo.template import template_common
+        # Assume a good location for PREDEFINED_JSON is the same dir
+        # as PARAMETERS_PYTHON_FILE.jinja.
+        return sim_data.resource_path(
+            template_common.jinja_filename(
+                template_common.PARAMETERS_PYTHON_FILE,
+            ),
+        ).dirpath(b)
+
     sim_data = sirepo.sim_data.get_class('srw')
     beams = []
     for beam in srwl_uti_src.srwl_uti_src_e_beam_predef():
@@ -54,33 +74,13 @@ def create_predefined(out_dir=None):
             )),
         )
 
-    def f(file_type):
-        return sim_data.srw_lib_file_paths_for_type(
-            file_type,
-            lambda f: PKDict(fileName=f.basename),
-            want_user_lib_dir=False,
-        )
-
-    def p(out_dir):
-        b = srw_common.PREDEFINED_JSON
-        if out_dir:
-            return pkio.py_path(out_dir).join(b)
-        from sirepo.template import template_common
-        # Assume a good location for PREDEFINED_JSON is the same dir
-        # as PARAMETERS_PYTHON_FILE.jinja.
-        return sim_data.resource_path(
-            template_common.jinja_filename(
-                template_common.PARAMETERS_PYTHON_FILE,
-            ),
-        ).dirpath(b)
-
-    n = p(out_dir)
+    n = predefined_json_path(out_dir)
     pykern.pkjson.dump_pretty(
         PKDict(
             beams=beams,
-            magnetic_measurements=f('undulatorTable'),
-            mirrors=f('mirror'),
-            sample_images=f('sample'),
+            magnetic_measurements=lib_file_path('undulatorTable'),
+            mirrors=lib_file_path('mirror'),
+            sample_images=lib_file_path('sample'),
         ),
         filename=n,
     )

--- a/sirepo/pkcli/srw.py
+++ b/sirepo/pkcli/srw.py
@@ -61,8 +61,20 @@ def create_predefined(out_dir=None):
             want_user_lib_dir=False,
         )
 
-    p = srw_common.PREDEFINED_JSON
-    p = pkio.py_path(out_dir).join(p) if out_dir else sim_data.resource_path('').join(p)
+    def p(out_dir):
+        b = srw_common.PREDEFINED_JSON
+        if out_dir:
+            return pkio.py_path(out_dir).join(b)
+        from sirepo.template import template_common
+        # Assume a good location for PREDEFINED_JSON is the same dir
+        # as PARAMETERS_PYTHON_FILE.jinja.
+        return sim_data.resource_path(
+            template_common.jinja_filename(
+                template_common.PARAMETERS_PYTHON_FILE,
+            ),
+        ).dirpath(b)
+
+    n = p(out_dir)
     pykern.pkjson.dump_pretty(
         PKDict(
             beams=beams,
@@ -70,9 +82,9 @@ def create_predefined(out_dir=None):
             mirrors=f('mirror'),
             sample_images=f('sample'),
         ),
-        filename=p,
+        filename=n,
     )
-    return 'Created {}'.format(p)
+    return 'Created {}'.format(n)
 
 
 def python_to_json(run_dir='.', in_py='in.py', out_json='out.json'):

--- a/sirepo/pkcli/srw.py
+++ b/sirepo/pkcli/srw.py
@@ -36,7 +36,6 @@ def create_predefined(out_dir=None):
         b = srw_common.PREDEFINED_JSON
         if out_dir:
             return pkio.py_path(out_dir).join(b)
-        from sirepo.template import template_common
         # Assume a good location for PREDEFINED_JSON is the same dir
         # as PARAMETERS_PYTHON_FILE.jinja.
         return sim_data.resource_path(

--- a/sirepo/sim_data/srw.py
+++ b/sirepo/sim_data/srw.py
@@ -390,15 +390,16 @@ class SimData(sirepo.sim_data.SimDataBase):
     @classmethod
     def srw_predefined(cls):
         import pykern.pkjson
-        import sirepo.template.srw_common
+        from sirepo.template import srw_common
 
-        # TODO(e-carlin): git.radiasoft.org/sirepo/issues/3941
-        f = cls.resource_path('').join(sirepo.template.srw_common.PREDEFINED_JSON)
-        if not f.check():
+        try:
+            f = cls.resource_path(srw_common.PREDEFINED_JSON)
+        except FileNotFoundError:
             assert pkconfig.channel_in('dev'), \
-                '{}: not found; call "sirepo srw create-predefined" before pip install'.format(f)
-            import sirepo.pkcli.srw
-            sirepo.pkcli.srw.create_predefined()
+                f'{srw_common.PREDEFINED_JSON}: not found; call "sirepo srw create-predefined" before pip install'
+            from sirepo.pkcli import srw
+            srw.create_predefined()
+            f = cls.resource_path(srw_common.PREDEFINED_JSON)
         return cls._memoize(pykern.pkjson.load_any(f))
 
     @classmethod

--- a/sirepo/sim_data/srw.py
+++ b/sirepo/sim_data/srw.py
@@ -394,7 +394,9 @@ class SimData(sirepo.sim_data.SimDataBase):
 
         try:
             f = cls.resource_path(srw_common.PREDEFINED_JSON)
-        except FileNotFoundError:
+        except Exception as e:
+            if not pkio.exception_is_not_found(e):
+                raise
             assert pkconfig.channel_in('dev'), \
                 f'{srw_common.PREDEFINED_JSON}: not found; call "sirepo srw create-predefined" before pip install'
             from sirepo.pkcli import srw

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -451,6 +451,10 @@ def histogram_bins(nbins):
     return nbins
 
 
+def jinja_filename(filename):
+    return filename + '.jinja'
+
+
 def parameter_plot(x, plots, model, plot_fields=None, plot_colors=None):
     res = PKDict(
         x_points=x,
@@ -540,7 +544,7 @@ def render_jinja(sim_type, v, name=PARAMETERS_PYTHON_FILE, jinja_env=None):
         str: source text
     """
     # append .jinja, because file may already have an extension
-    b = f'{name}.jinja'
+    b = jinja_filename(name)
     return pkjinja.render_file(
         sirepo.sim_data.get_class(sim_type).resource_path(b) if sim_type \
             else sirepo.sim_data.resource_path(b),

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -452,6 +452,7 @@ def histogram_bins(nbins):
 
 
 def jinja_filename(filename):
+    # append .jinja, because file may already have an extension
     return filename + '.jinja'
 
 
@@ -543,7 +544,6 @@ def render_jinja(sim_type, v, name=PARAMETERS_PYTHON_FILE, jinja_env=None):
     Returns:
         str: source text
     """
-    # append .jinja, because file may already have an extension
     b = jinja_filename(name)
     return pkjinja.render_file(
         sirepo.sim_data.get_class(sim_type).resource_path(b) if sim_type \


### PR DESCRIPTION
We need to check for the full path for cases when we use package_path
and multiple packages may have sirepo.sim_data._TEMPLATE_RESOURCE_DIR.
We now will search all packages until a match is found.