### PR TITLE
Fix #2431: reload supervisor and flask on file changes

### DIFF
--- a/sirepo/pkcli/job_supervisor.py
+++ b/sirepo/pkcli/job_supervisor.py
@@ -4,7 +4,6 @@
 :copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 from pykern import pkconfig
 from pykern import pkio
 from pykern import pkjson
@@ -13,14 +12,18 @@ from pykern.pkdebug import pkdp, pkdlog, pkdexc, pkdc
 import asyncio
 import copy
 import functools
+import importlib
 import signal
 import sirepo.events
+import sirepo.feature_config
 import sirepo.job
 import sirepo.job_driver
 import sirepo.job_supervisor
 import sirepo.sim_db_file
 import sirepo.srdb
 import sirepo.srtime
+import sirepo.util
+import tornado.autoreload
 import tornado.httpserver
 import tornado.ioloop
 import tornado.web
@@ -59,6 +62,10 @@ def default_command():
         websocket_ping_interval=sirepo.job.cfg.ping_interval_secs,
         websocket_ping_timeout=sirepo.job.cfg.ping_timeout_secs,
     )
+    if cfg.debug:
+        for f in sirepo.util.files_to_watch_for_reload('jinja', 'json', 'py'):
+            tornado.autoreload.watch(f)
+
     server = tornado.httpserver.HTTPServer(
         app,
         xheaders=True,

--- a/sirepo/pkcli/job_supervisor.py
+++ b/sirepo/pkcli/job_supervisor.py
@@ -63,7 +63,7 @@ def default_command():
         websocket_ping_timeout=sirepo.job.cfg.ping_timeout_secs,
     )
     if cfg.debug:
-        for f in sirepo.util.files_to_watch_for_reload('jinja', 'json', 'py'):
+        for f in sirepo.util.files_to_watch_for_reload('json', 'py'):
             tornado.autoreload.watch(f)
 
     server = tornado.httpserver.HTTPServer(

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -29,6 +29,7 @@ __cfg = None
 
 def flask():
     from sirepo import server
+    from sirepo import util
     import sirepo.pkcli.setup_dev
 
     with pkio.save_chdir(_run_dir()) as r:
@@ -42,6 +43,7 @@ def flask():
         werkzeug.serving.click = None
         app.run(
             exclude_patterns=[str(r.join('*'))],
+            extra_files=util.files_to_watch_for_reload('json'),
             host=_cfg().ip,
             port=_cfg().port,
             threaded=True,

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -198,10 +198,7 @@ def files_to_watch_for_reload(*extensions):
             d = pykern.pkio.py_path(
                 getattr(importlib.import_module(p), '__file__'),
             ).dirname
-            for f in pykern.pkio.sorted_glob(
-                    f'{d}/**/*.{e}',
-                    recursive=True,
-            ):
+            for f in pykern.pkio.sorted_glob(f'{d}/**/*.{e}'):
                 yield f
 
 

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -4,7 +4,6 @@ u"""Support routines and classes, mostly around errors and I/O.
 :copyright: Copyright (c) 2018 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 from pykern import pkcompat
 from pykern import pkconfig
 from pykern.pkcollections import PKDict
@@ -12,7 +11,6 @@ from pykern.pkdebug import pkdlog, pkdp, pkdexc, pkdc
 import asyncio
 import base64
 import concurrent.futures
-import contextlib
 import hashlib
 import importlib
 import inspect
@@ -189,6 +187,22 @@ def create_token(value):
 
 def err(obj, fmt='', *args, **kwargs):
     return '{}: '.format(obj) + fmt.format(*args, **kwargs)
+
+
+def files_to_watch_for_reload(*extensions):
+    from sirepo import feature_config
+    if not pkconfig.channel_in('dev'):
+        return []
+    for e in extensions:
+        for p in set(['sirepo', *feature_config.cfg().package_path]):
+            d = pykern.pkio.py_path(
+                getattr(importlib.import_module(p), '__file__'),
+            ).dirname
+            for f in pykern.pkio.sorted_glob(
+                    f'{d}/**/*.{e}',
+                    recursive=True,
+            ):
+                yield f
 
 
 def find_obj(arr, key, value):


### PR DESCRIPTION
**This PR depends on radiasoft/pykern#124. Merge that before this**

Tornado's debug mode causes the server to reload whenever an imported
module changes. But, modules that aren't imported in the supervisor
(ex templates) should cause the system to reload so we pick up the
changes. When the supervisor reloads agent's are dropped and killed on
restart which forces a reload for them and any downstream processes
(ex job_cmd's).

Flask's reloader works like Tornado (reloads when imported python
module changes). But, for extra files it is only relevant to reload
flask when json files changes (ex a code's schema.json).

@mkeilman I'd like it if you gave this a try. It adds watching a lot of files. If NFS sharing between your host and vm is the culprit behind the slowdown starting the server this is probably going to make the problem worse. 