### PR TITLE
Fix #4306 - disable orientation marker

### DIFF
--- a/sirepo/package_data/static/js/silas.js
+++ b/sirepo/package_data/static/js/silas.js
@@ -513,6 +513,12 @@ SIREPO.app.directive('crystal3d', function(appState, plotting, silasService, uti
             };
 
             $scope.resize = refresh;
+
+            $scope.$on('$destroy', function() {
+                if (orientationMarker) {
+                    orientationMarker.setEnabled(false);
+                }
+            });
         },
         link: function link(scope, element) {
             plotting.vtkPlot(scope, element);

--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -2195,6 +2195,9 @@ SIREPO.app.directive('vtkDisplay', function(appState, geometry, panelState, plot
             $scope.$on('$destroy', function() {
                 $element.off();
                 $($window).off('resize', resize);
+                if ($scope.hasMarker()) {
+                    marker.setEnabled(false);
+                }
                 fsRenderer.getInteractor().unbindEvents();
                 fsRenderer.delete();
                 plotToPNG.removeCanvas($scope.reportId);

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -3215,6 +3215,13 @@ SIREPO.app.directive('beamline3d', function(appState, plotting, srwService, vtkT
                 orientationMarker.updateMarkerOrientation();
                 fsRenderer.getRenderWindow().render();
             };
+
+            $scope.$on('$destroy', function() {
+                if (orientationMarker) {
+                    orientationMarker.setEnabled(false);
+                }
+            });
+
         },
         link: function link(scope, element) {
             plotting.linkPlot(scope, element);

--- a/sirepo/package_data/static/js/warpvnd.js
+++ b/sirepo/package_data/static/js/warpvnd.js
@@ -4868,6 +4868,11 @@ SIREPO.app.directive('particle3d', function(appState, errorService, frameCache, 
                 return selector ? e.select(selector) : e;
             }
 
+            $scope.$on('$destroy', function() {
+                if (orientationMarker) {
+                    orientationMarker.setEnabled(false);
+                }
+            });
 
         },
 

--- a/sirepo/package_data/static/js/zgoubi.js
+++ b/sirepo/package_data/static/js/zgoubi.js
@@ -1248,6 +1248,13 @@ SIREPO.app.directive('particle3d', function(appState, plotting, utilities) {
             };
 
             $scope.resize = refresh;
+
+            $scope.$on('$destroy', function() {
+                if (orientationMarker) {
+                    orientationMarker.setEnabled(false);
+                }
+            });
+
         },
         link: function link(scope, element) {
             plotting.vtkPlot(scope, element);


### PR DESCRIPTION
The problem seems to stem from resize handling of the "orientation marker" after the renderer goes away. Disabling the marker when we destroy the scope gets around this.