### PR TITLE
Fix #4015 added SIREPO_SMTP_SEND_DIRECTLY

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ pykern.pksetup.setup(
         'aenum',
         'asyncssh',
         'cryptography>=2.8',
+        'dnspython',
         'futures',
         # for virtualenv
         'importlib-metadata<2,>=0.12',

--- a/sirepo/smtp.py
+++ b/sirepo/smtp.py
@@ -6,34 +6,92 @@ u"""SMTP connection to send emails
 """
 
 from __future__ import absolute_import, division, print_function
+from pykern.pkdebug import pkdp, pkdlog
 from pykern import pkconfig
 from pykern.pkcollections import PKDict
 import email
 import smtplib
 
 _DEV_SMTP_SERVER = 'dev'
+_SEND = None
+cfg = None
+
 
 def send(recipient, subject, body):
     if cfg.server == _DEV_SMTP_SERVER:
+        pkdlog('DEV configuration so not sending to {}', recipient)
         return False
     m = email.message.EmailMessage()
     m['From'] = f'{cfg.from_name} <{cfg.from_email}>'
     m['To'] = recipient
     m['Subject'] = subject
     m.set_content(body)
+    _SEND(m)
+    return True
+
+
+def _mx(msg):
+    import dns.resolver
+    import pykern.pkcompat
+
+    h = msg['To'].split('@')[1]
+    try:
+        for x in sorted(
+            dns.resolver.resolve(h, 'MX'),
+            key=lambda x: x.preference,
+        ):
+            yield str(x.exchange)
+    except dns.resolver.NoAnswer:
+        return h
+
+
+def _send_directly(msg):
+    for h in _mx(msg):
+        # Port 465 is not an official IETF port for SMTPS and has been
+        # reassigned so always try port 25 with starttls. stmplib will try
+        # 465 if it can import ssl even if the remote server doesn't support it.
+        with smtplib.SMTP(h, 25) as s:
+            try:
+                s.starttls()
+            except smtplib.SMTPNotSupportedError:
+                pass
+            s.ehlo()
+            s.send_message(msg)
+
+
+def _send_with_auth(msg):
     with smtplib.SMTP(cfg.server, cfg.port) as s:
         s.starttls()
         s.ehlo()
         s.login(cfg.user, cfg.password)
-        s.send_message(m)
-    return True
+        s.send_message(msg)
 
 
-cfg = pkconfig.init(
-    from_email=('support@sirepo.com', str, 'Email address of sender'),
-    from_name=('Sirepo Support', str, 'Name of email sender'),
-    password=pkconfig.RequiredUnlessDev('n/a', str, 'SMTP password'),
-    port=(587, int, 'SMTP Port'),
-    server=pkconfig.RequiredUnlessDev(_DEV_SMTP_SERVER, str, 'SMTP TLS server'),
-    user=pkconfig.RequiredUnlessDev('n/a', str, 'SMTP user'),
-)
+def _init():
+    global cfg, _SEND
+    if cfg:
+        return
+    cfg = pkconfig.init(
+        from_email=('support@sirepo.com', str, 'Email address of sender'),
+        from_name=('Sirepo Support', str, 'Name of email sender'),
+        password=(None, str, 'SMTP password'),
+        port=(587, int, 'SMTP Port'),
+        send_directly=(False, bool, 'Send directly to the server in the recipient'),
+        server=(None, str, 'SMTP TLS server'),
+        user=(None, str, 'SMTP user'),
+    )
+    if cfg.send_directly:
+        cfg.server = 'not ' + _DEV_SMTP_SERVER
+        _SEND = _send_directly
+        return
+    _SEND = _send_with_auth
+    if pkconfig.channel_in('dev'):
+        if not cfg.server:
+            cfg.server = _DEV_SMTP_SERVER
+        return
+    if cfg.server is None or cfg.user is None or cfg.password is None:
+        pkconfig.raise_error(
+            f'server={cfg.server}, user={cfg.user}, and password={cfg.password} must be defined',
+        )
+
+_init()

--- a/sirepo/smtp.py
+++ b/sirepo/smtp.py
@@ -32,7 +32,6 @@ def send(recipient, subject, body):
 
 def _mx(msg):
     import dns.resolver
-    import pykern.pkcompat
 
     h = msg['To'].split('@')[1]
     try:
@@ -86,7 +85,7 @@ def _init():
         return
     _SEND = _send_with_auth
     if pkconfig.channel_in('dev'):
-        if not cfg.server:
+        if cfg.server is None:
             cfg.server = _DEV_SMTP_SERVER
         return
     if cfg.server is None or cfg.user is None or cfg.password is None:

--- a/tests/smtp1_test.py
+++ b/tests/smtp1_test.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+u"""conditionally test smtp
+
+:copyright: Copyright (c) 2022 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+import os
+import pytest
+
+
+pytestmark = pytest.mark.skipif(not os.environ.get('SIREPO_TESTS_SMTP_EMAIL'), reason='$SIREPO_TESTS_SMTP_EMAIL not set')
+
+
+def test_send_directly():
+    import pykern.pkconfig
+    from pykern.pkcollections import PKDict
+
+    pykern.pkconfig.reset_state_for_testing(
+        PKDict(
+            SIREPO_SMTP_SEND_DIRECTLY='1',
+        ),
+    )
+    import sirepo.smtp
+    import sirepo.util
+
+    sirepo.smtp.send(
+        os.environ.get('SIREPO_TESTS_SMTP_EMAIL'),
+        f'sirepo.smtp1_test {sirepo.util.random_base62(5)}',
+        'This is a message from sirepo/tests/smtp1_test.py\n',
+    )

--- a/tests/smtp2_test.py
+++ b/tests/smtp2_test.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+u"""conditionally test smtp
+
+:copyright: Copyright (c) 2022 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+import os
+import pytest
+
+
+pytestmark = pytest.mark.skipif(not os.environ.get('SIREPO_TESTS_SMTP_EMAIL'), reason='$SIREPO_TESTS_SMTP_EMAIL not set')
+
+
+def test_send_directly():
+    import pykern.pkconfig
+    from pykern.pkcollections import PKDict
+
+    pykern.pkconfig.reset_state_for_testing(
+        PKDict(
+            SIREPO_SMTP_SEND_DIRECTLY='0',
+        ),
+    )
+    import sirepo.smtp
+    import sirepo.util
+
+    assert sirepo.smtp.cfg.server != sirepo.smtp._DEV_SMTP_SERVER
+    sirepo.smtp.send(
+        os.environ.get('SIREPO_TESTS_SMTP_EMAIL'),
+        f'sirepo.smtp2_test {sirepo.util.random_base62(5)}',
+        'This is a message from sirepo/tests/smtp2_test.py\n',
+    )


### PR DESCRIPTION
Setting SIREPO_STMP_SEND_DIRECTLY allows smtp
to try to send directly to the server in question.
It doesn't retry so it's suboptimal, but useful
for sites that don't have a submission server