### PR TITLE
Fix #4511 - io ops to use fastcgi

### DIFF
--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -287,7 +287,7 @@ class _Dispatcher(PKDict):
 
     async def _cmd(self, msg, **kwargs):
         try:
-            if msg.opName == job.OP_ANALYSIS and msg.jobCmd != 'fastcgi':
+            if msg.opName in (job.OP_ANALYSIS, job.OP_IO,) and msg.jobCmd != 'fastcgi':
                 return await self._fastcgi_op(msg)
             p = self._get_cmd_type(msg)(
                 msg=msg,


### PR DESCRIPTION
When downloadDataFile was an analysis op, it took advantage of fastcgi, but once it became io it was a normal command, running one queued job at a time. It seems reasonable to add io ops to fastcgi.  Once I did that cloudmc was peppy.

I looked for any other analysis/io handling and the only other thing I could find is that analysis jobs are always sequential. I think it's ok for io t be parallel and it seems to work with sbatch, but it's something to consider.