### PR TITLE
Fix #4703 radia und example axis path

### DIFF
--- a/sirepo/package_data/template/radia/examples/undulator.json
+++ b/sirepo/package_data/template/radia/examples/undulator.json
@@ -12,6 +12,7 @@
             "paths": [
                 {
                     "_super": "fieldPath",
+                    "axis": "y",
                     "begin": "-0.0,-150,-0.0",
                     "end": "0.0,150,0.0",
                     "id": "6233b2ae-cc3e-4ec8-a746-b1e947a67ca0",

--- a/sirepo/package_data/template/radia/examples/wiggler.json
+++ b/sirepo/package_data/template/radia/examples/wiggler.json
@@ -12,6 +12,7 @@
             "paths": [
                 {
                     "_super": "fieldPath",
+                    "axis": "y",
                     "begin": "0, -225, 0",
                     "end": "0, 225, 0",
                     "id": 0,


### PR DESCRIPTION
Discarding changes to example will show the correct axis now. The wiggler example had the same problem. IMHO this is not worth adding fixup code, but I will do so if needed.