### PR TITLE
Fix #4061: sirepo command not found at NERSC

### DIFF
--- a/etc/run-supervisor.sh
+++ b/etc/run-supervisor.sh
@@ -29,7 +29,7 @@ radia_run redhat-docker
         nersc_user=$3
         export SIREPO_JOB_DRIVER_MODULES=local:sbatch
         export SIREPO_JOB_DRIVER_SBATCH_HOST=cori.nersc.gov
-        export SIREPO_JOB_DRIVER_SBATCH_SHIFTER_IMAGE=radiasoft/sirepo:sbatch
+        export SIREPO_JOB_DRIVER_SBATCH_SHIFTER_IMAGE="$docker_image"
         export SIREPO_JOB_DRIVER_SBATCH_SIREPO_CMD=/global/homes/${nersc_user::1}/$nersc_user/.pyenv/versions/$(pyenv version-name)/bin/sirepo
         export SIREPO_JOB_DRIVER_SBATCH_SRDB_ROOT='/global/cscratch1/sd/{sbatch_user}/sirepo-dev'
         export SIREPO_JOB_SUPERVISOR_SBATCH_POLL_SECS=15

--- a/sirepo/pkcli/flash.py
+++ b/sirepo/pkcli/flash.py
@@ -10,13 +10,11 @@ from pykern import pkjson
 from pykern.pkdebug import pkdp, pkdc, pkdlog
 from sirepo import mpi
 from sirepo import simulation_db
-from sirepo.template import flash_parser
 from sirepo.template import template_common
 import glob
 import os
 import re
 import sirepo.sim_data
-import sirepo.template.flash as template
 
 _SIM_DATA = sirepo.sim_data.get_class('flash')
 
@@ -42,12 +40,14 @@ def config_to_schema(path):
     Args:
       path (str): path to Config file to parse
     """
+    from sirepo.template import flash_parser
     return flash_parser.ConfigParser().parse(pkio.read_text(path))
 
 
 def parse_par(sim_id, par_path):
     """Returns parsed flash.par values.
     """
+    from sirepo.template import flash_parser
     sim_path = _sim_path_from_id(sim_id)
     return flash_parser.ParameterParser().parse(
         pkjson.load_any(pkio.read_text(sim_path)),
@@ -63,6 +63,7 @@ def update_sim_from_config(sim_id, config_path):
 
 
 def update_sim_from_par(sim_id, par_path):
+    from sirepo.template import flash_parser
     sim_path = _sim_path_from_id(sim_id)
     data = pkjson.load_any(pkio.read_text(sim_path))
     parser = flash_parser.ParameterParser()

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -711,16 +711,6 @@ class _SbatchRun(_SbatchCmd):
         await c._await_exit()
 
     def _sbatch_script(self):
-        def _assert_no_run_background():
-            from sirepo import pkcli
-            m = pkcli.import_module(self.msg)
-            if hasattr(m, 'run_background'):
-                raise AssertionError(
-                    f'simulation_type={self.msg.simulationType} cannot have'
-                    ' pkcli.run_background if called from sbatch. Sbatch only'
-                    ' supports running through `python parameters.py` ',
-                )
-
         def _assert_project():
             p = self.msg.sbatchProject
             if not p:
@@ -737,7 +727,6 @@ class _SbatchRun(_SbatchCmd):
                 return 'knl'
             return 'haswell'
 
-        _assert_no_run_background()
         i = self.msg.shifterImage
         s = o = ''
 #POSIT: job_api has validated values

--- a/sirepo/pkcli/radia.py
+++ b/sirepo/pkcli/radia.py
@@ -4,27 +4,15 @@
 :copyright: Copyright (c) 2017 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 from pykern import pkio
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp, pkdc
-from sirepo import mpi
 from sirepo import simulation_db
 from sirepo.template import template_common
-import py.path
-import sirepo.template.radia as template
 
 
 def run(cfg_dir):
+    import sirepo.template.radia as template
     template_common.exec_parameters()
     data = simulation_db.read_json(template_common.INPUT_BASE_NAME)
-    template.extract_report_data(py.path.local(cfg_dir), data)
-
-
-def run_background(cfg_dir):
-    """Run in ``cfg_dir`` with mpi
-
-    Args:
-        cfg_dir (str): directory to run in
-    """
-    template_common.exec_parameters_with_mpi()
+    template.extract_report_data(pkio.py_path.local(cfg_dir), data)

--- a/sirepo/pkcli/srw.py
+++ b/sirepo/pkcli/srw.py
@@ -10,7 +10,6 @@ from pykern.pkdebug import pkdp, pkdc
 from sirepo import simulation_db
 from sirepo.template import template_common
 import sirepo.job
-import sirepo.template.srw
 
 
 def create_predefined(out_dir=None):
@@ -103,6 +102,7 @@ def run(cfg_dir):
     Args:
         cfg_dir (str): directory to run srw in
     """
