### PR TITLE
Fix #4188: collapse and search elems

### DIFF
--- a/sirepo/package_data/static/css/lattice.css
+++ b/sirepo/package_data/static/css/lattice.css
@@ -115,3 +115,10 @@ div.sr-lattice-icon-disabled span {
   position: relative;
   overflow: hidden;
 }
+
+.sr-sticky-heading {
+  position: sticky;
+  top: 0;
+  background-color: white;
+  padding: 1em;
+}

--- a/sirepo/package_data/static/css/lattice.css
+++ b/sirepo/package_data/static/css/lattice.css
@@ -120,5 +120,10 @@ div.sr-lattice-icon-disabled span {
   position: sticky;
   top: 0;
   background-color: white;
-  padding: 1em;
+  padding: 0.5em;
+  z-index: 1000;
+}
+
+.sr-searchbar-elem {
+  margin: 0.2em;
 }

--- a/sirepo/package_data/static/css/lattice.css
+++ b/sirepo/package_data/static/css/lattice.css
@@ -123,3 +123,9 @@ div.sr-lattice-icon-disabled span {
   padding: 0.5em;
   z-index: 1000;
 }
+
+.sr-search-target {
+  background-color: yellow;
+  color: black;
+  border: solid 1px lightgray;
+}

--- a/sirepo/package_data/static/css/lattice.css
+++ b/sirepo/package_data/static/css/lattice.css
@@ -123,7 +123,3 @@ div.sr-lattice-icon-disabled span {
   padding: 0.5em;
   z-index: 1000;
 }
-
-.sr-searchbar-elem {
-  margin: 0.2em;
-}

