### PR TITLE
Sirepo 4079 run tests all codes

### DIFF
--- a/tests/animation_test.py
+++ b/tests/animation_test.py
@@ -57,6 +57,18 @@ def test_jspec(fc):
     )
 
 
+def test_radia(fc):
+    fc.sr_animation_run(
+        'Dipole',
+        'solverAnimation',
+        PKDict(
+            solverAnimation=PKDict(
+            ),
+        ),
+        timeout=20,
+    )
+
+
 def test_srw(fc):
     fc.sr_animation_run(
         "Young's Double Slit Experiment",

--- a/tests/animation_test.py
+++ b/tests/animation_test.py
@@ -8,6 +8,14 @@ from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
 import pytest
 
+def test_controls(fc):
+    fc.sr_animation_run(
+        'Sample MAD-X beamline',
+        'animation',
+        PKDict(),
+        expect_completed=False,
+    )
+
 
 def test_elegant(fc):
     fc.sr_animation_run(
@@ -57,15 +65,36 @@ def test_jspec(fc):
     )
 
 
+def test_madxs(fc):
+    fc.sr_animation_run(
+        'FODO PTC',
+        'animation',
+        PKDict(),
+    )
+
+
+def test_ml(fc):
+    fc.sr_animation_run(
+        '2019 World Happiness',
+        'animation',
+        PKDict(),
+        timeout=45,
+    )
+
+
+def test_opal(fc):
+    fc.sr_animation_run(
+        'Slit-1',
+        'animation',
+        PKDict(),
+    )
+
+
 def test_radia(fc):
     fc.sr_animation_run(
         'Dipole',
         'solverAnimation',
-        PKDict(
-            solverAnimation=PKDict(
-            ),
-        ),
-        timeout=20,
+        PKDict(),
     )
 
 

--- a/tests/animation_test.py
+++ b/tests/animation_test.py
@@ -65,7 +65,7 @@ def test_jspec(fc):
     )
 
 
-def test_madxs(fc):
+def test_madx(fc):
     fc.sr_animation_run(
         'FODO PTC',
         'animation',

--- a/tests/report_test.py
+++ b/tests/report_test.py
@@ -27,6 +27,14 @@ def test_elegant(fc):
     )
 
 
+def test_radia(fc):
+    _r(
+        fc,
+        'Dipole',
+        'geometryReport',
+    )
+
+
 def test_synergia(fc):
     _r(
         fc,

--- a/tests/report_test.py
+++ b/tests/report_test.py
@@ -9,6 +9,14 @@ from pykern.pkcollections import PKDict
 import pytest
 
 
+def test_controls(fc):
+    _r(
+        fc,
+        'Sample MAD-X beamline',
+        'initialMonitorPositionsReport',
+    )
+
+
 def test_elegant(fc):
     _r(
         fc,
@@ -27,11 +35,51 @@ def test_elegant(fc):
     )
 
 
+def test_madx(fc):
+    _r(
+        fc,
+        'FODO PTC',
+        'bunchReport1',
+    )
+
+
+def test_ml(fc):
+    _r(
+        fc,
+        '2019 World Happiness',
+        'fileColumnReport1',
+    )
+
+
+def test_opal(fc):
+    _r(
+        fc,
+        'Slit-1',
+        'bunchReport1',
+    )
+
+
 def test_radia(fc):
     _r(
         fc,
         'Dipole',
         'geometryReport',
+    )
+
+
+def test_shadow(fc):
+    _r(
+        fc,
+        'Diffraction Profile',
+        'beamStatisticsReport',
+    )
+
+
+def test_srw(fc):
+    _r(
+        fc,
+        "Young's Double Slit Experiment",
+        'initialIntensityReport',
     )
 
 


### PR DESCRIPTION
This adds tests for codes where it makes sense to do so. They are the simplest tests possible, requiring code completion (in most cases) but nothing more.