### PR TITLE
Fix #3981 blicon ml tabulated und fails

### DIFF
--- a/sirepo/package_data/template/srw/README.txt.jinja
+++ b/sirepo/package_data/template/srw/README.txt.jinja
@@ -17,7 +17,7 @@ This stores the data in the numpy file
     {{ fileBase }}.npy
 
 The script will prompt you to then run SRW with that data. To do so later, run
-    'python {{ pyFileName }} rsopt_run {{ fileBase }}npy'
+    'python {{ pyFileName }} rsopt_run {{ fileBase }}.npy'
 
 Please note:
     - rsopt does the job of running SRW with the stored input data

--- a/sirepo/package_data/template/srw/rsoptExport.sh.jinja
+++ b/sirepo/package_data/template/srw/rsoptExport.sh.jinja
@@ -14,8 +14,13 @@ then
     if [[ $confirm == [yY] ]]; then
         echo Running SRW...
         eval "$run_py"
-        echo Propagated single electron intensities are in datasets/beam_intensities.npy
-        echo Corresponding parameter values are in datasets/parameters.npy
+        if [ $? -eq 0 ]
+        then
+            echo Propagated single electron intensities are in datasets/beam_intensities.npy
+            echo Corresponding parameter values are in datasets/parameters.npy
+        else
+            echo "ERROR: SRW failed with return code $?"
+        fi
     else
         echo "NOTE: to run SRW with generated data, use
         $run_py"

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -1596,9 +1596,10 @@ def _generate_beamline_optics(report, data):
 
 def _generate_parameters_file(data, plot_reports=False, run_dir=None):
     report = data.report
+    for_rsopt = report == 'rsoptExport'
     dm = data.models
     # do this before validation or arrays get turned into strings
-    if report == 'rsoptExport':
+    if for_rsopt:
         rsopt_ctx = _rsopt_jinja_context(dm.exportRsOpt)
     _validate_data(data, SCHEMA)
     _update_model_fields(dm)
@@ -1607,7 +1608,7 @@ def _generate_parameters_file(data, plot_reports=False, run_dir=None):
     v.rs_type = dm.simulation.sourceType
     if v.rs_type == 't' and dm.tabulatedUndulator.undulatorType == 'u_i':
         v.rs_type = 'u'
-    if report == 'rsoptExport':
+    if for_rsopt:
         v.update(rsopt_ctx)
     # rsopt uses this as a lookup param so want it in one place
     v.ws_fni_desc = 'file name for saving propagated single-e intensity distribution vs horizontal and vertical position'
@@ -1630,12 +1631,12 @@ def _generate_srw_main(data, plot_reports, beamline_info):
     report = data.report
     for_rsopt = report == 'rsoptExport'
     source_type = data.models.simulation.sourceType
-    run_all = report == _SIM_DATA.SRW_RUN_ALL_MODEL or report == 'rsoptExport'
+    run_all = report == _SIM_DATA.SRW_RUN_ALL_MODEL or for_rsopt
     vp_var = 'vp' if for_rsopt else 'varParam'
     content = [
         f'v = srwl_bl.srwl_uti_parse_options(srwl_bl.srwl_uti_ext_options({vp_var}), use_sys_argv={plot_reports})',
     ]
-    if plot_reports and _SIM_DATA.srw_uses_tabulated_zipfile(data):
+    if (plot_reports or for_rsopt) and _SIM_DATA.srw_uses_tabulated_zipfile(data):
         content.append('setup_magnetic_measurement_files("{}", v)'.format(data.models.tabulatedUndulator.magneticFile))
     if report == 'beamlineAnimation':
         content.append("v.si_fn = ''")
@@ -1975,7 +1976,8 @@ def _save_user_model_list(model_name, beam_list):
 
 
 def _set_magnetic_measurement_parameters(run_dir, v):
-    src_zip = str(run_dir.join(v.tabulatedUndulator_magneticFile))
+    src_zip = str(run_dir.join(v.tabulatedUndulator_magneticFile)) if run_dir else \
+        str(_SIM_DATA.lib_file_abspath(v.tabulatedUndulator_magneticFile))
     target_dir = str(run_dir.join(_TABULATED_UNDULATOR_DATA_DIR))
     # The MagnMeasZip class defined above has convenient properties we can use here
     mmz = MagnMeasZip(src_zip)
@@ -1991,6 +1993,7 @@ def _set_magnetic_measurement_parameters(run_dir, v):
 
 def _set_parameters(v, data, plot_reports, run_dir):
     report = data.report
+    for_rsopt = report == 'rsoptExport'
     dm = data.models
     v.beamlineOptics, v.beamlineOpticsParameters, beamline_info = _generate_beamline_optics(report, data)
     v.beamlineFirstElementPosition = _get_first_element_position(report, data)
@@ -1999,10 +2002,10 @@ def _set_parameters(v, data, plot_reports, run_dir):
     v[report] = 1
     for k in _OUTPUT_FOR_MODEL:
         v['{}Filename'.format(k)] = _OUTPUT_FOR_MODEL[k].filename
-    v.setupMagneticMeasurementFiles = plot_reports and _SIM_DATA.srw_uses_tabulated_zipfile(data)
+    v.setupMagneticMeasurementFiles = (plot_reports or for_rsopt) and _SIM_DATA.srw_uses_tabulated_zipfile(data)
     v.srwMain = _generate_srw_main(data, plot_reports, beamline_info)
-    if run_dir and _SIM_DATA.srw_uses_tabulated_zipfile(data):
-        _set_magnetic_measurement_parameters(run_dir, v)
+    if (run_dir or for_rsopt) and _SIM_DATA.srw_uses_tabulated_zipfile(data):
+        _set_magnetic_measurement_parameters(run_dir or '', v)
     if _SIM_DATA.srw_is_background_report(report) and 'beamlineAnimation' not in report:
         if report in dm and dm[report].get('jobRunMode', '') == 'sbatch':
             v.sbatchBackup = '1'


### PR DESCRIPTION
Tabulated undulators are only "activated" when a ```plot_reports``` param is true. We don't want to produce plots as part of the rsopt runs (at least by default) so this adds a check for rsopt runs in the appropriate places.

Also cleans up the readme and shell script