### PR TITLE
Fix #4030 radia replace uuids

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -198,7 +198,7 @@ SIREPO.app.factory('radiaService', function(appState, fileUpload, geometry, pane
     // In order to associate VTK objects in the viewer with Radia objects, we need a mapping between them.
     // When we create objects on the client side we don't yet know the Radia id so we cannot use it directly.
     // Instead, generate an id here and map it when the Radia object is created. A random string is good enough
-    self.generateId = () => utilities.generateId(length=16);
+    self.generateId = () => utilities.randomString(62, 16);
 
     self.pathEditorTitle = function() {
         if (! appState.models.fieldPaths) {
@@ -3309,7 +3309,7 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
 
             //function setColor(info, type, color, alpha=255) {
             function setColor(info, type, color, alpha) {
-                srdbg('setColor', 'info', info, 'type', type, 'color', color, 'alpha', alpha);
+                //srdbg('setColor', 'info', info, 'type', type, 'color', color, 'alpha', alpha);
                 if (angular.isUndefined(alpha)) {
                     alpha = 255;
                 }
@@ -3488,7 +3488,7 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
                 updateViewer();
             });
 
-            $scope.$on('radiaObject.color', function (e, d) {
+            $scope.$on('radiaObject.color', function (e, h) {
                 setColor(
                     selectedInfo,
                     SIREPO.APP_SCHEMA.constants.geomTypePolys,

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -198,7 +198,7 @@ SIREPO.app.factory('radiaService', function(appState, fileUpload, geometry, pane
     // In order to associate VTK objects in the viewer with Radia objects, we need a mapping between them.
     // When we create objects on the client side we don't yet know the Radia id so we cannot use it directly.
     // Instead, generate an id here and map it when the Radia object is created. A random string is good enough
-    self.generateId = () => utilities.randomString(62, 16);
+    self.generateId = () => utilities.randomString(16);
 
     self.pathEditorTitle = function() {
         if (! appState.models.fieldPaths) {

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -195,6 +195,7 @@ SIREPO.app.factory('radiaService', function(appState, fileUpload, geometry, pane
     };
 
     self.generateId = function() {
+        return utilities.generateId();
         // a uuid generator found on the interwebs
         return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
             (c ^ window.crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -194,13 +194,11 @@ SIREPO.app.factory('radiaService', function(appState, fileUpload, geometry, pane
         self.showPathPicker(true, true);
     };
 
-    self.generateId = function() {
-        return utilities.generateId();
-        // a uuid generator found on the interwebs
-        return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-            (c ^ window.crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-        );
-    };
+
+    // In order to associate VTK objects in the viewer with Radia objects, we need a mapping between them.
+    // When we create objects on the client side we don't yet know the Radia id so we cannot use it directly.
+    // Instead, generate an id here and map it when the Radia object is created. A random string is good enough
+    self.generateId = () => utilities.generateId(length=16);
 
     self.pathEditorTitle = function() {
         if (! appState.models.fieldPaths) {
@@ -3311,7 +3309,7 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
 
             //function setColor(info, type, color, alpha=255) {
             function setColor(info, type, color, alpha) {
-                //srdbg('setColor', 'info', info, 'type', type, 'color', color, 'alpha', alpha);
+                srdbg('setColor', 'info', info, 'type', type, 'color', color, 'alpha', alpha);
                 if (angular.isUndefined(alpha)) {
                     alpha = 255;
                 }
@@ -3479,7 +3477,7 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
                 //srdbg('modelChanged', name);
             });
 
-            $scope.$on('geomObject.changed', function(e) {
+            $scope.$on('radiaObject.changed', function(e) {
                 radiaService.saveGeometry(true, false);
             });
 
@@ -3490,12 +3488,11 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
                 updateViewer();
             });
 
-            $scope.$on('geomObject.color', function (e, h) {
-                var c = vtk.Common.Core.vtkMath.hex2float(h);
+            $scope.$on('radiaObject.color', function (e, d) {
                 setColor(
                     selectedInfo,
                     SIREPO.APP_SCHEMA.constants.geomTypePolys,
-                    vtkUtils.floatToRGB(c)
+                    vtkUtils.floatToRGB(vtk.Common.Core.vtkMath.hex2float(h))
                 );
                 setAlpha();
             });

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -4599,13 +4599,12 @@ SIREPO.app.service('utilities', function($window, $interval) {
         };
     };
 
-    // create a non-cryptographic baseN string, with N <= 64
-    this.randomString = function(base=62, length=32) {
-        const BASE64 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/';
-        const s = BASE64.substring(0, base);
+    // create a non-cryptographic base62 string
+    this.randomString = function(length=32) {
+        const BASE62 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
         return new Array(length)
             .fill('')
-            .map(x => s[Math.floor(s.length * Math.random())])
+            .map(x => BASE62[Math.floor(BASE62.length * Math.random())])
             .join('');
     };
 

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -4599,6 +4599,16 @@ SIREPO.app.service('utilities', function($window, $interval) {
         };
     };
 
+    // create a non-cryptographic baseN string, with N <= 64
+    this.generateId = function(base=62, length=32) {
+        const BASE64 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/';
+        const s = BASE64.substring(0, base);
+        return new Array(length)
+            .fill('')
+            .map(x => s[Math.floor(s.length * Math.random())])
+            .join('');
+    };
+
     this.indexArray = function(size) {
         var res = [];
         for (var i = 0; i < size; res.push(i++)) {}

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -4600,7 +4600,7 @@ SIREPO.app.service('utilities', function($window, $interval) {
     };
 
     // create a non-cryptographic baseN string, with N <= 64
-    this.generateId = function(base=62, length=32) {
+    this.randomString = function(base=62, length=32) {
         const BASE64 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/';
         const s = BASE64.substring(0, base);
         return new Array(length)

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -694,7 +694,7 @@
         },
         "geometryReport": {
             "doGenerate": ["_", "Boolean", "1"],
-            "id": ["_", "UUID", ""],
+            "id": ["_", "RandomId", ""],
             "isSolvable": ["_", "Boolean", "1"],
             "name": ["Name", "String", ""],
             "objects": ["_", "Group", []]
@@ -710,7 +710,7 @@
             "bevels": ["Bevels", "BevelTable", []],
             "center": ["Center", "FloatStringArray", "0.0, 0.0, 0.0", "", "x (mm), y (mm), z (mm)"],
             "segments": ["Num Divisions", "IntStringArray", "1, 1, 1", "", "Nx, Ny, Nz"],
-            "id": ["_", "UUID", ""],
+            "id": ["_", "RandomId", ""],
             "layoutShape":  ["_", "String", "rect"],
             "magnetization": ["Magentization [T]", "FloatStringArray", "0.0, 0.0, 0.0", "", "x, y, z"],
             "remanentMag": ["Remanent Magnetization [T]", "Float", 0.0, "", 0.0],
@@ -724,7 +724,7 @@
             "_super": ["_", "model", "undulator"],
             "magnetArmHeight": ["_", "Float", 1.0],
             "magnetArmPosition": ["_", "ArmPosition", "0"],
-            "magnetBaseObjectId": ["_", "UUID", ""],
+            "magnetBaseObjectId": ["_", "RandomId", ""],
             "magnetColor": ["Color", "Color", "#00ffff"],
             "magnetCrossSection": ["Cross Section [mm]", "FloatStringArray", "65.0, 45.0", "", "Width, Height"],
             "magnetSegments": ["Segments per Octant", "IntStringArray", "1, 1, 3", "Segmentation is applied to one octant of the magent. Radia duplicates it across symmetry planes to build the full undulator", "Transverse, Vertical, Beam"],
@@ -739,7 +739,7 @@
             "gapOffset": ["Gap Offset [mm]", "Float", 1.0, "Additional offset of magnets away from the beam along the gap axis"],
             "poleArmHeight": ["_", "Float", 3.0],
             "poleArmPosition": ["_", "ArmPosition", "1"],
-            "poleBaseObjectId": ["_", "UUID", ""],
+            "poleBaseObjectId": ["_", "RandomId", ""],
             "poleColor": ["Color", "Color", "#ff00ff"],
             "poleCrossSection": ["Cross Section [mm]", "FloatStringArray", "45.0, 25.0", "", "Width, Height"],
             "poleSegments": ["Segments per Octant", "IntStringArray", "2, 5, 2", "Segmentation is applied to one octant of the magent. Radia duplicates it across symmetry planes to build the full undulator", "Transverse, Vertical, Beam"],
@@ -778,7 +778,7 @@
         "layoutObject": {
             "color": ["Color", "Color", "#cccccc"],
             "groupId": ["_", "String", ""],
-            "id": ["_", "UUID", ""],
+            "id": ["_", "RandomId", ""],
             "layoutShape":  ["_", "String", "rect"]
         },
         "linePath": {
@@ -847,7 +847,7 @@
             "name": ["Name", "String", "Rotate"]
         },
         "rotateClone": {
-            "id": ["_", "UUID", ""],
+            "id": ["_", "RandomId", ""],
             "angle": ["Angle (deg)", "Float", "0.0"],
             "axis": ["Axis", "FloatStringArray", "0.0, 0.0, 1.0", "", "x, y, z"],
             "center": ["Center", "FloatStringArray", "0.0, 0.0, 0.0", "", "x, y, z"],
@@ -899,7 +899,7 @@
             "type": ["Object Type", "TerminationType", "magnet", ""]
         },
         "transform": {
-            "id": ["_", "UUID", ""],
+            "id": ["_", "RandomId", ""],
             "name": ["Name", "String", "Transform"],
             "object": ["Apply to", "geomObject", ""]
         },
@@ -908,7 +908,7 @@
             "name": ["Name", "String", "Translate"]
         },
         "translateClone": {
-            "id": ["_", "UUID", ""],
+            "id": ["_", "RandomId", ""],
             "distance": ["Direction", "FloatStringArray", "10.0, 0.0, 0.0", "", "x, y, z"],
             "name": ["Name", "String", "Translate"]
         },

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -418,6 +418,7 @@
                 "color": "#ff00ff",
                 "segments": "4, 4, 4",
                 "magnetization": "0.0, 0.0, 1.0",
+                "name": "pole",
                 "remanentMag": 1.0,
                 "material": "NdFeB",
                 "type": "cuboid",

--- a/sirepo/sim_data/__init__.py
+++ b/sirepo/sim_data/__init__.py
@@ -419,6 +419,9 @@ class SimDataBase(object):
             if the data type is "UUID" and the default value is empty, set the
             value to a new UUUID string
 
+            if the data type is "RandomId" and the default value is empty, set the
+            value to a new Base62 string
+
             if the data type has the form "model.zzz", set the value to the default
             value of model "zzz"
 
@@ -438,6 +441,8 @@ class SimDataBase(object):
                 res[f] = copy.deepcopy(d[2])
                 if d[1] == 'UUID' and not res[f]:
                     res[f] = str(uuid.uuid4())
+                if d[1] == 'RandomId' and not res[f]:
+                    res[f] = sirepo.util.random_base62(length=16)
         return res
 
     # TODO(e-carlin): Supplying uid is a temprorary workaround until


### PR DESCRIPTION
Notes:

- I left the "UUID" field handling in place in ```SimDataBase.model_defaults```  since it could be useful, but am not opposed to ditching it
- ctrl-click of objects was not working in the radia viewer - fixed since this is a primary use of the id mapping