### PR TITLE
Fix #4081 - randomSeed default from null to empty

### DIFF
--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -651,7 +651,7 @@
             "numCores": ["Number of Cores", "Integer", 4],
             "numSamples": ["Samples per Parameter", "Integer", 100, "", 1],
             "numWorkers": ["Number of Workers", "Integer", 1],
-            "randomSeed": ["Random Seed", "RandomSeed", null, "Explicit seed for random numbers in the range [{{ SIREPO.APP_SCHEMA.model.exportRsOpt.randomSeed[SIREPO.INFO_INDEX_MIN] }}, {{ SIREPO.APP_SCHEMA.model.exportRsOpt.randomSeed[SIREPO.INFO_INDEX_MAX] }}). Leave empty to allow server to decide the seed.", 0, 4294967296],
+            "randomSeed": ["Random Seed", "RandomSeed", "", "Explicit seed for random numbers in the range [{{ SIREPO.APP_SCHEMA.model.exportRsOpt.randomSeed[SIREPO.INFO_INDEX_MIN] }}, {{ SIREPO.APP_SCHEMA.model.exportRsOpt.randomSeed[SIREPO.INFO_INDEX_MAX] }}). Leave empty to allow server to decide the seed.", 0, 4294967296],
             "scanType": ["Scan Type", "ScanType", "random", "Grid samples each parameter uniformly. Random takes a random sample for each parameter."],
             "totalSamples": ["Total Samples", "Integer", 100, "Grid: &lt;number of samples&gt;^&lt;number of params&gt;. Random: &lt;number of samples&gt;", 1]
         },


### PR DESCRIPTION
```SIM_DATA.model_defaults``` should have set the default value for ```randomSeed``` ,  but the default value was null, translating to None, and was therefore skipped. Using an empty string allows the value to be set.