### PR TITLE
Fix #4633 test timeouts

### DIFF
--- a/tests/job_concurrency1_test.py
+++ b/tests/job_concurrency1_test.py
@@ -36,7 +36,7 @@ def test_myapp_cancel(fc):
             ),
         )
         pkdlog(r2)
-        for _ in range(20):
+        for _ in range(40):
             pkunit.pkok(r2.state != "error", "unexpected error state: {}")
             if r2.state == "running":
                 break
@@ -60,7 +60,7 @@ def test_myapp_cancel(fc):
             simulationType=d.simulationType,
         ),
     )
-    for _ in range(50):
+    for _ in range(100):
         pkdlog(r1)
         pkunit.pkok(r1.state != "error", "unexpected error state: {}")
         if r1.state == "running":
@@ -72,7 +72,7 @@ def test_myapp_cancel(fc):
 
     t2 = threading.Thread(target=_t2)
     t2.start()
-    time.sleep(0.1)
+    time.sleep(0.5)
     pkdlog("runCancel")
     c = fc.sr_post("runCancel", r1.nextRequest)
     pkunit.pkeq("canceled", c.state)
@@ -88,7 +88,7 @@ def test_myapp_cancel(fc):
             simulationType=d.simulationType,
         ),
     )
-    for _ in range(10):
+    for _ in range(20):
         pkunit.pkok(r1.state != "error", "unexpected error state: {}")
         if r1.state == "running":
             break
@@ -136,7 +136,7 @@ def test_elegant_concurrent_sim_frame(fc):
                 simulationType=d.simulationType,
             ),
         )
-        for _ in range(10):
+        for _ in range(20):
             pkunit.pkok(r1.state != "error", "unexpected error state: {}")
             if r1.state == "completed":
                 break

--- a/tests/job_timeout_test.py
+++ b/tests/job_timeout_test.py
@@ -15,8 +15,8 @@ _MAX_SECS_PARALLEL_PREMIUM = "4"
 def setup_module(module):
     os.environ.update(
         SIREPO_JOB_SUPERVISOR_MAX_SECS_PARALLEL_PREMIUM=_MAX_SECS_PARALLEL_PREMIUM,
-        SIREPO_JOB_SUPERVISOR_MAX_SECS_ANALYSIS="3",
-        SIREPO_JOB_SUPERVISOR_MAX_SECS_IO="3",
+        SIREPO_JOB_SUPERVISOR_MAX_SECS_ANALYSIS="6",
+        SIREPO_JOB_SUPERVISOR_MAX_SECS_IO="6",
     )
 
 
@@ -71,6 +71,8 @@ def test_myapp_analysis(fc):
     from pykern.pkdebug import pkdp
 
     d = fc.sr_sim_data()
+    # If a machine is slow, this might timeout on getting the heightWeightReport
+    # in analysis when we want the timeout below.
     r = fc.sr_run_sim(d, "heightWeightReport", expect_completed=True)
     r = fc.sr_get(
         "downloadDataFile",

--- a/tests/job_timeout_test.py
+++ b/tests/job_timeout_test.py
@@ -40,7 +40,7 @@ def test_srw(fc):
         if r.state == "completed":
             return r
         cancel = r.get("nextRequest")
-        for _ in range(10):
+        for _ in range(20):
             if r.state == "canceled":
                 pkunit.pkeq(
                     int(_MAX_SECS_PARALLEL_PREMIUM),

--- a/tests/partial_animation_test.py
+++ b/tests/partial_animation_test.py
@@ -32,7 +32,7 @@ def test_synergia(fc):
             ),
         )
         cancel = r.nextRequest
-        for _ in range(100):
+        for _ in range(200):
             if r.state in ("completed", "error"):
                 pkdlog(r.state)
                 cancel = None

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -129,7 +129,7 @@ def test_synergia_data_file(fc):
         ),
     )
     pkunit.pkeq("pending", run.state, "not pending, run={}", run)
-    for _ in range(20):
+    for _ in range(40):
         if run.state == "completed":
             break
         run = fc.sr_post("runStatus", run.nextRequest)


### PR DESCRIPTION
Various test timeouts needed to be adjusted to run on the slower build machine. 