### PR TITLE
Fix #4237 authlib changed to 1.0.0 (from 15.1.5) and in it they remov…

### DIFF
--- a/sirepo/auth/github.py
+++ b/sirepo/auth/github.py
@@ -6,7 +6,6 @@ GitHub is written Github and github (no underscore or dash) for ease of use.
 :copyright: Copyright (c) 2016-2019 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 from pykern import pkconfig
 from pykern import pkinspect
 from pykern.pkcollections import PKDict
@@ -20,8 +19,8 @@ from sirepo import http_reply
 from sirepo import http_request
 from sirepo import uri_router
 from sirepo import util
-import authlib.integrations.base_client
 import authlib.integrations.requests_client
+import authlib.oauth2.rfc6749.errors
 import flask
 import sirepo.events
 import sqlalchemy
@@ -50,12 +49,18 @@ def api_authGithubAuthorized():
     Tracks oauth users in a database.
     """
     # clear temporary cookie values first
-    oc = _client(cookie.unchecked_remove(_COOKIE_NONCE))
+    s = cookie.unchecked_remove(_COOKIE_NONCE)
     t = cookie.unchecked_remove(_COOKIE_SIM_TYPE)
-    if not oc.authorize_access_token():
+    oc = _client()
+    try:
+        oc.fetch_token(
+            authorization_response=flask.request.url,
+            state=s,
+        )
+    except authlib.oauth2.rfc6749.errors.MismatchingStateException:
         auth.login_fail_redirect(t, this_module, 'oauth-state', reload_js=True)
         raise AssertionError('auth.login_fail_redirect returned unexpectedly')
-    d = oc.get('user').json()
+    d = oc.get('https://api.github.com/user').json()
     sirepo.events.emit('github_authorized', PKDict(user_name=d['login']))
     with util.THREAD_LOCK:
         u = AuthGithubUser.search_by(oauth_id=d['id'])
@@ -80,7 +85,12 @@ def api_authGithubLogin(simulation_type):
         # must be executed in an app and request context so can't
         # initialize earlier.
         cfg.callback_uri = uri_router.uri_for_api('authGithubAuthorized')
-    return _client(s).authorize_redirect(redirect_uri=cfg.callback_uri, state=s)
+    u, _ = _client().create_authorization_url(
+        'https://github.com/login/oauth/authorize',
+        redirect_uri=cfg.callback_uri,
+        state=s,
+    )
+    return http_reply.gen_redirect(u)
 
 
 @api_perm.allow_cookieless_set_user
@@ -96,49 +106,17 @@ def avatar_uri(model, size):
     )
 
 
-class _Client(authlib.integrations.base_client.RemoteApp):
-
-    def __init__(self, state):
-        super().__init__(
-            framework=PKDict(oauth2_client_cls=authlib.integrations.requests_client.OAuth2Session),
-            name='github',
-            access_token_params=None,
-            access_token_url='https://github.com/login/oauth/access_token',
-            api_base_url='https://api.github.com/',
-            authorize_params=None,
-            authorize_url='https://github.com/login/oauth/authorize',
-            client_id=cfg.key,
-            client_kwargs={'scope': 'user:email'},
-            client_secret=cfg.secret,
-        )
-        self.__state = state
-
-    def authorize_access_token(self):
-        assert flask.request.method == 'GET'
-        a = self.__state
-        assert a
-        b = flask.request.args.get('state')
-        if a != b:
-            pkdlog('mismatch oauth state: expected {} != got {}', a, b)
-            return None
-        t = self.fetch_access_token(code=flask.request.args['code'], state=b)
-        self.token = t
-        return t
-
-    def authorize_redirect(self, redirect_uri=None, **kwargs):
-        return http_reply.gen_redirect(
-            self.create_authorization_url(redirect_uri, **kwargs)['url'],
-        )
-
-    def request(self, method, url, token=None, **kwargs):
-        if token is None and not kwargs.get('withhold_token'):
-            token = self.token
-        return super().request(method, url, token=token, **kwargs)
-
-
-def _client(state):
+def _client(token=None):
     """Makes it easier to mock, see github_srunit.py"""
-    return _Client(state)
+    # OAuth2Session doesn't inherit from OAuth2Mixin for some reason.
+    # So, supplying api_base_url has no effect.
+    return authlib.integrations.requests_client.OAuth2Session(
+        cfg.key,
+        cfg.secret,
+        scope='user:email',
+        token=token,
+        token_endpoint='https://github.com/login/oauth/access_token',
+    )
 
 
 def _init():

--- a/sirepo/github_srunit.py
+++ b/sirepo/github_srunit.py
@@ -14,35 +14,33 @@ class MockOAuthClient(object):
         from pykern import pkcollections
         from sirepo.auth import github
 
-        self.values = pkcollections.Dict(
-            access_token='xyzzy',
-            user=pkcollections.Dict(
+        self.values = PKDict({
+            'access_token': 'xyzzy',
+            'https://api.github.com/user': PKDict(
                 # don't really care about id as long as it is bound to login
                 id=user_name,
                 login=user_name,
             ),
-        )
+        })
         monkeypatch.setattr(github, '_client', self)
 
     def __call__(self, *args, **kwargs):
         return self
 
-    def authorize_redirect(self, redirect_uri, state):
-        from sirepo.auth import github
-        import sirepo.http_reply
-
-        self.values.redirect_uri = redirect_uri
-        self.values.state = state
-        return sirepo.http_reply.gen_redirect(
-            'https://github.com/login/oauth/oauthorize?response_type=code&client_id={}&redirect_uri={}&state={}'.format(
-                github.cfg.key,
-                github.cfg.callback_uri,
-                state,
-            ),
-        )
 
     def authorize_access_token(self, *args, **kwargs):
         return self.values
+
+    def create_authorization_url(self, *args, **kwargs):
+        from sirepo.auth import github
+        import sirepo.http_reply
+
+        self.values.redirect_uri = kwargs['redirect_uri']
+        self.values.state = kwargs['state']
+        return f'https://github.com/login/oauth/oauthorize?response_type=code&client_id={github.cfg.key}&redirect_uri={github.cfg.callback_uri}&state={self.values.state}', self.values.state
+
+    def fetch_token(self, *args, **kwargs):
+        return 'a_mock_token'
 
     def get(self, *args, **kwargs):
         return _JSON(self.values[args[0]])

--- a/tests/auth/github_test.py
+++ b/tests/auth/github_test.py
@@ -30,9 +30,9 @@ def test_guest_merge(monkeypatch):
         ),
     )
     guest_uid = fc.sr_auth_state().uid
-    r = fc.sr_get('authGithubLogin', {'simulation_type': sim_type})
+    fc.sr_get('authGithubLogin', {'simulation_type': sim_type})
     state = oc.values.state
-    s = fc.sr_auth_state(isLoggedIn=True, method='guest')
+    fc.sr_auth_state(isLoggedIn=True, method='guest')
     fc.sr_get('authGithubAuthorized', query={'state': state})
     fc.sr_auth_state(method='github', uid=guest_uid)
     fc.sr_post(


### PR DESCRIPTION
…ed RemoteApp

Use the authlib.integrations.requests_client.OAuth2Session client instead. The "requests"
is the python requests library which is used under the hood to make requests to the oauth
server.