### PR TITLE
Fix #4313: shadow user manual in ? icon

### DIFF
--- a/sirepo/package_data/static/json/shadow-schema.json
+++ b/sirepo/package_data/static/json/shadow-schema.json
@@ -1,4 +1,7 @@
 {
+    "constants": {
+        "helpUserManualURL": "https://forge.epn-campus.eu/attachments/download/996/Shadow3Primer.pdf"
+    },
     "enum": {
         "AbsoluteOrigin": [
             ["0", "Absolute"],


### PR DESCRIPTION
The shaddow app now has a link to the user manual in the '?' icon dropdown:

![Screen Shot 2022-04-14 at 2 28 40 PM](https://user-images.githubusercontent.com/49498231/163470335-ede4620b-6f7e-42bb-8461-21dd5fdb6e0b.png)

This look right to you @bruhwiler 

