### PR TITLE
By being in the package.json the binaries are found

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "karma-jasmine": "latest"
   },
   "scripts": {
-    "lint": "npx jshint --config=etc/jshint.conf",
-    "test": "npx karma start etc/karma-conf.js"
+    "lint": "jshint --config=etc/jshint.conf",
+    "test": "karma start etc/karma-conf.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
So the full path to the binary nor npx are needed.

Not exactly sure what was wrong with npx but it seemed to not work
when ~/src was shared over NFS between the host and vm