### PR TITLE
Fix #3909: Raydata run multiple analyses

### DIFF
--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -120,6 +120,9 @@ def _init():
             'Names of root packages that should be checked for codes and resources. Order is important, the first package with a matching code/resource will be used. sirepo added automatically.',
         ),
         proprietary_sim_types=(set(), set, 'codes that require authorization'),
+        raydata=dict(
+            data_dir=('raydata', str, 'dir to store raydata output under sirepo.srdb.root')
+        ),
         sim_common=dict(
             hide_guest_warning=b('Hide the guest warning in the UI', dev=True),
         ),

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -107,10 +107,6 @@ def _init():
             msg,
         )
 
-    def _raydata_data_dir(path):
-        from sirepo import srdb
-        return srdb.root().join(path)
-
     _cfg = pkconfig.init(
         # No secrets should be stored here (see sirepo.job.agent_env)
         api_modules=((), set, 'optional api modules, e.g. status'),
@@ -126,7 +122,7 @@ def _init():
         proprietary_sim_types=(set(), set, 'codes that require authorization'),
         raydata=dict(
             # POSIT: Included in sirepo.job_driver.docker.cfg.aux_volumes
-            data_dir=(None, _raydata_data_dir, 'dir to store raydata output under sirepo.srdb.root')
+            data_dir=(None, pkio.py_path, 'abspath of dir to store raydata analysis output')
         ),
         sim_common=dict(
             hide_guest_warning=b('Hide the guest warning in the UI', dev=True),

--- a/sirepo/job.py
+++ b/sirepo/job.py
@@ -34,6 +34,9 @@ SERVER_SRTIME_URI = '/job-api-srtime'
 #: path supervisor registers to receive requests from server
 SERVER_URI = '/job-api-request'
 
+#: path supervisor registers to receive runMulti requests from server
+SERVER_RUN_MULTI_URI = '/job-api-run-multi-request'
+
 #: path supervisor registers to receive pings from server
 SERVER_PING_URI = '/job-api-ping'
 

--- a/sirepo/job_driver/docker.py
+++ b/sirepo/job_driver/docker.py
@@ -267,7 +267,7 @@ class DockerDriver(job_driver.DriverBase):
             #   these are all the local environ directories.
             for v in '~/src', '~/.pyenv', '~/.local':
                 v = pkio.py_path(v)
-                # pyenv and src shouldn't be writable, only rundir
+                # read-only
                 _res(v, v + ':ro')
         # SECURITY: Must only mount the user's directory
         _res(self._user_dir, self._user_dir)

--- a/sirepo/job_driver/docker.py
+++ b/sirepo/job_driver/docker.py
@@ -83,6 +83,7 @@ class DockerDriver(job_driver.DriverBase):
                 int,
                 'how long to wait for agent start',
             ),
+            aux_volumes=(tuple(), tuple, 'Additional volumes mounted in the container (ex. raydata)'),
             constrain_resources=(True, bool, 'apply --cpus and --memory constraints'),
             dev_volumes=(pkconfig.channel_in('dev'), bool, 'mount ~/.pyenv, ~/.local and ~/src for development'),
             hosts=pkconfig.RequiredUnlessDev(tuple(), tuple, 'execution hosts'),
@@ -259,18 +260,21 @@ class DockerDriver(job_driver.DriverBase):
 
     def _volumes(self):
         res = []
-        def _res(src, tgt):
-            res.append('--volume={}:{}'.format(src, tgt))
+        def _res(vol, mode=None):
+            t = s = pkio.py_path(vol)
+            if mode:
+                t += f':{mode}'
+            res.append('--volume={}:{}'.format(s, t))
 
         if self.cfg.dev_volumes:
             # POSIT: radiasoft/download/installers/rpm-code/codes.sh
             #   these are all the local environ directories.
             for v in '~/src', '~/.pyenv', '~/.local':
-                v = pkio.py_path(v)
-                # read-only
-                _res(v, v + ':ro')
+                _res(v, mode='ro')
+            for v in self.cfg.aux_volumes:
+                _res(v)
         # SECURITY: Must only mount the user's directory
-        _res(self._user_dir, self._user_dir)
+        _res(self._user_dir)
         return tuple(res)
 
 

--- a/sirepo/package_data/static/html/raydata-analysis.html
+++ b/sirepo/package_data/static/html/raydata-analysis.html
@@ -1,13 +1,10 @@
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-6 col-xl-4">
-      <div data-simple-panel="simulationStatus">
-        <div data-sim-status-panel="analysis.simState"></div>
-      </div>
-    </div>
     <div class="clearfix"></div>
-    <div class="col-md-6 col-xl-4" data-ng-repeat="m in analysis.pngOutputFiles" data-ng-if="analysis.simState.hasFrames()">
-      <div data-report-panel="pngImage" data-model-name="{{ m }}" data-panel-title="{{ appState.models[m].filename }}"></div>
+    <div class="col-md-8 col-xl-6">
+        <div data-loading-and-error-panel="" data-model-key="{{ analysis.modelKey }}">
+      <div data-analysis-status-panel="" data-args="args"></div>
+        </div>
     </div>
   </div>
 </div>

--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -261,6 +261,7 @@ SIREPO.app.directive('analysisStatusPanel', function() {
 		};
 		if (showLoadingSpinner) {
 		    c.modelName = $scope.args.modelKey;
+		    c.panelState = panelState;
 		}
 		runMulti.status(
 		    getSelectedScans(),
@@ -448,7 +449,7 @@ SIREPO.app.directive('metadataTable', function() {
               </table>
             </div>
 	`,
-	controller: function(appState, requestSender, $scope) {
+	controller: function(appState, panelState, requestSender, $scope) {
 	    $scope.expanded = {};
 
 	    function elementForKey(key) {
@@ -473,6 +474,7 @@ SIREPO.app.directive('metadataTable', function() {
 		    },
 		    {
 			modelName: $scope.args.modelKey,
+			panelState: panelState,
 		    }
 		);
 	    }
@@ -635,7 +637,8 @@ SIREPO.app.directive('scanSelector', function() {
 			onError: (data) => {
 			    errorService.alertText(data.error);
 			    panelState.setLoading($scope.args.modelKey, false);
-			}
+			},
+			panelState: panelState,
 		    }
 		);
 	    };
@@ -689,7 +692,7 @@ SIREPO.app.directive('visualizationScanSelector', function() {
 	      </form>
 	    </div>
         `,
-        controller: function(appState, raydataService, requestSender, simulationDataCache, $scope) {
+        controller: function(appState, panelState, raydataService, $scope) {
 	    $scope.appState = appState;
             $scope.modelName = 'scans';
             $scope.fields = ['visualizationId'];
@@ -705,6 +708,7 @@ SIREPO.app.directive('visualizationScanSelector', function() {
 		    },
 		    {
 			modelName: $scope.args.modelKey,
+			panelState: panelState,
 		    }
 		);
 	    }

--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -420,36 +420,6 @@ SIREPO.app.directive('appHeader', function(appState) {
     };
 });
 
-SIREPO.app.directive('htmlAsString', function() {
-    return {
-        restrict: 'A',
-        scope: {
-	    html: '<',
-	    changeEvent: '@',
-	},
-        template: `
-            <element-to-replace></element-to-replace>
-        `,
-	controller: function($compile, $element, $timeout, $scope) {
-	    let currentElement = $element;
-	    function compile() {
-		$compile($scope.html)($scope , function(compiledContent){
-		    const r = angular.element(compiledContent);
-		    currentElement.replaceWith(r);
-		    currentElement = r;
-		});
-	    }
-	    $scope.$on($scope.changeEvent, function(){
-		// Need to wait one digest cycle before compile. The
-		// new html is available on scope in the cycle after
-		// the changEvent is emitted.
-		$timeout(compile, 0);
-	    });
-	    compile();
-	}
-    };
-});
-
 SIREPO.app.directive('metadataTable', function() {
     return {
         restrict: 'A',
@@ -555,9 +525,9 @@ SIREPO.app.directive('pngImage', function(plotting) {
 	    image: '@'
 	},
         template: `<img class="img-responsive" id="{{ id }}" />`,
-	controller: function(raydataService, $element, $scope, $timeout) {
+	controller: function(raydataService, $element, $scope) {
 	    $scope.id = raydataService.nextPngImageId();
-	    $timeout(raydataService.setPngDataUrl($element.children()[0], $scope.image), 0);
+	    raydataService.setPngDataUrl($element.children()[0], $scope.image);
 	}
     };
 });

--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -291,9 +291,9 @@ SIREPO.app.directive('analysisStatusPanel', function() {
 		if (runStatusInterval) {
 		    return;
 		}
-		// TODO(e-carlin): where should we get the interval time from?
-		// normally we get from nextRequest
-		runStatusInterval = $interval(() => runStatus(false), 500);
+		// POSIT: 2000 ms is the nextRequestSeconds interval
+		// the supervisor uses.
+		runStatusInterval = $interval(() => runStatus(false), 2000);
 	    }
 
 	    $scope.enableModalClick = function(scan) {

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -625,7 +625,7 @@ SIREPO.app.directive('loadingAndErrorPanel', function(appState, panelState) {
               </div>
             </div>
         `,
-        controller: function(simulationDataCache, $scope) {
+        controller: function($scope) {
 	    $scope.panelState = panelState;
 	    $scope.panelHeading = () => {
 		return appState.viewInfo($scope.modelKey).title;
@@ -828,7 +828,7 @@ SIREPO.app.directive('fieldEditor', function(appState, keypressService, panelSta
     };
 });
 
-SIREPO.app.directive('loadingSpinner', function(appState, panelState) {
+SIREPO.app.directive('loadingSpinner', function() {
     return {
         restrict: 'A',
         scope: {
@@ -1256,6 +1256,44 @@ SIREPO.app.directive('fileUploadDialog', function(appState, fileUpload, panelSta
                 $(element).off();
                 $(element).detach();
             });
+        },
+    };
+});
+
+SIREPO.app.directive('headerTooltip', function() {
+    return {
+        restrict: 'A',
+        scope: {
+            tipText: '=headerTooltip',
+        },
+        template: [
+            '<span data-ng-class="className()"></span>',
+        ],
+        controller: function link($scope, $element) {
+	    $scope.className = function() {
+		return 'glyphicon sr-info-pointer glyphicon-' + ({
+		    canceled: 'ban-circle',
+		    completed: 'ok',
+		    error: 'exclamation-sign',
+		    missing: 'question-sign',
+		    pending: 'hourglass',
+		    running: 'transfer'
+		}[$scope.tipText] || 'info-sign');
+	    };
+
+            $scope.$on('$destroy', function() {
+                $($element).tooltip('destroy');
+            });
+
+	    $scope.$watch('tipText', () => {
+		$($element).tooltip().attr('data-original-title', $scope.tipText);
+	    });
+
+	    $($element).tooltip({
+		title: $scope.tipText,
+		html: true,
+		placement: 'bottom',
+	    });
         },
     };
 });

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1398,7 +1398,7 @@ SIREPO.app.factory('authService', function(authState, requestSender, stringsServ
  *     return self;
  * });
  * */
-SIREPO.app.factory('panelState', function(appState, requestSender, simulationQueue, utilities, validationService, $compile, $rootScope, $timeout, $window) {
+SIREPO.app.factory('panelState', function(appState, requestSender, simulationQueue, utilities, $compile, $rootScope, $timeout, $window) {
     // Tracks the data, error, hidden and loading values
     var self = {};
     var panels = {};
@@ -2355,21 +2355,23 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, $http,
     };
 
     self.sendStatelessCompute = function(appState, successCallback, data, options) {
-	// TODO(e-carlin): This is a hack to get around dependency
-	// cycle. Comment out and use normal dependency injection (add
-	// 'panelState' to parameter list of 'requestSender') to see
-	// the cycle.
-	const panelState = $injector.get('panelState');
+	const maybeSetPanelState = (state) => {
+	    if (! options.panelState) {
+		return;
+	    }
+	    options.panelState.maybeSetState(options.modelName, state);
+	};
+
 	const onError = (data) => {
 	    srlog('statelessCompute error: ', data.error);
 	    if (options.onError) {
 		options.onError(data);
 		return;
 	    }
-	    panelState.maybeSetState(options.modelName, 'error');
+	    maybeSetPanelState('error');
 	};
 
-	panelState.maybeSetState(options.modelName, 'loading');
+	maybeSetPanelState('loading');
 	sendWithSimulationFields(
 	    'statelessCompute',
 	    appState,
@@ -2378,7 +2380,7 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, $http,
 		    onError(data);
 		    return;
 		}
-		panelState.maybeSetState(options.modelName, 'loadingDone');
+		maybeSetPanelState('loadingDone');
 		successCallback(data);
 	    },
 	    data,

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -1670,28 +1670,6 @@ SIREPO.app.directive('appHeader', function(appState, panelState, srwService) {
     };
 });
 
-SIREPO.app.directive('headerTooltip', function() {
-    return {
-        restrict: 'A',
-        scope: {
-            tipText: '=headerTooltip',
-        },
-        template: [
-            '<span class="glyphicon glyphicon-info-sign sr-info-pointer"></span>',
-        ],
-        link: function link(scope, element) {
-            $(element).tooltip({
-                title: scope.tipText,
-                html: true,
-                placement: 'bottom',
-            });
-            scope.$on('$destroy', function() {
-                $(element).tooltip('destroy');
-            });
-        },
-    };
-});
-
 //TODO(pjm): refactor and generalize with mirrorUpload
 SIREPO.app.directive('importPython', function(appState, fileManager, fileUpload, requestSender, simulationQueue) {
     return {

--- a/sirepo/package_data/static/json/raydata-schema.json
+++ b/sirepo/package_data/static/json/raydata-schema.json
@@ -46,6 +46,9 @@
         "analysisMetadata": {
             "notes": ["Notes", "Text", ""]
 	},
+        "analysisStatus": {
+            "notes": ["Notes", "Text", ""]
+	},
         "generalMetadata": {
             "notes": ["Notes", "Text", ""]
 	},
@@ -67,6 +70,12 @@
     "view": {
         "analysisMetadata": {
             "title": "Analysis",
+            "advanced": [
+		"notes"
+	    ]
+        },
+        "analysisStatus": {
+            "title": "Analysis Status",
             "advanced": [
 		"notes"
 	    ]

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -109,6 +109,7 @@
     "route": {
         "adjustTime": "/adjust-time/?<days>",
         "admJobs": "/adm-jobs",
+        "analysisJob": "/analysis-job",
         "authBlueskyLogin": "/auth-bluesky-login",
         "authCompleteRegistration": "/auth-complete-registration",
         "authEmailAuthorized": "/auth-email-authorized/<simulation_type>/<token>",
@@ -152,6 +153,7 @@
         "robotsTxt": "/robots.txt",
         "root": "/*<path_info>",
         "runCancel": "/run-cancel",
+        "runMulti": "/run-multi",
         "runSimulation": "/run-simulation",
         "runStatus": "/run-status",
         "saveSimulationData": "/save-simulation",

--- a/sirepo/package_data/template/raydata/parameters.py.jinja
+++ b/sirepo/package_data/template/raydata/parameters.py.jinja
@@ -17,6 +17,8 @@ def _main():
         # completed.
         os.makedirs('{{ scan_dir }}')
     except FileExistsError:
+        # TODO(e-carlin): It would be better to get the actual state
+        # of the job (ex running, error) and report that back.
         return
     # TODO(e-carlin): this save_chdir will have a path that doesn't
     # make sense on user's machine when user downloads parameters.py

--- a/sirepo/package_data/template/raydata/parameters.py.jinja
+++ b/sirepo/package_data/template/raydata/parameters.py.jinja
@@ -6,7 +6,11 @@ from pykern.pkdebug import pkdlog, pkdexc
 
 def _main():
     try:
-       os.makedirs('{{ scan_dir }}')
+        # Creating the directory acts as a lock. If we are able to
+        # create the dir then we get the "lock". If the dir already
+        # exists then another agent has it locked or the analysis is
+        # completed.
+        os.makedirs('{{ scan_dir }}')
     except FileExistsError:
         return
     # TODO(e-carlin): this save_chdir will have a path that doesn't

--- a/sirepo/package_data/template/raydata/parameters.py.jinja
+++ b/sirepo/package_data/template/raydata/parameters.py.jinja
@@ -4,6 +4,11 @@ import papermill
 from pykern import pkio
 from pykern.pkdebug import pkdlog, pkdexc
 
+# POSIT: Matches mask_path in
+# https://github.com/radiasoft/raydata/blob/main/AnalysisNotebooks/XPCS_SAXS/XPCS_SAXS.ipynb
+_MASK_DIR = 'masks'
+
+
 def _main():
     try:
         # Creating the directory acts as a lock. If we are able to
@@ -17,13 +22,19 @@ def _main():
     # make sense on user's machine when user downloads parameters.py
     # (could expose our paths too)
     with pkio.save_chdir('{{ scan_dir }}'):
+        if '{{ mask_path }}':
+            import sirepo.util
+            d = pkio.py_path(_MASK_DIR)
+            pkio.mkdir_parent(d)
+            for f, b in sirepo.util.read_zip('{{ mask_path }}'):
+                d.join(f).write_binary(b)
         try:
             papermill.execute_notebook(
                 input_path='{{ input_name }}',
                 kernel_name='py3',
                 log_output=True,
                 output_path='{{ output_name }}',
-                parameters=dict(uid='{{ scan_uid }}'),
+                parameters=dict(uid='{{ scan_uuid }}'),
             )
         except Exception:
             pkdlog('Error running uid={} error={}', '{{ scan_uid }}', pkdexc())

--- a/sirepo/package_data/template/raydata/parameters.py.jinja
+++ b/sirepo/package_data/template/raydata/parameters.py.jinja
@@ -1,11 +1,28 @@
 # -*- python -*-
-from pykern import pksubprocess
+import os
+import papermill
+from pykern import pkio
+from pykern.pkdebug import pkdlog, pkdexc
 
-pksubprocess.check_call_with_signals((
-    'papermill',
-    # POSIT: same kernel isntalled by rscode-ipykernel
-    '--kernel=py3',
-    '--log-output',
-    '{{ input_name }}',
-    '{{ output_name }}',
-))
+def _main():
+    try:
+       os.makedirs('{{ scan_dir }}')
+    except FileExistsError:
+        return
+    # TODO(e-carlin): this save_chdir will have a path that doesn't
+    # make sense on user's machine when user downloads parameters.py
+    # (could expose our paths too)
+    with pkio.save_chdir('{{ scan_dir }}'):
+        try:
+            papermill.execute_notebook(
+                input_path='{{ input_name }}',
+                kernel_name='py3',
+                log_output=True,
+                output_path='{{ output_name }}',
+                parameters=dict(uid='{{ scan_uid }}'),
+            )
+        except Exception:
+            pkdlog('Error running uid={} error={}', '{{ scan_uid }}', pkdexc())
+            raise
+
+_main()

--- a/sirepo/pkcli/job_cmd.py
+++ b/sirepo/pkcli/job_cmd.py
@@ -255,6 +255,7 @@ def _do_stateful_compute(msg, template):
 def _do_stateless_compute(msg, template):
     return _dispatch_compute(msg)
 
+
 def _maybe_parse_user_alert(exception, error=None):
     e = error or str(exception)
     if isinstance(exception, sirepo.util.UserAlert):

--- a/sirepo/pkcli/job_cmd.py
+++ b/sirepo/pkcli/job_cmd.py
@@ -16,6 +16,7 @@ from sirepo.template import template_common
 import contextlib
 import re
 import requests
+import sirepo.sim_data
 import sirepo.template
 import sirepo.util
 import subprocess
@@ -65,7 +66,7 @@ class _AbruptSocketCloseError(Exception):
 
 def _background_percent_complete(msg, template, is_running):
     return template.background_percent_complete(
-        msg.data.report,
+        sirepo.sim_data.get_class(msg.simulationType).parse_model(msg.data),
         msg.runDir,
         is_running,
     ).pksetdefault(
@@ -116,6 +117,10 @@ def _do_compute(msg, template):
             template,
             msg.runDir,
         )
+
+
+def _do_analysis_job(msg, template):
+    return _dispatch_compute(msg)
 
 
 def _do_download_data_file(msg, template):
@@ -249,7 +254,6 @@ def _do_stateful_compute(msg, template):
 
 def _do_stateless_compute(msg, template):
     return _dispatch_compute(msg)
-
 
 def _maybe_parse_user_alert(exception, error=None):
     e = error or str(exception)

--- a/sirepo/pkcli/raydata.py
+++ b/sirepo/pkcli/raydata.py
@@ -10,7 +10,6 @@ from pykern import pksubprocess
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp, pkdlog
 from sirepo.template import template_common
-import sirepo.simulation_db
 import sys
 
 

--- a/sirepo/sim_data/raydata.py
+++ b/sirepo/sim_data/raydata.py
@@ -20,6 +20,10 @@ class SimData(sirepo.sim_data.SimDataBase):
         return []
 
     @classmethod
+    def _compute_model(cls, analysis_model, resp):
+        return analysis_model
+
+    @classmethod
     def _lib_file_basenames(cls, data):
         def _input_files():
             for k, v in data.models.inputFiles.items():

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -78,7 +78,7 @@ def analysis_job_output_files(data):
         for f in sorted(glob.glob(str(d.join('*.png'))), key=os.path.getmtime):
             yield pkio.py_path(f)
 
-    return PKDict(data=list(map(_filename_and_image, _paths())))
+    return PKDict(data=[_filename_and_image(p) for p in _paths()])
 
 
 def background_percent_complete(report, run_dir, is_running):
@@ -92,7 +92,7 @@ def stateless_compute_metadata(data):
 
 
 def stateless_compute_scan_info(data):
-    return _scan_info_result(list(map(_scan_info, data.scans)))
+    return _scan_info_result([_scan_info(s) for s in data.scans])
 
 
 def stateless_compute_scans(data):

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -24,11 +24,7 @@ import sirepo.util
 _SIM_DATA, SIM_TYPE, SCHEMA = sirepo.sim_data.template_globals()
 
 # TODO(e-carlin): from user
-_CATALOG_NAME = 'chxmulti'
-
-# POSIT: Matches mask_path in
-# https://github.com/radiasoft/raydata/blob/main/AnalysisNotebooks/XPCS_SAXS/XPCS_SAXS.ipynb
-_MASK_PATH = 'masks'
+_CATALOG_NAME = 'chx'
 
 # TODO(e-carlin): tune this number
 _MAX_NUM_SCANS = 1000
@@ -113,16 +109,6 @@ def write_parameters(data, run_dir, is_parallel):
         run_dir.join(template_common.PARAMETERS_PYTHON_FILE),
         _generate_parameters_file(data, run_dir),
     )
-    m = data.models.inputFiles.mask
-    if m:
-        d = run_dir.join(_MASK_PATH)
-        pkio.mkdir_parent(d)
-        for f, b in sirepo.util.read_zip(pkio.py_path(_SIM_DATA.lib_file_name_with_model_field(
-                'inputFiles',
-                'mask',
-                m,
-        ))):
-            d.join(f).write_binary(b)
 
 
 def _catalog():
@@ -138,10 +124,16 @@ def _dir_for_scan_uuid(scan_uuid):
 
 def _generate_parameters_file(data, run_dir):
     s = _parse_scan_uuid(data)
+    m = run_dir.join(_SIM_DATA.lib_file_name_with_model_field(
+                'inputFiles',
+                'mask',
+                data.models.inputFiles.mask,
+        )) if data.models.inputFiles.mask else None
     return template_common.render_jinja(
         SIM_TYPE,
         PKDict(
             input_name=run_dir.join(data.models.analysisAnimation.notebook),
+            mask_path=m,
             output_name=_OUTPUT_FILE,
             scan_dir=_dir_for_scan_uuid(s),
             scan_uuid=s,

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -131,8 +131,7 @@ def _catalog():
 
 def _dir_for_scan_uuid(scan_uuid):
     return pkio.py_path(sirepo.util.safe_path(
-        sirepo.srdb.root(),
-        sirepo.feature_config.for_sim_type(SIM_TYPE).data_dir,
+        str(sirepo.feature_config.for_sim_type(SIM_TYPE).data_dir),
         scan_uuid,
     ))
 

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -14,7 +14,10 @@ import databroker
 import databroker.queries
 import glob
 import os
+import sirepo.feature_config
 import sirepo.sim_data
+import sirepo.simulation_db
+import sirepo.srdb
 import sirepo.util
 
 
@@ -32,11 +35,7 @@ _MAX_NUM_SCANS = 1000
 
 _NON_DISPLAY_SCAN_FIELDS = ('uid')
 
-# TODO(e-carlin): from user
-_RUN_UID = 'bdcce1f3-7317-4775-bc26-ece8f0612758'
-
 _OUTPUT_FILE = 'out.ipynb'
-
 
 # The metadata fields are from bluesky. Some have spaces while others don't.
 _METDATA = PKDict(
@@ -63,38 +62,29 @@ _METDATA = PKDict(
     ),
 )
 
+def analysis_job_output_files(data):
+    def _filename_and_image(path):
+        return PKDict(
+            filename=path.basename,
+            image=pkcompat.from_bytes(
+                base64.b64encode(
+                    pkio.read_binary(path),
+                ),
+            )
+        )
+
+    def _paths():
+        d = _dir_for_scan_uuid(_parse_scan_uuid(data))
+        for f in sorted(glob.glob(str(d.join('*.png'))), key=os.path.getmtime):
+            yield pkio.py_path(f)
+
+    return PKDict(data=list(map(_filename_and_image, _paths())))
+
 
 def background_percent_complete(report, run_dir, is_running):
-    def _png_filenames():
-        return [
-            pkio.py_path(f).basename for f in sorted(
-                glob.glob(str(run_dir.join('*.png'))),
-                key=os.path.getmtime
-            )
-        ]
-
-    def _sanitized_name(filename):
-        return sirepo.util.sanitize_string(filename) + 'Animation'
-
-    res = PKDict(
-        pngOutputFiles=[
-            PKDict(name=_sanitized_name(f), filename=f) for f in _png_filenames()
-        ],
-    )
-    res.pkupdate(frameCount=len(res.pngOutputFiles))
     if is_running:
-        return res.pkupdate(percentComplete=0)
-    return res.pkupdate(percentComplete=100)
-
-
-def sim_frame(frame_args):
-    return PKDict(image=pkcompat.from_bytes(
-        base64.b64encode(
-            pkio.read_binary(
-                sirepo.util.safe_path(frame_args.run_dir, frame_args.filename),
-            ),
-        ),
-    ))
+        return PKDict(percentComplete=0)
+    return PKDict(percentComplete=100)
 
 
 def stateless_compute_metadata(data):
@@ -123,7 +113,7 @@ def stateless_compute_scans(data):
 def write_parameters(data, run_dir, is_parallel):
     pkio.write_text(
         run_dir.join(template_common.PARAMETERS_PYTHON_FILE),
-        _generate_parameters_file(data),
+        _generate_parameters_file(data, run_dir),
     )
     m = data.models.inputFiles.mask
     if m:
@@ -141,12 +131,23 @@ def _catalog():
     return databroker.catalog[_CATALOG_NAME]
 
 
-def _generate_parameters_file(data):
+def _dir_for_scan_uuid(scan_uuid):
+    return pkio.py_path(sirepo.util.safe_path(
+        sirepo.srdb.root(),
+        sirepo.feature_config.for_sim_type(SIM_TYPE).data_dir,
+        scan_uuid,
+    ))
+
+
+def _generate_parameters_file(data, run_dir):
+    s = _parse_scan_uuid(data)
     return template_common.render_jinja(
         SIM_TYPE,
         PKDict(
-            input_name=data.models.analysisAnimation.notebook,
+            input_name=str(run_dir.join(data.models.analysisAnimation.notebook)),
             output_name=_OUTPUT_FILE,
+            scan_dir=_dir_for_scan_uuid(s),
+            scan_uuid=s,
         ),
     )
 
@@ -160,13 +161,13 @@ def _metadata(data):
     return res
 
 
-def _scan_info(uid, metadata=None):
+def _scan_info(scan_uuid, metadata=None):
     m = metadata
     if not m:
-        m =  _catalog()[uid].metadata
+        m =  _catalog()[scan_uuid].metadata
     return PKDict(
-        uid=uid,
-        suid=_suid(uid),
+        uid=scan_uuid,
+        suid=_suid(scan_uuid),
         owner=m['start']['owner'],
         start=m['start']['time'],
         stop=m['stop']['time'],
@@ -182,5 +183,8 @@ def _scan_info_result(scans):
     ))
 
 
-def _suid(uid):
-    return uid.split('-')[0]
+def _parse_scan_uuid(data):
+    return data.computeModel.split('animation')[1]
+
+def _suid(scan_uuid):
+    return scan_uuid.split('-')[0]

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -75,7 +75,7 @@ def analysis_job_output_files(data):
 
     def _paths():
         d = _dir_for_scan_uuid(_parse_scan_uuid(data))
-        for f in sorted(glob.glob(str(d.join('*.png'))), key=os.path.getmtime):
+        for f in pkio.sorted_glob(d.join('*.png'), key='mtime'):
             yield pkio.py_path(f)
 
     return PKDict(data=[_filename_and_image(p) for p in _paths()])

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -142,7 +142,7 @@ def _generate_parameters_file(data, run_dir):
     return template_common.render_jinja(
         SIM_TYPE,
         PKDict(
-            input_name=str(run_dir.join(data.models.analysisAnimation.notebook)),
+            input_name=run_dir.join(data.models.analysisAnimation.notebook),
             output_name=_OUTPUT_FILE,
             scan_dir=_dir_for_scan_uuid(s),
             scan_uuid=s,

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -130,10 +130,10 @@ def _catalog():
 
 
 def _dir_for_scan_uuid(scan_uuid):
-    return pkio.py_path(sirepo.util.safe_path(
-        str(sirepo.feature_config.for_sim_type(SIM_TYPE).data_dir),
-        scan_uuid,
-    ))
+    return sirepo.feature_config.for_sim_type(SIM_TYPE).data_dir.join(
+        sirepo.util.safe_path(scan_uuid),
+    )
+
 
 
 def _generate_parameters_file(data, run_dir):

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -82,9 +82,7 @@ def analysis_job_output_files(data):
 
 
 def background_percent_complete(report, run_dir, is_running):
-    if is_running:
-        return PKDict(percentComplete=0)
-    return PKDict(percentComplete=100)
+    return PKDict(percentComplete=0 if is_running else 100)
 
 
 def stateless_compute_metadata(data):

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -218,6 +218,14 @@ class ParticleEnergy():
         cls.__set_from_beta(particle, energy)
 
 
+def analysis_job_dispatch(data):
+    t = sirepo.template.import_module(data.simulationType)
+    return getattr(
+        t,
+        f'analysis_job_{_validate_method(t, data)}',
+    )(data)
+
+
 def compute_field_range(args, compute_range):
     """ Computes the fieldRange values for all parameters across all animation files.
     Caches the value on the animation input file. compute_range() is called to

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -70,9 +70,7 @@ def call_api(func_or_name, kwargs=None, data=None):
             # Any (GET) uri will have simulation_type in uri if it is application
             # specific.
             s = sirepo.http_request.set_sim_type(kwargs.get('simulation_type'))
-        f = func_or_name if callable(func_or_name) \
-            else _api_to_route[func_or_name].func
-        sirepo.api_auth.check_api_call(f)
+        f = check_api_call(func_or_name)
         try:
             if data:
                 p = sirepo.http_request.set_post(data)
@@ -93,6 +91,18 @@ def call_api(func_or_name, kwargs=None, data=None):
     sirepo.cookie.save_to_cookie(r)
     sirepo.events.emit('end_api_call', PKDict(resp=r))
     return r
+
+
+def check_api_call(func_or_name):
+    """Check if API is callable by current user (proper credentials)
+
+    Args:
+        func_or_name (function or str): API to check
+    """
+    f = func_or_name if callable(func_or_name) \
+        else _api_to_route[func_or_name].func
+    sirepo.api_auth.check_api_call(f)
+    return f
 
 
 def init(app, simulation_db):


### PR DESCRIPTION
Add the 'analysisStatusPanel' to Raydata which shows the status of
selected analysis jobs and allows one to start analysis for missing
jobs. In addition, each row in the table can be clicked if the job is
running or completed. A modal will appear with the png's output from
the notebook.

Two new API's:
- runMulti: Run multiple requests in one API call. In addition, these
requests can be "fire and forget". Normall runSimulation blocks until
the simulation starts. This can take a long while if there is resource
contention. This allows starting the job, not waiting for the
response, and then polling runStatus for updates.
- analysisJob: Call template code on the agent with access to the run
dir.