### PR TITLE
Fix #4245: set multiElectronNumberOfIterations to 25 in slurm and 5 everywhere else

### DIFF
--- a/sirepo/srunit.py
+++ b/sirepo/srunit.py
@@ -515,7 +515,7 @@ class _TestClient(flask.testing.FlaskClient):
             compute_model,
             reports,
             # Things take longer with Slurm.
-            timeout=60,
+            timeout=90,
             **kwargs,
         )
 

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -2046,10 +2046,9 @@ def _set_parameters(v, data, plot_reports, run_dir):
     if (run_dir or is_for_rsopt) and _SIM_DATA.srw_uses_tabulated_zipfile(data):
         _set_magnetic_measurement_parameters(run_dir or '', v)
     if _SIM_DATA.srw_is_background_report(report) and 'beamlineAnimation' not in report:
-        if report in dm and dm[report].get('jobRunMode', '') == 'sbatch':
+        if sirepo.mpi.cfg.in_slurm:
             v.sbatchBackup = '1'
-        # Number of "iterations" per save is best set to num processes
-        v.multiElectronNumberOfIterations = sirepo.mpi.cfg.cores
+            v.multiElectronNumberOfIterations = 25
         if report == 'multiElectronAnimation':
             if dm.multiElectronAnimation.calcCoherence == '1':
                 v.multiElectronCharacteristic = 41


### PR DESCRIPTION
The number of iterations between saves is n(log(n)) where n is
multiElectronNumberOfIterations. This is because the primary process
waits for all worker processes to complete an iteration and counts
that as iteration.

The cause of #4245 was since the number of cores was set to 512 a save
only occurred after 262K macro electrons. That resulted in very slow
progress for the simulation which meant no report was requested from
the GUI and so the user interface looked "stuck".