### PR TITLE
Fix #4254 eval rpns prior to particle gen

### DIFF
--- a/sirepo/pkcli/madx.py
+++ b/sirepo/pkcli/madx.py
@@ -4,7 +4,6 @@
 :copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from py import code
 from pykern import pkio
 from pykern import pksubprocess
 from pykern.pkcollections import PKDict

--- a/sirepo/pkcli/madx.py
+++ b/sirepo/pkcli/madx.py
@@ -35,8 +35,9 @@ def run_background(cfg_dir):
 
 def create_particle_file(cfg_dir, data):
     twiss = PKDict()
-    for p in data.models:
-        pkdp('\n\n\n {}: {}', p, data.models[p])
+    pkdp('\n\n\n Entering create_particle_file')
+    # for p in data.models:
+    #     pkdp('\n\n\n {}: {}', p, data.models[p])
     # pkdp('\n\n\n type(data.models.bunch): {}, \n data.models.bunch: {}', type(data.models.bunch), data.models.bunch)
     pkdp('\n\n\n before: {}', data.models.command_beam)
     vars = []
@@ -46,14 +47,16 @@ def create_particle_file(cfg_dir, data):
             value=data.models.command_beam[key],
         ))
     # pkdp('\n\n\n vars: {}', vars)
+    #TODO (gurhar1133): do we want to fill in vals in other areas of data.models from rpnCache?
+    #TODO (gurhar1133): Also, how to we get rpnCache? is it exhaustive?
     for key in data.models.command_beam:
         value = data.models.command_beam.get(key)
         # pkdp('\n\n\n value: {}', value)
-        if type(value) == str:
-            e = code_var(vars).eval_var(value)
-            # pkdp('\n now {} = {}', key, e)
-            if e[0]:
-                data.models.command_beam[key] = e[0]
+        if value in data.models.rpnCache:
+            data.models.command_beam[key] = data.models.rpnCache[value]
+            # e = code_var(vars).eval_var(value)
+            # if e[0]:
+            #     data.models.command_beam[key] = e[0]
     pkdp('\n\n\n after : {}', data.models.command_beam)
     data.models.commands[0] = data.models.command_beam
     if data.models.bunch.matchTwissParameters == '1':

--- a/sirepo/pkcli/madx.py
+++ b/sirepo/pkcli/madx.py
@@ -53,13 +53,7 @@ def create_particle_file(cfg_dir, data):
 def _generate_ptc_particles_file(run_dir, data, twiss):
     bunch = data.models.bunch
     beam = LatticeUtil.find_first_command(data, 'beam')
-    c = code_var([
-            PKDict(name='ex', value=beam.ex),
-            PKDict(name='ey', value=beam.ey),
-            PKDict(name='sigt', value=beam.sigt),
-            PKDict(name='sige', value=beam.sige),
-        ]
-    )
+    c = code_var(data.models.rpnVariables)
     p = particle_beam.populate_uncoupled_beam(
         bunch.numberOfParticles,
         float(bunch.betx),

--- a/sirepo/pkcli/madx.py
+++ b/sirepo/pkcli/madx.py
@@ -46,7 +46,6 @@ def create_particle_file(cfg_dir, data):
         data.models.bunch.update(twiss)
         # restore the original report and generate new source with the updated beam values
         data.report = report
-        # pkdp('\n\n\n data.models.bunch in if: {}', data.models.bunch)
         if data.report == 'animation':
             template.write_parameters(data, pkio.py_path(cfg_dir), False)
     _generate_ptc_particles_file(cfg_dir, data, twiss)
@@ -66,7 +65,7 @@ def _generate_ptc_particles_file(run_dir, data, twiss):
         bunch.numberOfParticles,
         float(bunch.betx),
         float(bunch.alfx),
-        c.eval_var_with_assert(beam.ey),
+        float(c.eval_var_with_assert(beam.ex)),
         float(bunch.bety),
         float(bunch.alfy),
         c.eval_var_with_assert(beam.ey),


### PR DESCRIPTION
Codevar now evals the fields that UI was letting user enter as expression but was not being evaluated on the backend