### PR TITLE
Fix #3899: wm_nmm added

### DIFF
--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -518,7 +518,7 @@
             "horizontalPosition": ["Horizontal Center Position [mm]", "Float"],
             "horizontalRange": ["Range of Horizontal Position [mm]", "Float"],
             "method": ["Single-Electron Spectrum Computation Method", "IntensityMethod"],
-            "mpiGroupCount": ["Number of MPI processes groups", "Integer", 2, "", 2],
+            "mpiGroupCount": ["Number of independent groups of MPI processes", "Integer", 2, "", 2],
             "initialPosition": ["Initial Longitudinal Position for SR Calculation (effective if smaller than final position)", "Float", 0.0],
             "finalPosition": ["Final Longitudinal Position for SR Calculation (effective if larger than initial position)", "Float", 0.0],
             "photonEnergy": ["Photon Energy [eV]", "Float"],

--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -518,6 +518,7 @@
             "horizontalPosition": ["Horizontal Center Position [mm]", "Float"],
             "horizontalRange": ["Range of Horizontal Position [mm]", "Float"],
             "method": ["Single-Electron Spectrum Computation Method", "IntensityMethod"],
+            "mpiGroupCount": ["Number of MPI processes groups", "Integer", 2, "", 2],
             "initialPosition": ["Initial Longitudinal Position for SR Calculation (effective if smaller than final position)", "Float", 0.0],
             "finalPosition": ["Final Longitudinal Position for SR Calculation (effective if larger than initial position)", "Float", 0.0],
             "photonEnergy": ["Photon Energy [eV]", "Float"],
@@ -1222,6 +1223,7 @@
                     "characteristic",
                     "samplingMethod",
                     "sampleFactor",
+                    "mpiGroupCount",
                     [
                         ["Horizontal", [
                             "horizontalPosition",

--- a/sirepo/package_data/template/srw/parameters.py.jinja
+++ b/sirepo/package_data/template/srw/parameters.py.jinja
@@ -241,7 +241,7 @@ varParam = [
     ['wm_fni', 's', '{{multiElectronAnimationFilename}}', 'file name for saving propagated multi-e intensity distribution vs horizontal and vertical position'],
     ['wm_ff', 's', '{{multiElectronFileFormat or 'ascii'}}', 'format of file name for saving propagated multi-e intensity distribution vs horizontal and vertical position (ascii and hdf5 supported)'],
 
-    ['wm_nmm', 'i', {{mpiMasterCount or 1}}, 'number of MPI masters to use'],
+    ['wm_nmm', 'i', {{mpiGroupCount or 1}}, 'number of MPI masters to use'],
     ['wm_ncm', 'i', {{coherentModesAnimation_numberOfCoherentModes}}, 'number of Coherent Modes to calculate'],
     ['wm_acm', 's', 'SP', 'coherent mode decomposition algorithm to be used (supported algorithms are: "SP" for SciPy, "SPS" for SciPy Sparse, "PM" for Primme, based on names of software packages)'],
     ['wm_nop', '', '', 'switch forcing to do calculations ignoring any optics defined (by set_optics function)', 'store_true'],

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -2064,7 +2064,7 @@ def _set_parameters(v, data, plot_reports, run_dir):
         elif report == 'coherentModesAnimation':
             v.multiElectronAnimation = 1
             v.multiElectronCharacteristic = 61
-            v.mpiMasterCount = max(2, int(sirepo.mpi.cfg.cores / 4))
+            v.mpiGroupCount = dm.coherentModesAnimation.mpiGroupCount
             v.multiElectronFileFormat = 'h5'
             v.multiElectronAnimationFilename = _OUTPUT_FOR_MODEL[report].basename
 


### PR DESCRIPTION
wm_nmm added to coherent modes editor with label "Number of MPI processes groups", with default and min of 2

LMK if anything else needed for this @moellep 