### PR TITLE
4680 material library

### DIFF
--- a/sirepo/package_data/static/html/vtk-display.html
+++ b/sirepo/package_data/static/html/vtk-display.html
@@ -3,11 +3,11 @@
         <div class="viewer-title" style="font-weight: normal; text-align: center"></div>
         <div class="sr-screenshot">
             <div class="vtk-canvas-holder" data-ng-class="{'vtk-canvas-holder-border': showBorder}"></div>
-        </div>
-        <div class="vtk-info-overlay vtk-info-overlay-move" data-ng-attr-style="width: {{ canvasGeometry().size.width }}px; height:{{ canvasGeometry().size.height }}px; top:{{ canvasGeometry().pos.top }}px; left:{{ canvasGeometry().pos.left }}px;">
-            <div data-vtk-axes="" data-ng-if="enableAxes" data-width="canvasGeometry().size.width" data-height="canvasGeometry().size.height" data-bound-obj="axisObj" data-axis-cfg="axisCfg"></div>
-            <div class="vtk-load-indicator">
-                <img class="sr-page-load-image" src="/static/img/sirepo_animated.gif" />
+            <div class="vtk-info-overlay vtk-info-overlay-move" data-ng-attr-style="width: {{ canvasGeometry().size.width }}px; height:{{ canvasGeometry().size.height }}px; top:{{ canvasGeometry().pos.top }}px; left:{{ canvasGeometry().pos.left }}px;">
+                <div data-vtk-axes="" data-ng-if="enableAxes" data-width="canvasGeometry().size.width" data-height="canvasGeometry().size.height" data-bound-obj="axisObj" data-axis-cfg="axisCfg"></div>
+                <div class="vtk-load-indicator">
+                    <img class="sr-page-load-image" src="/static/img/sirepo_animated.gif" />
+                </div>
             </div>
         </div>
         <div class="sr-plot-legend plot-visibility">

--- a/sirepo/package_data/static/json/cloudmc-schema.json
+++ b/sirepo/package_data/static/json/cloudmc-schema.json
@@ -36,6 +36,10 @@
             ["add_nuclide", "Nuclide"],
             ["add_s_alpha_beta", "S alpha beta"]
         ],
