### PR TITLE
Fix #4370: remove srw video links

### DIFF
--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -126,7 +126,7 @@ def _init():
         srw=dict(
             app_url=('/en/xray-beamlines.html', str, 'URL for SRW link'),
             mask_in_toolbar=b('Show the mask element in toolbar'),
-            show_video_links=(True, bool, 'Display instruction video links'),
+            show_video_links=(False, bool, 'Display instruction video links'),
             show_open_shadow=(pkconfig.channel_in_internal_test(), bool, 'Show "Open as a New Shadow Simulation" menu item'),
             show_rsopt_ml=(pkconfig.channel_in_internal_test(), bool, 'Show "Export ML Script" menu item'),
         ),

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -126,6 +126,7 @@ def _init():
         srw=dict(
             app_url=('/en/xray-beamlines.html', str, 'URL for SRW link'),
             mask_in_toolbar=b('Show the mask element in toolbar'),
+            show_video_links=(True, bool, 'Display instruction video links'),
             show_open_shadow=(pkconfig.channel_in_internal_test(), bool, 'Show "Open as a New Shadow Simulation" menu item'),
             show_rsopt_ml=(pkconfig.channel_in_internal_test(), bool, 'Show "Export ML Script" menu item'),
         ),

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -1384,10 +1384,11 @@ SIREPO.app.directive('videoButton', function(appState, $window) {
             viewName: '@videoButton',
         },
         template: `
-            <div><button class="close sr-help-icon" data-ng-click="openVideo()" title="{{ ::tooltip }}"><span class="glyphicon glyphicon-film"></span></button></div>
+            <div data-ng-if="showLink"><button class="close sr-help-icon" data-ng-click="openVideo()" title="{{ ::tooltip }}"><span class="glyphicon glyphicon-film"></span></button></div>
         `,
         controller: function($scope) {
             var viewInfo = appState.viewInfo($scope.viewName);
+            $scope.showLink = SIREPO.APP_SCHEMA.feature_config.show_video_links;
             $scope.tooltip = viewInfo.title + ' Help Video';
             $scope.openVideo = function() {
                 $window.open(
@@ -2408,7 +2409,7 @@ SIREPO.app.directive('appHeaderRight', function(appDataService, authState, appSt
                             class="glyphicon glyphicon-exclamation-sign"></span> Report a Bug</a></li>
                     <li data-help-link="helpUserManualURL" data-title="User Manual" data-icon="list-alt"></li>
                     <li data-help-link="helpUserForumURL" data-title="User Forum" data-icon="globe"></li>
-                    <li data-help-link="helpVideoURL" data-title="Instructional Video" data-icon="film"></li>
+                    <li data-ng-if="showLink" data-help-link="helpVideoURL" data-title="Instructional Video" data-icon="film"></li>
                   </ul>
                 </li>
               </ul>
@@ -2431,7 +2432,7 @@ SIREPO.app.directive('appHeaderRight', function(appDataService, authState, appSt
         controller: function($scope, stringsService) {
             $scope.authState = authState;
             $scope.slackUri = $scope.authState.slackUri;
-
+            $scope.showLink = SIREPO.APP_SCHEMA.feature_config.show_video_links;
             $scope.modeIsDefault = function () {
                 return appDataService.isApplicationMode('default');
             };

--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -14,7 +14,6 @@
         }
     },
     "constants": {
-        "helpVideoURL": "https://vimeo.com/410318423/632634aa5d",
         "rsOptDefaultOffsetInfo": {
             "position": ["Position [m]", "FloatStringArray", "0.0, 0.0, 0.0", "", "Horizontal, Vertical, Longitudinal"],
             "radius": ["Radius [m]", "FloatStringArray", "0.0", "", "Radius"],

--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -14,6 +14,7 @@
         }
     },
     "constants": {
+        "helpVideoURL": "https://vimeo.com/410318423/632634aa5d",
         "rsOptDefaultOffsetInfo": {
             "position": ["Position [m]", "FloatStringArray", "0.0, 0.0, 0.0", "", "Horizontal, Vertical, Longitudinal"],
             "radius": ["Radius [m]", "FloatStringArray", "0.0", "", "Radius"],


### PR DESCRIPTION
Now you can turn displaying the SRW instructional video links on and off as a config option (default is on)