### PR TITLE
Fix #4019 radia extrusion triangulation control

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -3219,16 +3219,14 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
                 return j;
             }
 
-            // some weird disconnect between the model and the slider when cancelling...???
             function setAlpha() {
                 if (! renderer) {
                     return;
                 }
-                const alpha = $scope.model.alpha;
-                for (var id in actorInfo) {
-                    var info = actorInfo[id];
-                    var s = info.scalars;
-                    if (! s) {
+                const alpha = appState.models[$scope.modelName].alpha;
+                for (const id in actorInfo) {
+                    let info = actorInfo[id];
+                    if (! info.scalars) {
                         info.actor.getProperty().setOpacity(alpha);
                         continue;
                     }
@@ -3726,20 +3724,20 @@ SIREPO.viewLogic('objectShapeView', function(appState, panelState, radiaService,
 
     let triangulationLevelDelegate = function() {
         const m = 'extrudedPoly';
-        var f = 'triangulationLevel';
+        const f = 'triangulationLevel';
         let d = panelState.getFieldDelegate(m, f);
-        d.range = function() {
+        d.range = () => {
             return {
                 min: appState.fieldProperties(m, f).min,
                 max: appState.fieldProperties(m, f).max,
                 step: 0.01
             };
         };
-        d.readout = function() {
+        d.readout = () => {
             return appState.modelInfo(m)[f][SIREPO.INFO_INDEX_LABEL];
         };
         d.update = function() {};
-        d.watchFields = [];
+        d.watchFields = [`${m}.${f}`];
         return d;
     };
 

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -3722,7 +3722,7 @@ SIREPO.viewLogic('objectShapeView', function(appState, panelState, radiaService,
         updateObjectEditor();
     };
 
-    let triangulationLevelDelegate = function() {
+    function buildTriangulationLevelDelegate() {
         const m = 'extrudedPoly';
         const f = 'triangulationLevel';
         let d = panelState.getFieldDelegate(m, f);
@@ -3736,12 +3736,9 @@ SIREPO.viewLogic('objectShapeView', function(appState, panelState, radiaService,
         d.readout = () => {
             return appState.modelInfo(m)[f][SIREPO.INFO_INDEX_LABEL];
         };
-        d.update = function() {};
-        d.watchFields = [`${m}.${f}`];
-        return d;
-    };
-
-    $scope.fieldDelegate = triangulationLevelDelegate();
+        d.update = () => {};
+        $scope.fieldDelegate = d;
+    }
 
     function modelField(f) {
         const m = appState.parseModelField(f);
@@ -3760,6 +3757,8 @@ SIREPO.viewLogic('objectShapeView', function(appState, panelState, radiaService,
             );
         });
     }
+
+    buildTriangulationLevelDelegate();
 });
 
 SIREPO.viewLogic('geomObjectView', function(appState, panelState, radiaService, $scope) {

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -3711,7 +3711,7 @@ SIREPO.viewLogic('objectShapeView', function(appState, panelState, radiaService,
     $scope.watchFields = [
         [
             'geomObject.type',
-            "extrudedPoly.extrusionAxisSegments",
+            "extrudedPoly.extrusionAxisSegments", "extrudedPoly.triangulationLevel",
             'stemmed.armHeight', 'stemmed.armPosition', 'stemmed.stemWidth', 'stemmed.stemPosition',
             'jay.hookHeight', 'jay.hookWidth',
         ], updateObjectEditor
@@ -3723,6 +3723,27 @@ SIREPO.viewLogic('objectShapeView', function(appState, panelState, radiaService,
         radiaService.updateModelAndSuperClasses(modelType, $scope.modelData);
         updateObjectEditor();
     };
+
+    let triangulationLevelDelegate = function() {
+        const m = 'extrudedPoly';
+        var f = 'triangulationLevel';
+        let d = panelState.getFieldDelegate(m, f);
+        d.range = function() {
+            return {
+                min: appState.fieldProperties(m, f).min,
+                max: appState.fieldProperties(m, f).max,
+                step: 0.01
+            };
+        };
+        d.readout = function() {
+            return appState.modelInfo(m)[f][SIREPO.INFO_INDEX_LABEL];
+        };
+        d.update = function() {};
+        d.watchFields = [];
+        return d;
+    };
+
+    $scope.fieldDelegate = triangulationLevelDelegate();
 
     function modelField(f) {
         const m = appState.parseModelField(f);

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -3499,8 +3499,8 @@ SIREPO.app.directive('rangeSlider', function(appState, panelState) {
         `,
         controller: function($scope, $element) {
 
-            var slider;
-            var delegate = null;
+            let slider;
+            let delegate = null;
 
             function update() {
                 updateReadout();
@@ -3508,7 +3508,7 @@ SIREPO.app.directive('rangeSlider', function(appState, panelState) {
             }
 
             function updateSlider() {
-                var r = delegate.range();
+                const r = delegate.range();
                 slider.attr('min', r.min);
                 slider.attr('step', r.step);
                 slider.attr('max', r.max);
@@ -3525,20 +3525,31 @@ SIREPO.app.directive('rangeSlider', function(appState, panelState) {
                     $scope.fieldDelegate = delegate;
                 }
                 appState.watchModelFields($scope, (delegate.watchFields || []), update);
-                slider = $('#' + $scope.modelName + '-' + $scope.field + '-range');
+                slider = $(`#${$scope.modelName}-${$scope.field}-range`);
                 update();
                 // on load, the slider will coerce model values to fit the basic input model of range 0-100,
                 // step 1.  This resets to the saved value
-                var val = delegate.storedVal;
-                if ((val || val === 0) && $scope.model[$scope.field] != val) {
+                let val = delegate.storedVal;
+                if ((val || val === 0) && $scope.model[$scope.field] !== val) {
                     $scope.model[$scope.field] = val;
-                    var form = $element.find('input').eq(0).controller('form');
+                    const form = $element.find('input').eq(0).controller('form');
                     if (! form) {
                         return;
                     }
                     // changing the value dirties the form; make it pristine or we'll get a spurious save button
                     form.$setPristine();
                 }
+
+                $scope.$on('cancelChanges', (e, d) => {
+                    if (d !== $scope.modelName) {
+                        return;
+                    }
+                    delegate.update();
+                });
+            });
+
+            $scope.$on(`${$scope.modelName}.changed`, () => {
+                delegate.storedVal = $scope.model[$scope.field];
             });
 
             $scope.$on('sliderParent.ready', function (e, m) {

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -3529,7 +3529,7 @@ SIREPO.app.directive('rangeSlider', function(appState, panelState) {
                 update();
                 // on load, the slider will coerce model values to fit the basic input model of range 0-100,
                 // step 1.  This resets to the saved value
-                let val = delegate.storedVal;
+                const val = delegate.storedVal;
                 if ((val || val === 0) && $scope.model[$scope.field] !== val) {
                     $scope.model[$scope.field] = val;
                     const form = $element.find('input').eq(0).controller('form');

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -674,6 +674,7 @@
         },
         "extrudedPoly": {
             "_super": ["_", "model", "geomObject"],
+            "area": ["_", "Float", 0,0],
             "extrusionAxis": ["Extrusion Direction", "BeamAxis", "z"],
             "extrusionAxisSegments": ["Segments in Extrusion Direction", "Integer", 1, "", 1],
             "heightAxis": ["_", "BeamAxis", "y"],
@@ -1270,6 +1271,7 @@
                     "color",
                     "stemmed.extrusionAxis",
                     "extrudedPoly.extrusionAxisSegments",
+                    "extrudedPoly.triangulationLevel",
                     "stemmed.armHeight",
                     "stemmed.armPosition",
                     "stemmed.stemWidth",

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -679,7 +679,7 @@
             "extrusionAxisSegments": ["Segments in Extrusion Direction", "Integer", 1, "", 1],
             "heightAxis": ["_", "BeamAxis", "y"],
             "points": ["Points", "Points", []],
-            "triangulationLevel": ["Triangulation Level", "Range", 0.5, "", 0.0, 1.0],
+            "triangulationLevel": ["Triangulation Detail", "Range", 0.5, "Governs the max size of triangles used to subdivide the shape, from coarse to fine. Smaller triangles gain accuracy at the expense of longer solve times.", 0.0, 1.0],
             "widthAxis": ["_", "BeamAxis", "x"]
         },
         "freehand": {},

--- a/sirepo/package_data/template/radia/geometryReport.py.jinja
+++ b/sirepo/package_data/template/radia/geometryReport.py.jinja
@@ -48,6 +48,7 @@ def _add_object(o, radia_objs, id_map):
         )
     if _MODEL_EXTRUDED_POLY in sc:
         g_id = radia_util.extrude(
+            area=o.area,
             center=ctr,
             size=sz,
             extrusion_axis=o.extrusionAxis,
@@ -56,6 +57,7 @@ def _add_object(o, radia_objs, id_map):
             magnetization=m,
             rem_mag=o.remanentMag,
             segments=segs,
+            t_level=o.triangulationLevel,
             h_m_curve=o.h_m_curve
     )
     if t == _MODEL_RACETRACK:

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -1360,10 +1360,10 @@ def _update_geom_objects(objects):
 
 
 def _update_geom_obj(o, **kwargs):
+    # uses the "shoelace formula" to calculate the area of a polygon
     def _poly_area(pts):
-        x = [c[0] for c in pts]
-        y = [c[1] for c in pts]
-        return 0.5 * numpy.abs(numpy.dot(x, numpy.roll(y, 1)) - numpy.dot(y, numpy.roll(x, 1)))
+        t = numpy.array(pts).T
+        return 0.5 * numpy.abs(numpy.dot(t[0], numpy.roll(t[1], 1)) - numpy.dot(t[1], numpy.roll(t[0], 1)))
 
     d = PKDict(
         center=[0.0, 0.0, 0.0],
@@ -1390,9 +1390,8 @@ def _update_geom_obj(o, **kwargs):
             o,
             _get_stemmed_info(o)
         )
-    if o.points:
+    if 'points' in o:
         o.area = _poly_area(o.points)
-
     return o
 
 

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -1360,6 +1360,11 @@ def _update_geom_objects(objects):
 
 
 def _update_geom_obj(o, **kwargs):
+    def _poly_area(pts):
+        x = [c[0] for c in pts]
+        y = [c[1] for c in pts]
+        return 0.5 * numpy.abs(numpy.dot(x, numpy.roll(y, 1)) - numpy.dot(y, numpy.roll(x, 1)))
+
     d = PKDict(
         center=[0.0, 0.0, 0.0],
         magnetization=[0.0, 0.0, 0.0],
@@ -1385,6 +1390,9 @@ def _update_geom_obj(o, **kwargs):
             o,
             _get_stemmed_info(o)
         )
+    if o.points:
+        o.area = _poly_area(o.points)
+
     return o
 
 

--- a/sirepo/template/radia_util.py
+++ b/sirepo/template/radia_util.py
@@ -227,14 +227,18 @@ def dump_bin(g_id):
 def extrude(**kwargs):
     d = PKDict(kwargs)
     b = AXIS_VECTORS[d.extrusion_axis]
+    p = f'TriAreaMax->{0.5 * d.area * (1.01 - d.t_level)}' if d.t_level > 0 else None
     g_id = radia.ObjMltExtTri(
         numpy.sum(b * d.center),
         numpy.sum(b * d.size),
         d.points,
         numpy.full((len(d.points), 2), [1, 1]).tolist(),
         d.extrusion_axis,
-        d.magnetization
+        d.magnetization,
+        p
     )
+    #str_param = 'ki->Numb,TriAngMin->' + str(triangle_min_size) + ',TriAreaMax->' + str(
+    #    triangle_max_size)
     _apply_segments(g_id, d.segments)
     radia.MatApl(g_id, _radia_material(d.material, d.rem_mag, d.h_m_curve))
     return g_id

--- a/sirepo/template/radia_util.py
+++ b/sirepo/template/radia_util.py
@@ -227,7 +227,6 @@ def dump_bin(g_id):
 def extrude(**kwargs):
     d = PKDict(kwargs)
     b = AXIS_VECTORS[d.extrusion_axis]
-    p = f'TriAreaMax->{0.5 * d.area * (1.01 - d.t_level)}' if d.t_level > 0 else None
     g_id = radia.ObjMltExtTri(
         numpy.sum(b * d.center),
         numpy.sum(b * d.size),
@@ -235,10 +234,8 @@ def extrude(**kwargs):
         numpy.full((len(d.points), 2), [1, 1]).tolist(),
         d.extrusion_axis,
         d.magnetization,
-        p
+        f'TriAreaMax->{0.125 * d.area * (1.04 - d.t_level)}' if d.t_level > 0 else ''
     )
-    #str_param = 'ki->Numb,TriAngMin->' + str(triangle_min_size) + ',TriAreaMax->' + str(
-    #    triangle_max_size)
     _apply_segments(g_id, d.segments)
     radia.MatApl(g_id, _radia_material(d.material, d.rem_mag, d.h_m_curve))
     return g_id


### PR DESCRIPTION
This adds a slider to control how finely Radia triangulates extruded polygons. The ```ObjMltExtTri``` function takes a number of parameters (via a string) to that end, of which we currently use only ```TriAreaMax```, which sets a limit on the area of the triangles. As a simplification, the slider runs from 0-1 (coarse to fine), and we set the max area to a multiple of the polygon's area according to ```0.125 * <area> * (1.04 - <value>)``` (a purely phenomenological formula). We can change the details according to user feedback.

Also included are improvements to the rangeSlider and style cleanup