### PR TITLE
Fix #4760 - handle duplicate element names

### DIFF
--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -2087,7 +2087,10 @@ def _process_image(data, tmp_dir):
 
 def _process_rsopt_elements(els):
     x = [e for e in els if e.enabled and e.enabled != "0"]
+    names = []
     for e in x:
+        e.title = _safe_beamline_item_name(e.title, names)
+        names.append(e.title)
         for p in _RSOPT_PARAMS:
             if p in e:
                 e[p].offsets = sirepo.util.split_comma_delimited_string(


### PR DESCRIPTION
The problem was that both elliptical mirrors are named "Elliptical Mirror", so only the first mirror was deflected. `_safe_beamline_item_name` takes care of this when generating `parameters.py` (generating "Elliptical_Mirror2"), but the rsopt section passed the element names without modification.