### PR TITLE
Fix #4504: use flask client injected by pytest

### DIFF
--- a/tests/role_moderation_test.py
+++ b/tests/role_moderation_test.py
@@ -64,13 +64,11 @@ def test_moderation(auth_fc):
     pkunit.pkok(r.get('models'), 'no models r={}', r)
 
 
-def test_no_guest():
+def test_no_guest(fc):
     from pykern import pkunit
     from pykern.pkdebug import pkdp
     from pykern.pkcollections import PKDict
-    from sirepo import srunit
 
-    fc = srunit.flask_client()
     fc.sr_login_as_guest(sim_type='srw')
     r = fc.sr_post(
         'saveModerationReason',

--- a/tests/uri_router_test.py
+++ b/tests/uri_router_test.py
@@ -9,16 +9,13 @@ import pytest
 pytest.importorskip('srwl_bl')
 
 
-def test_error_for_bots():
+def test_error_for_bots(fc):
     from pykern import pkcompat
     from pykern.pkcollections import PKDict
     from pykern.pkunit import pkeq, pkexcept, pkok, pkre
     from sirepo import http_request
-    from sirepo import srunit
 
-    fc = srunit.flask_client()
     fc.sr_login_as_guest()
-
     uri = '/get-application-data'
     d = PKDict(simulationType='srw', method='NO SUCH METHOD')
 
@@ -40,12 +37,10 @@ def test_error_for_bots():
         pkeq(500, r.status_code)
 
 
-def test_not_found():
+def test_not_found(fc):
     from pykern.pkdebug import pkdp
     from pykern.pkunit import pkeq
-    from sirepo import srunit
 
-    fc = srunit.flask_client()
     for uri in ('/some random uri', '/srw/wrong-param', '/export-archive'):
         resp = fc.get(uri)
         pkeq(404, resp.status_code)
@@ -58,9 +53,7 @@ def test_uri_for_api():
         from pykern.pkdebug import pkdp
         from pykern.pkunit import pkeq, pkexcept, pkre, pkeq
         from sirepo import uri_router
-        import re
 
-        fc = srunit.flask_client()
         uri = uri_router.uri_for_api('homePage', params={'path_info': None})
         pkre('http://[^/]+/en$', uri)
         uri = uri_router.uri_for_api(


### PR DESCRIPTION
Calling srunit.flask_client directly circumvents setting up the work dir
for the subprocesses to run in (ex job_supervisor) which causes them
to run in the default run dir (srdb.root).