### PR TITLE
Fix #4503 - moved overlay sizing to style

### DIFF
--- a/sirepo/package_data/static/html/vtk-display.html
+++ b/sirepo/package_data/static/html/vtk-display.html
@@ -1,25 +1,26 @@
 <div class="container-fluid">
     <div class="sr-screenshot">
-    <div class="viewer-title" style="font-weight: normal; text-align: center"></div>
-    <div>
-        <div class="vtk-canvas-holder" data-ng-class="{'vtk-canvas-holder-border': showBorder}"></div>
-    </div>
-    <div class="vtk-info-overlay vtk-info-overlay-move" data-ng-attr-width="{{ canvasGeometry().size.width }}px" data-ng-attr-height="{{ canvasGeometry().size.height }}px" data-ng-attr-style="top:{{ canvasGeometry().pos.top }}px; left:{{ canvasGeometry().pos.left }}px;">
-        <div data-vtk-axes="" data-ng-if="enableAxes" data-width="canvasGeometry().size.width" data-height="canvasGeometry().size.height" data-bound-obj="axisObj" data-axis-cfg="axisCfg"></div>
-        <div class="vtk-load-indicator" data-ng-attr-width="{{ canvasGeometry().size.width }}px" data-ng-attr-height="{{ canvasGeometry().size.height }}px">
-            <img class="sr-page-load-image" src="/static/img/sirepo_animated.gif" />
+        <div class="viewer-title" style="font-weight: normal; text-align: center"></div>
+        <div>
+            <div class="vtk-canvas-holder" data-ng-class="{'vtk-canvas-holder-border': showBorder}"></div>
         </div>
-    </div>
-    <div class="sr-plot-legend plot-visibility">
-        <div class="row">
-            <div class="col-sm-12">
-                <div style="padding-top: 5px; padding-bottom: 8px"><span>{{ modeText[vtkScene.interactionMode] }}</span><span data-ng-show="enableSelection" class="pull-right">{{ selection.info }}</span></div>
-                <div data-ng-show="enableSelection" data-toggle="tooltip" title="Select" class="btn btn-default" data-ng-class="{'btn-primary': vtkScene.interactionMode == VTKUtils.interactionMode().INTERACTION_MODE_SELECT}" style="margin: 2px;" data-ng-click="setInteractionMode(VTKUtils.interactionMode().INTERACTION_MODE_SELECT)">&#x2B09;</div>
-                <div data-ng-show="enableSelection" data-toggle="tooltip" title="Manipulate" class="btn btn-default" data-ng-class="{'btn-primary': vtkScene.interactionMode == VTKUtils.interactionMode().INTERACTION_MODE_MOVE}" style="margin: 2px;" data-ng-click="setInteractionMode(VTKUtils.interactionMode().INTERACTION_MODE_MOVE)"><span class="glyphicon glyphicon-hand-up"></span></div>
-                <div data-ng-repeat="dim in GeometryUtils.BASIS()" data-toggle="tooltip" title="View along {{ dim }} axis" class="btn btn-default" data-ng-class="{'btn-primary': vtkScene.viewSide == '{{dim}}'}" style="margin: 2px;" data-ng-click="showSide(dim)">{{dim}}{{ vtkScene.directionIcon() }}</div>
-                <div class="checkbox checkbox-inline"><label data-ng-if="vtkScene.hasMarker()"><input type="checkbox" id="sr-toggle-marker" data-ng-model="vtkScene.isMarkerEnabled" data-ng-change="vtkScene.refreshMarker()"> Toggle Marker</label></div>
-                <div data-toggle="tooltip" title="Toggle between perspective and orthographic view" class="btn btn-default pull-right"  style="margin: 2px;" data-ng-click="toggleOrtho()"><span data-ng-show="! isOrtho"><ng-include src="'/static/svg/perspective.svg'"></ng-include></span><span data-ng-show="isOrtho"><ng-include src="'/static/svg/ortho.svg'"></span></div>
-                <div data-ng-if="enableSelection && selection.model" data-advanced-editor-pane="" data-view-name="selection.model.modelKey" data-model-data="selection.model" data-want-buttons="true"></div>
+        <div class="vtk-info-overlay vtk-info-overlay-move" data-ng-attr-style="width: {{ canvasGeometry().size.width }}px; height:{{ canvasGeometry().size.height }}px; top:{{ canvasGeometry().pos.top }}px; left:{{ canvasGeometry().pos.left }}px;">
+            <div data-vtk-axes="" data-ng-if="enableAxes" data-width="canvasGeometry().size.width" data-height="canvasGeometry().size.height" data-bound-obj="axisObj" data-axis-cfg="axisCfg"></div>
+            <div class="vtk-load-indicator">
+                <img class="sr-page-load-image" src="/static/img/sirepo_animated.gif" />
+            </div>
+        </div>
+        <div class="sr-plot-legend plot-visibility">
+            <div class="row">
+                <div class="col-sm-12">
+                    <div style="padding-top: 5px; padding-bottom: 8px"><span>{{ modeText[vtkScene.interactionMode] }}</span><span data-ng-show="enableSelection" class="pull-right">{{ selection.info }}</span></div>
+                    <div data-ng-show="enableSelection" data-toggle="tooltip" title="Select" class="btn btn-default" data-ng-class="{'btn-primary': vtkScene.interactionMode == VTKUtils.interactionMode().INTERACTION_MODE_SELECT}" style="margin: 2px;" data-ng-click="setInteractionMode(VTKUtils.interactionMode().INTERACTION_MODE_SELECT)">&#x2B09;</div>
+                    <div data-ng-show="enableSelection" data-toggle="tooltip" title="Manipulate" class="btn btn-default" data-ng-class="{'btn-primary': vtkScene.interactionMode == VTKUtils.interactionMode().INTERACTION_MODE_MOVE}" style="margin: 2px;" data-ng-click="setInteractionMode(VTKUtils.interactionMode().INTERACTION_MODE_MOVE)"><span class="glyphicon glyphicon-hand-up"></span></div>
+                    <div data-ng-repeat="dim in GeometryUtils.BASIS()" data-toggle="tooltip" title="View along {{ dim }} axis" class="btn btn-default" data-ng-class="{'btn-primary': vtkScene.viewSide == '{{dim}}'}" style="margin: 2px;" data-ng-click="showSide(dim)">{{dim}}{{ vtkScene.directionIcon() }}</div>
+                    <div class="checkbox checkbox-inline"><label data-ng-if="vtkScene.hasMarker()"><input type="checkbox" id="sr-toggle-marker" data-ng-model="vtkScene.isMarkerEnabled" data-ng-change="vtkScene.refreshMarker()"> Toggle Marker</label></div>
+                    <div data-toggle="tooltip" title="Toggle between perspective and orthographic view" class="btn btn-default pull-right"  style="margin: 2px;" data-ng-click="toggleOrtho()"><span data-ng-show="! isOrtho"><ng-include src="'/static/svg/perspective.svg'"></ng-include></span><span data-ng-show="isOrtho"><ng-include src="'/static/svg/ortho.svg'"></span></div>
+                    <div data-ng-if="enableSelection && selection.model" data-advanced-editor-pane="" data-view-name="selection.model.modelKey" data-model-data="selection.model" data-want-buttons="true"></div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
`data-attr-width` etc. doesn't actually do anything - the overlay was expanding to fit the axes div, which had the size passed in to the directive. When that div was excluded the overlay collapsed. The sizing belongs in the style attribute.