--- a/sirepo/package_data/static/js/sirepo-lattice.js
+++ b/sirepo/package_data/static/js/sirepo-lattice.js
@@ -2388,7 +2388,7 @@ SIREPO.app.directive('latticeElementPanels', function(latticeService) {
                   <div class="panel panel-info" style="margin-bottom: 10px">
                     <div class="panel-heading"><span class="sr-panel-heading">Beamline Elements</span></div>
                     <div class="panel-body">
-                      <div style="z-index:1001;" class="pull-right sr-sticky-heading">
+                      <div style="z-index:1001; margin-top: 4px" class="pull-right sr-sticky-heading">
                         <button data-ng-if=":: latticeService.wantRpnVariables" class="btn btn-info btn-xs" data-ng-click="latticeService.showRpnVariables()"><span class="glyphicon glyphicon-list-alt"></span> Variables</button>
                         <button class="btn btn-info btn-xs" data-ng-click="latticeService.newElement()" accesskey="e"><span class="glyphicon glyphicon-plus"></span> New <u>E</u>lement</button>
                       </div>
@@ -2411,10 +2411,8 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, p
         scope: {},
         template: `
             <div class="sr-sticky-heading">
-                <button data-ng-click="findElement(searchVar)" class="btn btn-info btn-xs sr-searchbar-elem">Search</button>
-                <input class="sr-searchbar-elem" data-ng-change="findElement(searchVar)" data-ng-model="searchVar" placeholder="{{searchVar}}">
-                <br/>
-                <button data-ng-click="expandCollapseElems()" class="btn btn-info btn-xs sr-searchbar-elem">{{ collapseButtonText }}</button>
+                <button data-ng-click="expandCollapseElems()" class="btn btn-info btn-xs">{{ collapseButtonText }}</button>
+                <input style="display: inline; width: 15em" class="form-control input-sm" data-ng-change="findElement(searchVar)" data-ng-model="searchVar" placeholder="Search Elements" />
             </div>
             <table style="width: 100%; table-layout: fixed; margin-bottom: 0" class="table table-hover">
               <colgroup>

--- a/sirepo/package_data/static/js/sirepo-lattice.js
+++ b/sirepo/package_data/static/js/sirepo-lattice.js
@@ -2435,7 +2435,7 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, p
                 </tr>
                 <tr data-ng-show="! category.isCollapsed" data-ng-repeat="element in category.elements track by element._id">
                   <td style="padding-left: 1em">
-                    <div data-ng-attr-class="badge sr-badge-icon {{ element.isMarked ? 'sr-search-target' : ''}}"
+                    <div data-ng-attr-class="badge sr-badge-icon {{ element.isMarked ? 'sr-search-target' : ''}}">
                       <span data-ng-drag="true" data-ng-drag-data="element">
                         <span> {{ element.name }} </span>
                       </span>

--- a/sirepo/package_data/static/js/sirepo-lattice.js
+++ b/sirepo/package_data/static/js/sirepo-lattice.js
@@ -2408,8 +2408,11 @@ SIREPO.app.directive('latticeElementPanels', function(latticeService) {
 SIREPO.app.directive('latticeElementTable', function(appState, latticeService, $rootScope) {
     return {
         restrict: 'A',
-        scope: {},
+        scope: {
+            data: '=',
+        },
         template: `
+            <button data-ng-click="expandCollapseElems()" class="btn btn-info btn-xs">{{ collapseButtonText }}</button>
             <table style="width: 100%; table-layout: fixed; margin-bottom: 0" class="table table-hover">
               <colgroup>
                 <col style="width: 20ex">
@@ -2439,10 +2442,12 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, $
             </table>
         `,
         controller: function($scope) {
+            srdbg($scope);
             $scope.latticeService = latticeService;
             $scope.tree = [];
             var collapsedElements = {};
             var descriptionCache = {};
+            $scope.collapseButtonText = 'Expand All Elements';
 
             function computeBend(element) {
                 var angle = element.angle;
@@ -2502,7 +2507,7 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, $
                         category = {
                             name: element.type,
                             elements: [],
-                            isCollapsed: collapsedElements[element.type],
+                            isCollapsed: true,
                         };
                         $scope.tree.push(category);
                     }
@@ -2522,6 +2527,20 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, $
                 return latticeService.editElement(type, el);
             };
 
+            $scope.expandCollapseElems = () => {
+                if ($scope.collapseButtonText == 'Expand All Elements') {
+                    $scope.collapseButtonText = 'Collapse All Elements';
+                    $scope.tree.forEach((e) => {
+                        e.isCollapsed = false;
+                    })
+                } else {
+                    $scope.collapseButtonText = 'Expand All Elements';
+                    $scope.tree.forEach((e) => {
+                        e.isCollapsed = true;
+                    })
+                }
+            };
+
             $scope.copyElement = el => latticeService.copyElement(el);
 
             $scope.elementLength = function(element) {
@@ -2531,6 +2550,7 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, $
             $scope.toggleCategory = function(category) {
                 category.isCollapsed = ! category.isCollapsed;
                 collapsedElements[category.name] = category.isCollapsed;
+                srdbg('collapsedElements: ', collapsedElements);
             };
 
             $scope.$on('modelChanged', function(e, name) {

--- a/sirepo/package_data/static/js/sirepo-lattice.js
+++ b/sirepo/package_data/static/js/sirepo-lattice.js
@@ -2609,7 +2609,7 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, p
                 category.isCollapsed = ! category.isCollapsed;
                 collapsedElements[category.name] = category.isCollapsed;
                 appState.models.treeMap = getCollapsedMap();
-                appState.saveQuietly('treeMap');
+                appState.saveChanges('treeMap');
             };
 
             $scope.toggleCollapseElems = () => {
@@ -2618,7 +2618,7 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, p
                     e.isCollapsed = ! $scope.areAllExpanded;
                 });
                 appState.models.treeMap = getCollapsedMap();
-                appState.saveQuietly('treeMap');
+                appState.saveChanges('treeMap');
             };
 
             $scope.$on('modelChanged', function(e, name) {

--- a/sirepo/package_data/static/js/sirepo-lattice.js
+++ b/sirepo/package_data/static/js/sirepo-lattice.js
@@ -2413,6 +2413,8 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, $
         },
         template: `
             <button data-ng-click="expandCollapseElems()" class="btn btn-info btn-xs">{{ collapseButtonText }}</button>
+            <button data-ng-click="findElement(searchVar)" class="btn btn-info btn-xs">Search Elements</button>
+            <input data-ng-change="findElement(searchVar)" data-ng-model="searchVar" placeholder="{{searchVar}}">
             <table style="width: 100%; table-layout: fixed; margin-bottom: 0" class="table table-hover">
               <colgroup>
                 <col style="width: 20ex">
@@ -2433,7 +2435,16 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, $
                   <td style="cursor: pointer" colspan="4" data-ng-click="toggleCategory(category)" ><span class="glyphicon" data-ng-class="{\'glyphicon-chevron-up\': ! category.isCollapsed, \'glyphicon-chevron-down\': category.isCollapsed}"></span> <b>{{ category.name }}</b></td>
                 </tr>
                 <tr data-ng-show="! category.isCollapsed" data-ng-repeat="element in category.elements track by element._id">
-                  <td style="padding-left: 1em"><div class="badge sr-badge-icon"><span data-ng-drag="true" data-ng-drag-data="element">{{ element.name }}</span></div></td>
+                  <td style="padding-left: 1em">
+                    <div class="badge sr-badge-icon">
+                      <span data-ng-drag="true" data-ng-drag-data="element">
+                        <mark data-ng-if="element.isMarked">
+                            {{ element.name }}
+                        </mark>
+                        <span data-ng-if="!element.isMarked"> {{ element.name }} </span>
+                      </span>
+                    </div>
+                  </td>
                   <td style="overflow: hidden"><span style="color: #777; white-space: nowrap">{{ element.description }}</span></td>
                   <td style="text-align: right">{{ elementLength(element) }}</td>
                   <td style="text-align: right">{{ element.bend || \'&nbsp;\' }}<span data-ng-if="element.isBend">&deg;</span><div class="sr-button-bar-parent"><div class="sr-button-bar"><button class="btn btn-info btn-xs sr-hover-button" data-ng-click="copyElement(element)">Copy</button> <button data-ng-show="latticeService.activeBeamlineId" class="btn btn-info btn-xs sr-hover-button" data-ng-click="latticeService.addToBeamline(element)">Add to Beamline</button> <button data-ng-click="editElement(category.name, element)" class="btn btn-info btn-xs sr-hover-button">Edit</button> <button data-ng-click="deleteElement(element)" class="btn btn-danger btn-xs"><span class="glyphicon glyphicon-remove"></span></button></div><div></td>
@@ -2514,6 +2525,7 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, $
                     var clonedElement = appState.clone(element);
                     computeBend(clonedElement);
                     clonedElement.description = elementDescription(clonedElement);
+                    clonedElement.isMarked = false;
                     category.elements.push(clonedElement);
                 });
             }
@@ -2546,6 +2558,23 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, $
             $scope.elementLength = function(element) {
                 return latticeService.numFormat(element.l, 'm');
             };
+
+            $scope.findElement = (el) => {
+                srdbg("Looking for: ", el);
+                srdbg("tree: ", $scope.tree);
+                $scope.tree.forEach((t, i) => {
+                    t.elements.forEach((e, j) => {
+                        if (e.name == el){
+                            srdbg('found', el, 'at index: ', i);
+                            $scope.tree[i].isCollapsed = false;
+                            $scope.tree[i].elements[j].isMarked = true;
+                        } else {
+                            $scope.tree[i].elements[j].isMarked = false;
+                            // $scope.tree[i].isCollapsed = true;
+                        }
+                    })
+                })
+            }
 
             $scope.toggleCategory = function(category) {
                 category.isCollapsed = ! category.isCollapsed;

--- a/sirepo/package_data/static/js/sirepo-lattice.js
+++ b/sirepo/package_data/static/js/sirepo-lattice.js
@@ -2410,8 +2410,6 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, p
         restrict: 'A',
         scope: {},
         template: `
-
-
             <div class="sr-sticky-heading">
                 <button data-ng-click="findElement(searchVar)" class="btn btn-info btn-xs sr-searchbar-elem">Search</button>
                 <input class="sr-searchbar-elem" data-ng-change="findElement(searchVar)" data-ng-model="searchVar" placeholder="{{searchVar}}">

--- a/sirepo/package_data/static/js/sirepo-lattice.js
+++ b/sirepo/package_data/static/js/sirepo-lattice.js
@@ -2416,7 +2416,6 @@ SIREPO.app.directive('latticeElementTable', function(appState, latticeService, p
                 <br/>
                 <button data-ng-click="expandCollapseElems()" class="btn btn-info btn-xs sr-searchbar-elem">{{ collapseButtonText }}</button>
             </div>
-
             <table style="width: 100%; table-layout: fixed; margin-bottom: 0" class="table table-hover">
               <colgroup>
                 <col style="width: 20ex">


### PR DESCRIPTION
* Beamline elements are now searchable on the lattice tab.
* There is also a collapse/expand all elements option
* Categories that have been expanded and collapsed now get saved so that refreshing/revisiting the sim will not forget which element categories were expanded
* The searchbar is sticky at the top of the beamline elements panel so you don't lose it when you scroll
* Found items are scrolled into view and highlighted