### PR TITLE
Sbatch agent logging

### DIFF
--- a/etc/run-supervisor.sh
+++ b/etc/run-supervisor.sh
@@ -56,6 +56,11 @@ radia_run slurm-dev
         export SIREPO_JOB_DRIVER_SBATCH_SRDB_ROOT='/var/tmp/{sbatch_user}/sirepo'
         export SIREPO_JOB_SUPERVISOR_SBATCH_POLL_SECS=5
         export SIREPO_SIMULATION_DB_SBATCH_DISPLAY='Vagrant Cluster'
+	# In dev the node goes down randomly. This resets it.
+	sudo scontrol << EOF
+update NodeName=debug State=DOWN Reason="undraining"
+update NodeName=debug State=RESUME
+EOF
         ;;
     *)
         echo 'usage: bash run-supervisor.sh [docker|local|sbatch [slurm host]|nersc proxy-host nersc-user]'

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -154,10 +154,9 @@ disown
             p = pkio.py_path(self._local_user_dir).join('agent-sbatch', self.cfg.host)
             pkio.mkdir_parent(p)
             f = p.join(f'{datetime.datetime.now().strftime("%Y%m%d%H%M%S")}-{filename}.log')
-            d = PKDict(stdout=stdout, stderr=stderr)
-            pkjson.dump_pretty(d, f)
+            r = pkjson.dump_pretty(PKDict(stdout=stdout, stderr=stderr, filename=f), f)
             if pkconfig.channel_in('dev'):
-                pkdlog(d.pkupdate(filename=f))
+                pkdlog(r)
 
         async def get_agent_log(connection, before_start=True):
             try:


### PR DESCRIPTION
    Fix #3658: log job_agent.log before overwriting when starting a new agent

    In addition in dev write all log messages read from the job_agent to
    the job_supervisor log stream.

    Fix #2136: reset slurm node state at every start

    The node on dev machines seemes to go down randomly. It is quick to
    reset it so do so every time the supervisor is started in an sbatch
    configuration.