+        "MaterialLibrary": [
+            ["ENDFB-7.1-NNDC", "ENDFB-7.1-NNDC"],
+            ["TENDL-2019", "TENDL-2019"]
+        ],
         "Particle": [
             ["neutron", "Neutron"],
             ["photon", "Photon"]
@@ -125,9 +129,9 @@
     "model": {
         "box": {
             "_super": [ "_", "model", "spatial"],
-            "lower_left": ["Lower Left [cm]", "Point3D", [0, 0, 0], "Lower-left coordinates of cuboid"],
-            "upper_right": ["Upper Right [cm]", "Point3D", [0, 0, 0], "Upper-right coordinates of cuboid"],
-            "only_fissionable": ["Only Fissionable", "Boolean", "0", "Whether spatial sites should only be accepted if they occur in fissionable materials"]
+            "lower_left": ["Lower left [cm]", "Point3D", [0, 0, 0], "Lower-left coordinates of cuboid"],
+            "upper_right": ["Upper right [cm]", "Point3D", [0, 0, 0], "Upper-right coordinates of cuboid"],
+            "only_fissionable": ["Only fissionable", "Boolean", "0", "Whether spatial sites should only be accepted if they occur in fissionable materials"]
         },
         "dagmcAnimation": {},
         "discrete": {
@@ -136,18 +140,18 @@
         },
         "cartesianIndependent": {
             "_super": [ "_", "model", "spatial"],
-            "x": ["X Distribution", "Univariate", {"_type": "None"}],
-            "y": ["Y Distribution", "Univariate", {"_type": "None"}],
-            "z": ["Z Distribution", "Univariate", {"_type": "None"}]
+            "x": ["X distribution", "Univariate", {"_type": "None"}],
+            "y": ["Y distribution", "Univariate", {"_type": "None"}],
+            "z": ["Z distribution", "Univariate", {"_type": "None"}]
         },
         "coefficient": {
-            "coefficient": ["Expansion Coefficients", "FloatArray", "", "Probability density given by a Legendre polynomial expansion $\\sum\\limits_{\\ell=0}^N \\frac{2\\ell + 1}{2} a_\\ell P_\\ell(\\mu)$. $\\newline$ Expansion coefficients $a_\\ell$. Note that the $(2\\ell + 1)/2$ factor should not be included"]
+            "coefficient": ["Expansion coefficients", "FloatArray", "", "Probability density given by a Legendre polynomial expansion $\\sum\\limits_{\\ell=0}^N \\frac{2\\ell + 1}{2} a_\\ell P_\\ell(\\mu)$. $\\newline$ Expansion coefficients $a_\\ell$. Note that the $(2\\ell + 1)/2$ factor should not be included"]
         },
         "cylindricalIndependent": {
             "_super": [ "_", "model", "spatial"],
-            "r": ["R Distribution", "Univariate", {"_type": "None"}],
-            "phi": ["Phi Distribution", "Univariate", {"_type": "None"}, "Distribution of phi-coordinates (azimuthal angle) in a reference frame specified by the origin parameter"],
-            "z": ["Z Distribution", "Univariate", {"_type": "None"}],
+            "r": ["R distribution", "Univariate", {"_type": "None"}],
+            "phi": ["Phi distribution", "Univariate", {"_type": "None"}, "Distribution of phi-coordinates (azimuthal angle) in a reference frame specified by the origin parameter"],
+            "z": ["Z distribution", "Univariate", {"_type": "None"}],
             "origin": ["Origin", "Point3D [cm]", [0, 0, 0], "Coordinates (x0, y0, z0) of the center of the cylindrical reference frame for the source."]
         },
         "legendre": {
@@ -159,20 +163,20 @@
             "name": ["Name", "ComponentName", ""],
             "percent_with_type": ["Percent", "PercentWithType", "", "Atom weight (ao) or Weight percent (wo)"],
             "percent": ["Percent", "Float", 1.0],
-            "percent_type": ["Percent Type", "PercentType", "ao"],
+            "percent_type": ["Percent type", "PercentType", "ao"],
             "enrichment_with_type": ["Enrichment", "EnrichmentWithType", "", "Atom weight (ao) or Weight percent (wo)"],
             "enrichment": ["Enrichment", "OptionalFloat"],
-            "enrichment_type": ["Enrichment Type", "EnrichmentType", "none"],
-            "enrichment_target": ["Enrichment Target", "OptionalString"],
+            "enrichment_type": ["Enrichment type", "EnrichmentType", "none"],
+            "enrichment_target": ["Enrichment target", "OptionalString"],
             "fraction": ["Fraction", "Float", 1.0, "The fraction of relevant nuclei that are affected by the $S(\\alpha, \\beta)$ table."]
         },
         "geometryInput": {
-            "dagmcFile": ["DAGMC File", "InputFile", ""]
+            "dagmcFile": ["DAGMC file", "InputFile", ""]
         },
         "geometry3DReport": {
-            "bgColor": ["Background Color", "Color", "#fff9ed"],
-            "opacity": ["Global Alpha", "Range", 1.0, "", 0.0, 1.0],
-            "showEdges": ["Show Edges", "Boolean", "0"]
+            "bgColor": ["Background color", "Color", "#fff9ed"],
+            "opacity": ["Global alpha", "Range", 1.0, "", 0.0, 1.0],
+            "showEdges": ["Show edges", "Boolean", "0"]
         },
         "isotropic": {
             "_super": ["_", "model", "unitSphere"]
@@ -182,7 +186,7 @@
             "temperature": ["Temperature [K] (Optional)", "OptionalFloat"],
             "density_with_units": ["Density", "DensityWithUnits"],
             "density": ["Density", "Float"],
-            "density_units": ["Density Units", "DensityUnits", "g/cm3"],
+            "density_units": ["Density units", "DensityUnits", "g/cm3"],
             "depletable": ["Depletable", "Boolean", "0"],
             "volume": ["Volume [$cm^3$] (Optional)", "OptionalFloat"],
             "components": ["", "MaterialComponents"]
@@ -193,25 +197,26 @@
         },
         "monodirectional": {
             "_super": ["_", "model", "unitSphere"],
-            "reference_uvw": ["Polar Angle Direction", "Point3D", [1, 0, 0]]
+            "reference_uvw": ["Polar angle direction", "Point3D", [1, 0, 0]]
         },
         "muir": {
             "_super": [ "_", "model", "univariate"],
-            "e0": ["Mean Energy [eV]", "Float", 14.08e6, "The Muir energy spectrum is a Gaussian spectrum, but for convenience reasons allows the user 3 parameters to define the distribution, the mean energy of particles, the mass of reactants, and the ion temperature"],
-            "m_rat": ["Mass of Reactants", "Float", 5, "Ratio of the sum of the masses of the reaction inputs to an AMU"],
-            "kt": ["Ion Temperature [eV]", "Float", 20000]
+            "e0": ["Mean energy [eV]", "Float", 14.08e6, "The Muir energy spectrum is a Gaussian spectrum, but for convenience reasons allows the user 3 parameters to define the distribution, the mean energy of particles, the mass of reactants, and the ion temperature"],
+            "m_rat": ["Mass of reactants", "Float", 5, "Ratio of the sum of the masses of the reaction inputs to an AMU"],
+            "kt": ["Ion temperature [eV]", "Float", 20000]
         },
         "normal": {
             "_super": [ "_", "model", "univariate"],
-            "mean_value": ["Mean Value", "Float"],
-            "std_dev": ["Standard Deviation", "Float"]
+            "mean_value": ["Mean value", "Float"],
+            "std_dev": ["Standard deviation", "Float"]
         },
         "settings": {
             "batches": ["Number of batches to simulation", "Integer", 1],
             "inactive": ["Number of inactive batches", "Integer", 0],
             "particles": ["Number of particles per generation", "Integer", 5000],
             "sources": ["", "Sources", []],
-            "run_mode": ["Run Mode", "RunMode", "eigenvalue", "The type of calculation to perform"]
+            "run_mode": ["Run mode", "RunMode", "eigenvalue", "The type of calculation to perform"],
+            "materialLibrary": ["Material data library", "MaterialLibrary", "ENDFB-7.1-NNDC"]
         },
         "point": {
             "_super": [ "_", "model", "spatial"],
@@ -219,14 +224,14 @@
         },
         "polarAzimuthal": {
             "_super": ["_", "model", "unitSphere"],
-            "mu": ["Polar Angle Distribution", "Univariate", {"_type": "None"}, "Distribution of the cosine of the polar angle"],
-            "phi": ["Azimuthal Angle Distribution [rad]", "Univariate", {"_type": "None"}, "Distribution of the azimuthal angle in radians"],
-            "reference_uvw": ["Polar Angle Direction", "Point3D", [0, 0, 1]]
+            "mu": ["Polar angle distribution", "Univariate", {"_type": "None"}, "Distribution of the cosine of the polar angle"],
+            "phi": ["Azimuthal angle distribution [rad]", "Univariate", {"_type": "None"}, "Distribution of the azimuthal angle in radians"],
+            "reference_uvw": ["Polar angle direction", "Point3D", [0, 0, 1]]
         },
         "powerLaw": {
             "_super": [ "_", "model", "univariate"],
-            "a": ["Lower Bound", "Float", 0, "The power law distribution has density function $p(x) dx = c x^n dx$"],
-            "b": ["Upper Bound", "Float", 1],
+            "a": ["Lower bound", "Float", 0, "The power law distribution has density function $p(x) dx = c x^n dx$"],
+            "b": ["Upper bound", "Float", 1],
             "n": ["Exponent", "Float", 0, "Power law exponent. Defaults to zero, which is equivalent to a uniform distribution"]
         },
         "probabilityValue": {
@@ -234,17 +239,17 @@
             "p": ["Probability", "Float"]
         },
         "reflectivePlanes": {
-            "useReflectivePlanes": ["Use Reflective Planes", "Boolean", "0", "Add reflective planes for sector models. $Ax + By + Cz = D$"],
+            "useReflectivePlanes": ["Use reflective planes", "Boolean", "0", "Add reflective planes for sector models. $Ax + By + Cz = D$"],
             "plane1a": ["Plane 1 A", "Float", 0],
             "plane1b": ["Plane 1 B", "Float", -1],
             "plane2a": ["Plane 2 A", "Float", 1],
             "plane2b": ["Plane 2 B", "Float", 0]
         },
         "source": {
-            "space": ["Spatial Distribution", "Spatial", {"_type": "None"}],
-            "angle": ["Angular Distribution", "UnitSphere", {"_type": "None"}],
-            "energy": ["Energy Distribution", "Univariate", {"_type": "None"}],
-            "time": ["Time Distribution", "Univariate", {"_type": "None"}],
+            "space": ["Spatial distribution", "Spatial", {"_type": "None"}],
+            "angle": ["Angular distribution", "UnitSphere", {"_type": "None"}],
+            "energy": ["Energy distribution", "Univariate", {"_type": "None"}],
+            "time": ["Time distribution", "Univariate", {"_type": "None"}],
             "strength": ["Strength", "Float", 1],
             "particle": ["Particle", "Particle", "neutron"]
         },
@@ -253,9 +258,9 @@
         },
         "sphericalIndependent": {
             "_super": [ "_", "model", "spatial"],
-            "r": ["R Distribution", "Univariate", {"_type": "None"}],
-            "theta": ["Theta Distribution", "Univariate", {"_type": "None"}, "Distribution of theta-coordinates (angle relative to the z-axis) in a reference frame specified by the origin parameter"],
-            "phi": ["Phi Distribution", "Univariate", {"_type": "None"}, "Distribution of phi-coordinates (azimuthal angle) in a reference frame specified by the origin parameter"],
+            "r": ["R distribution", "Univariate", {"_type": "None"}],
+            "theta": ["Theta distribution", "Univariate", {"_type": "None"}, "Distribution of theta-coordinates (angle relative to the z-axis) in a reference frame specified by the origin parameter"],
+            "phi": ["Phi distribution", "Univariate", {"_type": "None"}, "Distribution of phi-coordinates (azimuthal angle) in a reference frame specified by the origin parameter"],
             "origin": ["Origin [cm]", "Point3D", [0, 0, 0], "Coordinates (x0, y0, z0) of the center of the spherical reference frame for the source."]
         },
         "tally": {
@@ -272,15 +277,15 @@
             "_super": [ "_", "model", "univariate"],
             "probabilityValue": ["", "ModelArray", ""],
             "interpolation": ["Interpolation", "Interpolation", "linear-linear"],
-            "ignore_negative": ["Ignore Negative Probabilities", "Boolean", "0"]
+            "ignore_negative": ["Ignore negative probabilities", "Boolean", "0"]
         },
         "tallyFilter": {
-            "type": ["Filter Type", "FilterType", "CellFilter"]
+            "type": ["Filter type", "FilterType", "CellFilter"]
         },
         "uniform": {
             "_super": [ "_", "model", "univariate"],
-            "a": ["Lower Bound", "Float", 0],
-            "b": ["Upper Bound", "Float", 1]
+            "a": ["Lower bound", "Float", 0],
+            "b": ["Upper bound", "Float", 1]
         },
         "unitSphere": {
             "_type": ["", "UnitSphereDistribution"]
@@ -406,7 +411,8 @@
                     "batches",
                     "inactive",
                     "particles",
-                    "run_mode"
+                    "run_mode",
+                    "materialLibrary"
                 ]],
                 ["Sources", [
                     "sources"

--- a/sirepo/package_data/template/cloudmc/parameters.py.jinja
+++ b/sirepo/package_data/template/cloudmc/parameters.py.jinja
@@ -43,7 +43,7 @@ def create_materials():
     {% endfilter %}
     materials.export_to_xml()
     openmc_data_downloader.just_in_time_library_generator(
-        libraries='ENDFB-7.1-NNDC',
+        libraries='{{ settings_materialLibrary }}',
         materials=materials,
         destination='../../lib',
     )


### PR DESCRIPTION
- fix #4680 two material libraries are available for selection
- fpc include vtk overlay in sr-screenshot container
- also standardize CloudMC schema labels to ucfirst on first word only