### PR TITLE
4166 auto save beamline

### DIFF
--- a/sirepo/package_data/static/js/sirepo-beamline.js
+++ b/sirepo/package_data/static/js/sirepo-beamline.js
@@ -250,7 +250,7 @@ SIREPO.app.directive('beamlineBuilder', function(appState, beamlineService, pane
               '</div>',
             '</div>',
         ].join(''),
-        controller: function($scope) {
+        controller: function($scope, $rootScope) {
             $scope.setWatchpointActive = function(item) {
                 if(! $scope.parentController.setWatchpointActive) {
                     return;
@@ -413,6 +413,9 @@ SIREPO.app.directive('beamlineBuilder', function(appState, beamlineService, pane
                 $scope.parentController.prepareToSave();
                 appState.saveChanges($scope.beamlineModels);
             };
+            $rootScope.$on('saveLattice', (e, d) => {
+                $scope.saveBeamlineChanges();
+            });
         },
     };
 });

--- a/sirepo/package_data/static/js/sirepo-beamline.js
+++ b/sirepo/package_data/static/js/sirepo-beamline.js
@@ -413,6 +413,7 @@ SIREPO.app.directive('beamlineBuilder', function(appState, beamlineService, pane
                 $scope.parentController.prepareToSave();
                 appState.saveChanges($scope.beamlineModels);
             };
+
             $rootScope.$on('saveLattice', (e, d) => {
                 $scope.saveBeamlineChanges();
             });

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -3306,6 +3306,7 @@ SIREPO.app.directive('beamlineAnimation', function(appState, frameCache, persist
             });
 
             $scope.start = function() {
+                srdbg('starting sim');
                 appState.models.simulation.framesCleared = false;
                 appState.saveChanges(
                     [$scope.simState.model, 'simulation'],

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -2,6 +2,7 @@
 
 var srlog = SIREPO.srlog;
 var srdbg = SIREPO.srdbg;
+
 SIREPO.app.config(function() {
     SIREPO.appDefaultSimulationValues.simulation.sourceType = 'u';
     SIREPO.SHOW_HELP_BUTTONS = true;
@@ -3271,7 +3272,7 @@ SIREPO.app.directive('srwNumberList', function(appState) {
     };
 });
 
-SIREPO.app.directive('beamlineAnimation', function(appState, beamlineService, frameCache, persistentSimulation, srwService) {
+SIREPO.app.directive('beamlineAnimation', function(appState, frameCache, persistentSimulation) {
     return {
         restrict: 'A',
         scope: {},

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -3312,8 +3312,10 @@ SIREPO.app.directive('beamlineAnimation', function(appState, beamlineService, fr
             }
 
             $scope.start = function() {
-                srdbg('Beamline right before save:', appState.models.beamline);
-                // TODO (gurhar1133): check if below commented out is necessary for any reason
+                srdbg('models right before save:', appState.models);
+                // TODO (gurhar1133): commented out below results in propogation model being updated,
+                // cant add beamline elems without updating propogation
+
                 // appState.models.beamline.sort(function(a, b) {
                 //     return parseFloat(a.position) - parseFloat(b.position);
                 // });

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -2,7 +2,6 @@
 
 var srlog = SIREPO.srlog;
 var srdbg = SIREPO.srdbg;
-
 SIREPO.app.config(function() {
     SIREPO.appDefaultSimulationValues.simulation.sourceType = 'u';
     SIREPO.SHOW_HELP_BUTTONS = true;
@@ -2634,7 +2633,6 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
             };
 
             $scope.startSimulation = function() {
-                srdbg('appState.models at start sim: ', appState.models);
                 setActiveAnimation();
                 $scope.particleCount = 0;
                 // The available jobRunModes can change. Default to parallel if
@@ -3298,7 +3296,7 @@ SIREPO.app.directive('beamlineAnimation', function(appState, beamlineService, fr
             <div data-watchpoint-report="" data-item-id="report.id"></div>
           </div>
         `,
-        controller: function($scope) {
+        controller: function($scope, $rootScope) {
             $scope.reports = [];
             $scope.simScope = $scope;
             $scope.simComputeModel = 'beamlineAnimation';
@@ -3306,139 +3304,8 @@ SIREPO.app.directive('beamlineAnimation', function(appState, beamlineService, fr
                 $scope.reports = [];
             });
 
-            // TODO (gurhar): start
-            function isWatchpointReportModelName(name) {
-                return name.indexOf('watchpointReport') >= 0
-                    || name.indexOf('beamlineAnimation') >= 0;
-            }
-
-            function defaultItemPropagationParams() {
-                return [0, 0, 1, 0, 0, 1.0, 1.0, 1.0, 1.0, 0, 0, 0, 0, 0, 0, 0, 0];
-            }
-
-            function defaultDriftPropagationParams() {
-                return [0, 0, 1, 1, 0, 1.0, 1.0, 1.0, 1.0, 0, 0, 0, 0, 0, 0, 0, 0];
-            }
-
-            function updateWatchpointReports() {
-                // special code to update initialIntensityReport and watchpointReports
-                // from beamlineAnimation models so sirepo_bluesky can continue to use those models
-                for (let name in appState.models) {
-                    let targetName;
-                    if (name == 'beamlineAnimation0') {
-                        targetName = 'initialIntensityReport';
-                    }
-                    else if (name.indexOf('beamlineAnimation') >= 0) {
-                        targetName = name.replace('beamlineAnimation', 'watchpointReport');
-                    }
-                    if (targetName) {
-                        appState.models[targetName] = appState.clone(appState.models[name]);
-                        appState.saveQuietly(targetName);
-                    }
-                }
-            }
-
-            const prepareToSave = () => {
-                if (! appState.isLoaded()) {
-                    return;
-                }
-                var beamline = appState.models.beamline;
-                if (! appState.models.propagation) {
-                    appState.models.propagation = {};
-                }
-                var propagation = appState.models.propagation;
-                self.propagations = [];
-                var i;
-                for (i = 0; i < beamline.length; i++) {
-                    if (! propagation[beamline[i].id]) {
-                        propagation[beamline[i].id] = [
-                            defaultItemPropagationParams(),
-                            defaultDriftPropagationParams(),
-                        ];
-                    }
-                    var p = propagation[beamline[i].id];
-
-                    if (beamline[i].type != 'watch' && beamline[i].type != 'grating' && beamline[i].type != 'crystal') {
-                        self.propagations.push({
-                            item: beamline[i],
-                            title: beamline[i].title,
-                            params: p[0],
-                            defaultparams: [p[0][12], p[0][13], p[0][14], p[0][15], p[0][16] ],
-                        });
-                    }
-
-                    if (beamline[i].type != 'watch' && (beamline[i].type == 'grating' || beamline[i].type == 'crystal')) {
-                        self.propagations.push({
-                            item: beamline[i],
-                            title: beamline[i].title,
-                            params: p[0],
-                            defaultparams: [beamline[i].outoptvx, beamline[i].outoptvy, beamline[i].outoptvz, beamline[i].outframevx, beamline[i].outframevy],
-                        });
-                    }
-
-                    if (i == beamline.length - 1) {
-                        break;
-                    }
-                    var d = parseFloat(beamline[i + 1].position) - parseFloat(beamline[i].position);
-                    if (d > 0) {
-                        self.propagations.push({
-                            title: 'Drift ' + srwService.formatFloat4(d) + 'm',
-                            params: p[1],
-                            defaultparams: [p[1][12], p[1][13], p[1][14], p[1][15], p[1][16] ],
-                        });
-                    }
-                }
-                if (! appState.models.postPropagation || appState.models.postPropagation.length === 0) {
-                    appState.models.postPropagation = defaultItemPropagationParams();
-                }
-                self.postPropagation = appState.models.postPropagation;
-
-                var newPropagations = {};
-                for (i = 0; i < appState.models.beamline.length; i++) {
-                    var item = appState.models.beamline[i];
-                    newPropagations[item.id] = appState.models.propagation[item.id];
-                }
-                appState.models.propagation = newPropagations;
-                updateWatchpointReports();
-            };
-
             $scope.start = function() {
-                // TODO (gurhar1133): commented out below results in propogation model being updated,
-                // cant add beamline elems without updating propogation
-
-                appState.models.beamline.sort(function(a, b) {
-                    return parseFloat(a.position) - parseFloat(b.position);
-                });
-                // culls and saves watchpoint models
-                var watchpoints = {
-                    // the first beamineAnimation is the initialIntensityReport equivalent
-                    beamlineAnimation0: true,
-                };
-                for (var i = 0; i < appState.models.beamline.length; i++) {
-                    var item = appState.models.beamline[i];
-                    if (item.type == 'watch') {
-                        watchpoints[beamlineService.watchpointReportName(item.id)] = true;
-                    }
-                }
-                var savedModelValues = appState.applicationState();
-                for (var modelName in appState.models) {
-                    if (isWatchpointReportModelName(modelName) && ! watchpoints[modelName]) {
-                        // deleted watchpoint, remove the report model
-                        delete appState.models[modelName];
-                        delete savedModelValues[modelName];
-                        continue;
-                    }
-                    if (isWatchpointReportModelName(modelName)) {
-                        savedModelValues[modelName] = appState.cloneModel(modelName);
-                    }
-                }
-                prepareToSave();
-                // TODO (gurhar1133): Also, check if needs to be done before starting sim in source tab
-                appState.saveChanges('beamline');
-                appState.saveChanges('propagation');
-                srdbg('saved');
-                srdbg('models right before sim:', appState.models);
-                // TODO (gurhar): end
+                $rootScope.$broadcast('saveLattice', appState.models);
                 appState.models.simulation.framesCleared = false;
                 appState.saveChanges(
                     [$scope.simState.model, 'simulation'],

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -2634,6 +2634,7 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
             };
 
             $scope.startSimulation = function() {
+                srdbg('appState.models at start sim: ', appState.models);
                 setActiveAnimation();
                 $scope.particleCount = 0;
                 // The available jobRunModes can change. Default to parallel if
@@ -3272,7 +3273,7 @@ SIREPO.app.directive('srwNumberList', function(appState) {
     };
 });
 
-SIREPO.app.directive('beamlineAnimation', function(appState, frameCache, persistentSimulation) {
+SIREPO.app.directive('beamlineAnimation', function(appState, beamlineService, frameCache, persistentSimulation) {
     return {
         restrict: 'A',
         scope: {},
@@ -3305,8 +3306,47 @@ SIREPO.app.directive('beamlineAnimation', function(appState, frameCache, persist
                 $scope.reports = [];
             });
 
+            function isWatchpointReportModelName(name) {
+                return name.indexOf('watchpointReport') >= 0
+                    || name.indexOf('beamlineAnimation') >= 0;
+            }
+
             $scope.start = function() {
-                srdbg('starting sim');
+                srdbg('Beamline right before save:', appState.models.beamline);
+                // TODO (gurhar1133): check if below commented out is necessary for any reason
+                // appState.models.beamline.sort(function(a, b) {
+                //     return parseFloat(a.position) - parseFloat(b.position);
+                // });
+                // // culls and saves watchpoint models
+                // var watchpoints = {
+                //     // the first beamineAnimation is the initialIntensityReport equivalent
+                //     beamlineAnimation0: true,
+                // };
+                // for (var i = 0; i < appState.models.beamline.length; i++) {
+                //     var item = appState.models.beamline[i];
+                //     if (item.type == 'watch') {
+                //         watchpoints[beamlineService.watchpointReportName(item.id)] = true;
+                //     }
+                // }
+                // var savedModelValues = appState.applicationState();
+                // for (var modelName in appState.models) {
+                //     if (isWatchpointReportModelName(modelName) && ! watchpoints[modelName]) {
+                //         // deleted watchpoint, remove the report model
+                //         delete appState.models[modelName];
+                //         delete savedModelValues[modelName];
+                //         continue;
+                //     }
+                //     if (isWatchpointReportModelName(modelName)) {
+                //         savedModelValues[modelName] = appState.cloneModel(modelName);
+                //     }
+                // }
+                // $scope.parentController.prepareToSave();
+
+                // TODO (gurhar1133): Also, check if needs to be done before starting sim in source tab
+                appState.saveChanges('beamline');
+                srdbg('saved');
+                srdbg('Beamline right before sim:', appState.models.beamline);
+
                 appState.models.simulation.framesCleared = false;
                 appState.saveChanges(
                     [$scope.simState.model, 'simulation'],


### PR DESCRIPTION
Lattice gets autosaved by event dispatch. Saving beamline requires considerable preprocessing that takes place in saveBeamlineChanges() in the 'beamlineBuilder' directive in sirepo-beamline.js so dispatching an event to that directive seemed like a clean way to do things.

Does the autosave need to be added to the 'start new simulation' button in the source tab as well @moellep ?