### PR TITLE
Fix #4356: get srw running in parallel on Cori

### DIFF
--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -748,9 +748,8 @@ class _SbatchRun(_SbatchCmd):
 cat > bash.stdin <<'EOF'
 {self.job_cmd_source_bashrc()}
 {self.job_cmd_env()}
-if [[ ! $LD_LIBRARY_PATH =~ /usr/lib64/mpich/lib ]]; then
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib64/mpich/lib
-fi
+# Inject libmpi ourselves. See: git.radiasoft.org/sirepo/issues/4356
+export LD_LIBRARY_PATH=/opt/cray/pe/mpt/7.7.19/gni/mpich-gnu-abi/8.2/lib:$LD_LIBRARY_PATH
 exec python {template_common.PARAMETERS_PYTHON_FILE}
 EOF
 exec srun {m} {s} /bin/bash bash.stdin

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -749,7 +749,10 @@ cat > bash.stdin <<'EOF'
 {self.job_cmd_source_bashrc()}
 {self.job_cmd_env()}
 # Inject libmpi ourselves. See: git.radiasoft.org/sirepo/issues/4356
-export LD_LIBRARY_PATH=/opt/cray/pe/mpt/7.7.19/gni/mpich-gnu-abi/8.2/lib:$LD_LIBRARY_PATH
+if [[ ! $LD_LIBRARY_PATH =~ /opt/cray/pe/mpt/7.7.19/gni/mpich-gnu-abi/8.2/lib ]]; then
+    export LD_LIBRARY_PATH=/opt/cray/pe/mpt/7.7.19/gni/mpich-gnu-abi/8.2/lib:$LD_LIBRARY_PATH
+fi
+
 exec python {template_common.PARAMETERS_PYTHON_FILE}
 EOF
 exec srun {m} {s} /bin/bash bash.stdin


### PR DESCRIPTION
SRW uses MPI when running in parallel. On Cori we run inside of
shifter. In order for the correct MPI libs to be loaded Cori swaps MPI
libs in the running shifter image
https://docs.nersc.gov/development/shifter/how-to-use/#using-mpi-in-shifter.

This is not working properly. So, we need to manually add the
libraries ourself.

@robnagler this is enough to get things working. Obviously, less than optimal to have to manually add these libs by hand. Also, not sure if other libraries for unused parts of mpi are missing...