### PR TITLE
Fix #4133: is_save_images now False

### DIFF
--- a/sirepo/package_data/template/srw/beamline_optics.py.jinja
+++ b/sirepo/package_data/template/srw/beamline_optics.py.jinja
@@ -233,7 +233,7 @@ v.op_{{ item.name }}_{{ nameMap.get(name, name) }}
                 shift_x={{ field(item, 'shiftX') }},
                 shift_y={{ field(item, 'shiftY') }},
                 invert=bool(int({{ field(item, 'invert') }})),
-                is_save_images=True,
+                is_save_images=False,
                 prefix='{{ item.name }}_sample',
                 output_image_format={{ field(item, 'outputImageFormat') }},
             ))
@@ -337,5 +337,5 @@ v.op_{{ item.name }}_{{ nameMap.get(name, name) }}
 {% if items|length > 0 %}
     if want_final_propagation:
         pp.append(v.op_fin_pp)
-{% endif %}                
+{% endif %}
     return srwlib.SRWLOptC(el, pp)


### PR DESCRIPTION
is_save_images is now False by default. examples/"sample from image" coherent results and partially coherent results both work with this change. 
