### PR TITLE
Fix #4195: yaml now requires a Loader

### DIFF
--- a/sirepo/hundli_console.py
+++ b/sirepo/hundli_console.py
@@ -36,7 +36,7 @@ def main():
         exit(1)
     input_yaml, output_csv = sys.argv[1:]
     with open(input_yaml, 'r') as f:
-        params = yaml.load(f)
+        params = yaml.safe_load(f)
 
     if params['name'] == 'srunit_long_run':
         time.sleep(100)


### PR DESCRIPTION
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation