### PR TITLE
Fix #4652: dont include v.ws or v.ws_pl for multiElectronAnimation

### DIFF
--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -1855,6 +1855,7 @@ def _generate_srw_main(data, plot_reports, beamline_info):
     report = data.report
     is_for_rsopt = _is_for_rsopt(report)
     source_type = data.models.simulation.sourceType
+    pkdp('\n\n\n _SIM_DATA.SRW_RUN_ALL_MODEL: {}', _SIM_DATA.SRW_RUN_ALL_MODEL)
     run_all = report == _SIM_DATA.SRW_RUN_ALL_MODEL or is_for_rsopt
     vp_var = "vp" if is_for_rsopt else "varParam"
     content = [

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -1906,7 +1906,7 @@ def _generate_srw_main(data, plot_reports, beamline_info):
         )
         if report != "multiElectronAnimation":
             content.append("v.ws = True")
-        if plot_reports:
+        if plot_reports and report != "multiElectronAnimation":
             content.append("v.ws_pl = 'xy'")
     else:
         content.append("op = None")

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -1855,7 +1855,6 @@ def _generate_srw_main(data, plot_reports, beamline_info):
     report = data.report
     is_for_rsopt = _is_for_rsopt(report)
     source_type = data.models.simulation.sourceType
-    pkdp('\n\n\n _SIM_DATA.SRW_RUN_ALL_MODEL: {}', _SIM_DATA.SRW_RUN_ALL_MODEL)
     run_all = report == _SIM_DATA.SRW_RUN_ALL_MODEL or is_for_rsopt
     vp_var = "vp" if is_for_rsopt else "varParam"
     content = [
@@ -1905,7 +1904,8 @@ def _generate_srw_main(data, plot_reports, beamline_info):
                 and int(beamline_info.last_id) == int(data.models.beamline[-1].id)
             )
         )
-        content.append("v.ws = True")
+        if report != "multiElectronAnimation":
+            content.append("v.ws = True")
         if plot_reports:
             content.append("v.ws_pl = 'xy'")
     else:


### PR DESCRIPTION
Now if report == multiElectronAnimation there will not be 
`v.ws = True`
and there wont be 
`v.ws_pl = 'xy'` in paramters.py