+    import sirepo.template.srw
     sirepo.job.init()
     sim_in = simulation_db.read_json(template_common.INPUT_BASE_NAME)
     r = template_common.exec_parameters()

--- a/sirepo/pkcli/warppba.py
+++ b/sirepo/pkcli/warppba.py
@@ -9,7 +9,6 @@ from pykern import pkinspect
 from pykern import pkio
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp
-from sirepo import mpi
 from sirepo import simulation_db
 from sirepo.template import template_common
 import sirepo.template
@@ -38,15 +37,6 @@ def run(cfg_dir):
     else:
         raise AssertionError('invalid report: {}'.format(a.frameReport))
     template_common.write_sequential_result(res)
-
-
-def run_background(cfg_dir, sbatch=False):
-    """Run code in ``cfg_dir`` with mpi
-
-    Args:
-        cfg_dir (str): directory to run code in
-    """
-    template_common.exec_parameters_with_mpi()
 
 
 def _run_code():

--- a/sirepo/srschema.py
+++ b/sirepo/srschema.py
@@ -216,8 +216,8 @@ def _validate_job_run_mode(field_name, schema):
     if hasattr(m, 'run_background'):
         raise AssertionError(
             f'simulation_type={t} cannot have'
-            ' pkcli.run_background because it supports slurm. Slurm only'
-            ' supports running a code through `python parameters.py` ',
+            + ' pkcli.run_background because it supports slurm. Slurm only'
+            + ' supports running a code through `python parameters.py` ',
         )
 
 

--- a/sirepo/srschema.py
+++ b/sirepo/srschema.py
@@ -148,6 +148,7 @@ def validate(schema):
         _validate_model_name(model_name)
         sch_model = sch_models[model_name]
         for field_name in sch_model:
+            _validate_job_run_mode(field_name, schema)
             sch_field_info = sch_model[field_name]
             if len(sch_field_info) <= 2:
                 continue
@@ -204,6 +205,20 @@ def _validate_enum(val, sch_field_info, sch_enums):
         return
     if str(val) not in map(lambda enum: str(enum[0]), sch_enums[type]):
         raise AssertionError(util.err(sch_enums, 'enum {} value {} not in schema', type, val))
+
+
+def _validate_job_run_mode(field_name, schema):
+    if field_name != 'jobRunMode':
+        return
+    from sirepo import pkcli
+    t = schema.simulationType
+    m = pkcli.import_module(t)
+    if hasattr(m, 'run_background'):
+        raise AssertionError(
+            f'simulation_type={t} cannot have'
+            ' pkcli.run_background because it supports slurm. Slurm only'
+            ' supports running a code through `python parameters.py` ',
+        )
 
 
 def _validate_model_name(model_name):

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -330,6 +330,9 @@ def write_parameters(data, run_dir, is_parallel):
         run_dir.join(template_common.PARAMETERS_PYTHON_FILE),
         _generate_parameters_file(data, is_parallel, run_dir=run_dir),
     )
+    if is_parallel:
+        return template_common.get_exec_parameters_cmd(mpi=True)
+    return None
 
 
 def _add_obj_lines(field_data, obj):

--- a/sirepo/template/warppba.py
+++ b/sirepo/template/warppba.py
@@ -258,6 +258,9 @@ def write_parameters(data, run_dir, is_parallel):
             is_parallel,
         ),
     )
+    if is_parallel:
+        return template_common.get_exec_parameters_cmd(mpi=True)
+    return None
 
 
 def _adjust_z_width(data_list, data_file):


### PR DESCRIPTION
At NERSC we start the job_agent by supplying the sirepo command
through env (sirepo.job_driver.sbatch.sirepo_cmd). This means that
sirepo commands called from the job agent do not have the proper env.
This was causing the sim_type pkcli lookup to fail.

Modify so the assert for no `run_background` happens at server init.

This has the side effect that all sim_type pkcli's that support sbatch
must be able to be imported without being fully initialized in the
server. This is because we must assert for no run background in the
sim type initialization code (srschema.validate).


I also updated the NERSC development wiki with details on how to setup one's NERSC env to support development https://github.com/radiasoft/sirepo/wiki/Development/_compare/4b3dee65ad2f732a64ce77bbecbbda3de87fba00...29c2bcf0d1d775f618188c1fbc7590575ac15255