### PR TITLE
fix radiasoft/download#285: rename workflow and installer

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,4 +1,4 @@
-name: ci-pull-request
+name: python-ci
 on:
   pull_request:
     branches:
@@ -10,8 +10,8 @@ on:
       - master
 
 jobs:
-  ci-pull-request:
+  python-ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: curl -LsS https://radia.run | bash -s ci-pull-request
+      - run: curl -LsS https://radia.run | bash -s python-ci


### PR DESCRIPTION
Depends on radiasoft/download#287. Will fail until that is merged