### PR TITLE
Fix #4617 proxy react (npm server) through server.py

### DIFF
--- a/sirepo/api.py
+++ b/sirepo/api.py
@@ -58,6 +58,13 @@ class Base:
     def reply_html(self, path):
         return http_reply.render_html(path)
 
+    def reply_as_proxy(self, response):
+        r = http_reply.gen_response(response.content)
+        # TODO(robnagler) requests seems to return content-encoding gzip, but
+        # it doesn't seem to be coming from npm
+        r.headers["Content-Type"] = response.headers["Content-Type"]
+        return http_reply.headers_for_no_cache(r)
+
     def reply_static_jinja(self, base, ext, j2_ctx, cache_ok=False):
         return http_reply.render_static_jinja(base, ext, j2_ctx, cache_ok=cache_ok)
 

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -535,8 +535,7 @@ class API(sirepo.api.Base):
         """
         if not path_info:
             sirepo.util.raise_not_found("empty path info")
-        pkdp(path_info)
-        self._proxy_react('static/' + path_info)
+        self._proxy_react("static/" + path_info)
         p = sirepo.resource.static(sirepo.util.safe_path(path_info))
         if _google_tag_manager and re.match(r"^en/[^/]+html$", path_info):
             return http_reply.headers_for_cache(
@@ -633,13 +632,13 @@ class API(sirepo.api.Base):
         if not cfg.react_server:
             return
         if path is not None and path not in (
-            'manifest.json',
-            'myapp-schema.json',
-            'static/js/bundle.js',
-            'static/js/bundle.js.map',
+            "manifest.json",
+            "myapp-schema.json",
+            "static/js/bundle.js",
+            "static/js/bundle.js.map",
         ):
             return
-        r = requests.get(cfg.react_server + (path or ''))
+        r = requests.get(cfg.react_server + (path or ""))
         # We want to throw an exception here, because it shouldn't happen
         r.raise_for_status()
         raise sirepo.util.Response(self.reply_as_proxy(r))
@@ -702,11 +701,16 @@ def _cfg_react_server(value):
     if value is None:
         return None
     if not pkconfig.channel_in("dev"):
-        pkconfig.raise_error('invalid channel={}; must be dev', pkconfig.cfg.channel)
+        pkconfig.raise_error("invalid channel={}; must be dev", pkconfig.cfg.channel)
     u = urllib.parse.urlparse(value)
-    if u.scheme and u.netloc and u.path == '/' and len(u.params + u.query + u.fragment) == 0:
+    if (
+        u.scheme
+        and u.netloc
+        and u.path == "/"
+        and len(u.params + u.query + u.fragment) == 0
+    ):
         return value
-    pkconfig.raise_error('invalid url={}, must be http://netloc/', value)
+    pkconfig.raise_error("invalid url={}, must be http://netloc/", value)
 
 
 def _handle_error(error):


### PR DESCRIPTION
@garsuga please test this branch by running `npm start` in your virtual machine, and then starting sirepo this way:

```sh
SIREPO_SERVER_REACT_SERVER=http://localhost:3000/ sirepo service http
```

I did not test updates to reactapp in real time. It's not clear how that works, because it only opens one port. However, I was able to get the basic app working just fine.
