### PR TITLE
Fix #4532: radia 3d axes update

### DIFF
--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -2645,7 +2645,7 @@ SIREPO.app.directive('vtkDisplay', function(appState, geometry, panelState, plot
                     }
                 });
                 Object.keys(eventHandlers).forEach(function (k) {
-                    rw[k] = function (evt) {
+                    body[k] = function (evt) {
                         eventHandlers[k](evt);
                         if (hdlrs[k]) {
                             hdlrs[k](evt);

--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -2646,12 +2646,17 @@ SIREPO.app.directive('vtkDisplay', function(appState, geometry, panelState, plot
                     }
                 });
                 Object.keys(eventHandlers).forEach(function (k) {
-                    view[k] = function (evt) {
+                    const f = function (evt) {
                         eventHandlers[k](evt);
                         if (hdlrs[k]) {
                             hdlrs[k](evt);
                         }
                     };
+                    if (k == 'onpointermove') {
+                        view[k] = f;
+                        return;
+                    }
+                    rw[k] = f;
                 });
                 // remove global VTK key listeners
                 for (const n of ['KeyPress', 'KeyDown', 'KeyUp']) {

--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -2616,6 +2616,7 @@ SIREPO.app.directive('vtkDisplay', function(appState, geometry, panelState, plot
             $scope.init = function() {
                 const rw = angular.element($($element).find('.vtk-canvas-holder'))[0];
                 const body = angular.element($($document).find('body'))[0];
+                const view = angular.element($($document).find('.sr-view-content'))[0];
                 hdlrs = $scope.eventHandlers || {};
 
                 // vtk adds keypress event listeners to the BODY of the entire document, not the render
@@ -2645,7 +2646,7 @@ SIREPO.app.directive('vtkDisplay', function(appState, geometry, panelState, plot
                     }
                 });
                 Object.keys(eventHandlers).forEach(function (k) {
-                    body[k] = function (evt) {
+                    view[k] = function (evt) {
                         eventHandlers[k](evt);
                         if (hdlrs[k]) {
                             hdlrs[k](evt);


### PR DESCRIPTION
Binding the listeners to the sim view seems to have fixed to issue.

@mkeilman while working on this I noticed a potential bug (on my branch and master). If you move the 3d element around a lot and then try to quickly click on the simulations link you may run into the js error:
```
 Cannot read properties of undefined (reading '0')
```
or 
```
 Cannot read properties of undefined (reading '1')
```
I think this has to do with the coords calculations for `lCoord` still being in progress 
```javascript
viewPortPoint(worldPoint) {
        // this is required to do conversions for different displays/devices
        const pixels = window.devicePixelRatio;
        this.worldCoord.setCoordinateSystemToWorld();
        this.worldCoord.setValue(worldPoint.coords());
        const lCoord = this.worldCoord.getComputedLocalDisplayValue()
            .map(x => x / pixels);
        return new SIREPO.GEOMETRY.Point(lCoord[0], lCoord[1]);
    }
```

Should I open an issue for this?
