### PR TITLE
Issue/4129 Speed up animation and report tests

### DIFF
--- a/sirepo/srunit.py
+++ b/sirepo/srunit.py
@@ -225,13 +225,12 @@ class _TestClient(flask.testing.FlaskClient):
         self.sr_sim_type = None
         self.sr_uid = None
 
-    def sr_animation_run(self, sim_name, compute_model, reports=None, **kwargs):
+    def sr_animation_run(self, data, compute_model, reports=None, **kwargs):
         from pykern import pkunit
         from pykern.pkcollections import PKDict
         from pykern.pkdebug import pkdp, pkdlog
         import re
 
-        data = self.sr_sim_data(sim_name)
         run = self.sr_run_sim(data, compute_model, **kwargs)
         for r, a in reports.items():
             if 'runSimulation' in a:

--- a/tests/animation_test.py
+++ b/tests/animation_test.py
@@ -9,9 +9,8 @@ from pykern.pkcollections import PKDict
 import pytest
 
 def test_controls(fc):
-    data = fc.sr_sim_data('Sample MAD-X beamline')
     fc.sr_animation_run(
-        data,
+        fc.sr_sim_data('Sample MAD-X beamline'),
         'animation',
         PKDict(),
         expect_completed=False,
@@ -31,6 +30,7 @@ def test_elegant(fc):
                 expect_y_range='-1.*e-15, 34.6',
             ),
         }),
+        timeout=30,
     )
 
 
@@ -73,6 +73,7 @@ def test_ml(fc):
         fc.sr_sim_data('iris Dataset'),
         'animation',
         PKDict(),
+        timeout=45,
     )
 
 
@@ -148,7 +149,7 @@ def test_warppba(fc):
         rCellResolution=20,
         zScale=1,
         zLength=10.162490077316,
-        zMax=1.600000000000,
+        zMax=1.6,
         zMin=-10.162490077316,
         zCellsPerWavelength=8,
         zCount=118,
@@ -169,6 +170,7 @@ def test_warppba(fc):
                 expect_y_range='-5.*e-06, 5.*e-06, 18',
             ),
         ),
+        timeout=20,
     )
 
 

--- a/tests/animation_test.py
+++ b/tests/animation_test.py
@@ -36,7 +36,7 @@ def test_elegant(fc):
 
 def test_jspec(fc):
     data = fc.sr_sim_data('DC Cooling Example')
-    data.models.simulationSettings.update(dict(
+    data.models.simulationSettings.update(PKDict(
         time=1,
         step_number=1,
         time_step=1,
@@ -138,7 +138,7 @@ def test_synergia(fc):
 
 def test_warppba(fc):
     data = fc.sr_sim_data('Laser Pulse')
-    data.models.simulationGrid.update(dict(
+    data.models.simulationGrid.update(PKDict(
         rScale=1,
         rLength=5.081245038595,
         rMax=5.081245038595,
@@ -187,7 +187,7 @@ def test_warpvnd(fc):
         timeout=20,
     )
     data = fc.sr_sim_data('Two Poles')
-    data.models.simulationGrid.update(dict(
+    data.models.simulationGrid.update(PKDict(
         num_steps=100,
         channel_width=0.09,
     ))

--- a/tests/report_test.py
+++ b/tests/report_test.py
@@ -23,16 +23,6 @@ def test_elegant(fc):
         'Compact Storage Ring',
         'twissReport',
     )
-#    _r(
-#        fc,
-#        'Script Element Example',
-#        'twissReport',
-#    )
-    _r(
-        fc,
-        'Backtracking',
-        'twissReport',
-    )
 
 
 def test_madx(fc):
@@ -95,11 +85,6 @@ def test_synergia(fc):
 def test_warppba(fc):
     _r(
         fc,
-        'Electron Beam',
-        'beamPreviewReport',
-    )
-    _r(
-        fc,
         'Laser Pulse',
         'laserPreviewReport',
     )
@@ -110,16 +95,6 @@ def test_zgoubi(fc):
         fc,
         'Los Alamos Proton Storage Ring',
         'twissReport',
-    )
-    _r(
-        fc,
-        'Los Alamos Proton Storage Ring',
-        'bunchReport1',
-    )
-    _r(
-        fc,
-        'Los Alamos Proton Storage Ring',
-        'twissReport2',
     )
 
 


### PR DESCRIPTION
This makes the animation test about a minute faster, but it still takes 2 minutes to run - about 8 seconds per server call. All sims are now expected to complete successfully. Almost all time is spent in non simulation runtime. I also removed some report tests which seemed redundant.