### PR TITLE
Fix #2435: reply to runSimulation request immediately (no await)

### DIFF
--- a/sirepo/job_driver/local.py
+++ b/sirepo/job_driver/local.py
@@ -11,7 +11,6 @@ from pykern.pkdebug import pkdp, pkdlog
 from sirepo import job
 from sirepo import job_driver
 import sirepo.mpi
-import sirepo.srdb
 import subprocess
 import tornado.ioloop
 import tornado.process

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -18,7 +18,6 @@ import datetime
 import errno
 import sirepo.job_supervisor
 import sirepo.simulation_db
-import sirepo.srdb
 import sirepo.util
 import tornado.gen
 import tornado.ioloop

--- a/tests/job_concurrency1_test.py
+++ b/tests/job_concurrency1_test.py
@@ -60,7 +60,7 @@ def test_myapp_cancel(fc):
             simulationType=d.simulationType,
         ),
     )
-    for _ in range(10):
+    for _ in range(20):
         pkdlog(r1)
         pkunit.pkok(r1.state != 'error', 'unexpected error state: {}')
         if r1.state == 'running':


### PR DESCRIPTION
Previously, runSimulation requests were held open until we got resources
to run the request (prepare_send).