### PR TITLE
fix radiasoft/raydata#18: Analysis status panel not showing all running analysis jobs

### DIFF
--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -598,6 +598,9 @@ SIREPO.app.directive('scanSelector', function() {
                     </tr>
                   </tbody>
                 </table>
+                <div data-ng-if="awaitingScans">
+                  <p>Loading scans...</p>
+                </div>
               </div>
             </div>
             <div data-column-picker="" data-title="Add Column" data-id="sr-columnPicker-editor" data-available-columns="availableColumns" data-save-column-changes="saveColumnChanges"></div>
@@ -610,6 +613,7 @@ SIREPO.app.directive('scanSelector', function() {
 
             $scope.appState = appState;
             $scope.availableColumns = [];
+            $scope.awaitingScans = false;
             // POSIT: same columns as sirepo.template.raydata._DEFAULT_COLUMNS
             $scope.defaultColumns = ['start', 'stop', 'suid'];
             $scope.orderByColumn = 'start';
@@ -667,9 +671,11 @@ SIREPO.app.directive('scanSelector', function() {
                 if (!appState.models.scans.searchStartTime || !appState.models.scans.searchStopTime) {
                     return;
                 }
+                $scope.awaitingScans = true;
                 requestSender.sendStatelessCompute(
                     appState,
                     (json) => {
+                        $scope.awaitingScans = false;
                         $scope.scans = [];
                         json.data.scans.forEach((s) => {
                             s.selected = s.uid in appState.models.selectedScans.uids;
@@ -694,6 +700,7 @@ SIREPO.app.directive('scanSelector', function() {
                         onError: (data) => {
                             errorService.alertText(data.error);
                             panelState.setLoading($scope.modelName, false);
+                            $scope.awaitingScans = false;
                         },
                         panelState: panelState,
                     }

--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -748,7 +748,7 @@ SIREPO.app.directive('scanSelector', function() {
                     }
                     $scope.selectAllColumns = false;
                 });
-            }
+            };
 
             $scope.$on('scans.changed', $scope.sendScanRequest);
             $scope.$watchCollection('appState.models.metadataColumns.selected', (newValue, previousValue) => {

--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -33,7 +33,6 @@ SIREPO.app.factory('raydataService', function(appState, panelState, requestSende
     };
 
     self.getScanField = function(scan, field) {
-        srdbg(`getScanField scan=${scan} field=${field}`)
         if (['start', 'stop'].includes(field)) {
             return timeService.unixTimeToDateString(scan[field]);
         }
@@ -41,7 +40,6 @@ SIREPO.app.factory('raydataService', function(appState, panelState, requestSende
     };
 
     self.getScanInfoTableHeader = function(firstColHeading, cols) {
-        srdbg(`getScanInfoTableHeader cols=${cols}`)
         return cols.length > 0 ? [firstColHeading].concat(cols) : [];
     };
 
@@ -135,8 +133,13 @@ SIREPO.app.factory('raydataService', function(appState, panelState, requestSende
     };
 
     self.updateScanInfoTableColsInCache = function(cols) {
-        simulationDataCache.scanInfoTableCols = cols;
-        return cols;
+        if (cols.length) {
+            simulationDataCache.scanInfoTableCols = cols;
+            return cols;
+        }
+        else {
+            return simulationDataCache.scanInfoTableCols;
+        }
     };
 
     self.updateScansInCache = function(scans) {
@@ -299,7 +302,6 @@ SIREPO.app.directive('analysisStatusPanel', function() {
             function handleGetScansInfo(scans, colz) {
                 cols = colz;
                 $scope.scans = scans;
-                srdbg('got scans=', scans)
                 const r = runningPending(scans);
                 if (r === 0) {
                     handleResult();
@@ -317,7 +319,6 @@ SIREPO.app.directive('analysisStatusPanel', function() {
             }
 
             function runStatus(showLoadingSpinner) {
-                srdbg('runStatus')
                 const c = {
                     onError: () => {
                         handleResult();
@@ -361,7 +362,6 @@ SIREPO.app.directive('analysisStatusPanel', function() {
             };
 
             $scope.getHeader = function() {
-                srdbg(`in getHeader cols=${cols}`)
                 return raydataService.getScanInfoTableHeader(
                     'status',
                     cols
@@ -405,7 +405,6 @@ SIREPO.app.directive('analysisStatusPanel', function() {
             $scope.startButtonLabel = 'Start New Analysis';
 
             appState.whenModelsLoaded($scope, () => {
-                srdbg('whenModelsLoaded')
                 $scope.$on('scansSelected.changed', () => {
                     raydataService.getScansInfo(handleGetScansInfo);
                 });
@@ -743,7 +742,6 @@ SIREPO.app.directive('scanSelector', function() {
 
             $scope.unselectAllScans = () => {
                 Object.keys(appState.models.selectedScans.uids).forEach((u) => {
-                    srdbg(`deleting selected scan ${u}`)
                     delete appState.models.selectedScans.uids[u];
                     for (let i = 0; i < $scope.scans.length; i++) {
                         $scope.toggleScanSelection($scope.scans[i], false);

--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -297,6 +297,7 @@ SIREPO.app.directive('analysisStatusPanel', function() {
             function handleGetScansInfo(scans, colz) {
                 cols = colz;
                 $scope.scans = scans;
+                srdbg('got scans=', scans)
                 const r = runningPending(scans);
                 if (r === 0) {
                     handleResult();
@@ -314,6 +315,7 @@ SIREPO.app.directive('analysisStatusPanel', function() {
             }
 
             function runStatus(showLoadingSpinner) {
+                srdbg('runStatus')
                 const c = {
                     onError: () => {
                         handleResult();
@@ -400,6 +402,7 @@ SIREPO.app.directive('analysisStatusPanel', function() {
             $scope.startButtonLabel = 'Start New Analysis';
 
             appState.whenModelsLoaded($scope, () => {
+                srdbg('whenModelsLoaded')
                 $scope.$on('scansSelected.changed', () => {
                     raydataService.getScansInfo(handleGetScansInfo);
                 });

--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -136,8 +136,7 @@ SIREPO.app.factory('raydataService', function(appState, panelState, requestSende
         if (cols.length) {
             simulationDataCache.scanInfoTableCols = cols;
             return cols;
-        }
-        else {
+        } else {
             return simulationDataCache.scanInfoTableCols;
         }
     };
@@ -743,11 +742,11 @@ SIREPO.app.directive('scanSelector', function() {
             $scope.unselectAllScans = () => {
                 Object.keys(appState.models.selectedScans.uids).forEach((u) => {
                     delete appState.models.selectedScans.uids[u];
-                    for (let i = 0; i < $scope.scans.length; i++) {
-                        $scope.toggleScanSelection($scope.scans[i], false);
-                    }
-                    $scope.selectAllColumns = false;
                 });
+                for (let i = 0; i < $scope.scans.length; i++) {
+                    $scope.toggleScanSelection($scope.scans[i], false);
+                }
+                $scope.selectAllColumns = false;
             };
 
             $scope.$on('scans.changed', $scope.sendScanRequest);

--- a/sirepo/pkcli/raydata.py
+++ b/sirepo/pkcli/raydata.py
@@ -9,7 +9,7 @@ from pykern.pkdebug import pkdp, pkdlog
 from sirepo.template import template_common
 
 
-def create_scans(num_scans, delay=True):
+def create_scans(num_scans, catalog_name, delay=True):
     from sirepo.template import raydata
     import bluesky
     import bluesky.plans
@@ -19,7 +19,7 @@ def create_scans(num_scans, delay=True):
 
     num_scans = int(num_scans)
     assert num_scans > 0, f"num_scans={num_scans} must be > 0"
-    d = databroker.Broker.named(raydata.catalog().name)
+    d = databroker.Broker.named(raydata.catalog(catalog_name).name)
     RE = bluesky.RunEngine({})
     RE.subscribe(d.insert)
     for i in range(num_scans):

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -185,7 +185,7 @@ def _scan_info(scan_uuid, scans_data, metadata=None):
     for c in _DEFAULT_COLUMNS:
         d[c] = locals()[f"_get_{c}"](m)
 
-    for c in scans_data.selectedColumns:
+    for c in scans_data.get("selectedColumns") or []:
         d[c] = m["start"].get(c)
     return d
 


### PR DESCRIPTION
Analysis panel shows everything that is selected, pending or running. Scans do not get unselected automatically even if they are outside of search window. Added Unselect all scans button to make it easy to unselect scans that are not visible in search results.

~~Based off https://github.com/radiasoft/sirepo/pull/4651. Maybe want to finish and merge that to master first.~~