### PR TITLE
Fix radiasoft/prop22_cloudmc#13: export statepoints

### DIFF
--- a/sirepo/exporter.py
+++ b/sirepo/exporter.py
@@ -16,9 +16,7 @@ from sirepo import simulation_db
 from sirepo import template
 from sirepo import uri_router
 import base64
-import copy
 import sirepo.util
-import zipfile
 
 
 def create_archive(sim, sapi):
@@ -96,12 +94,7 @@ def _create_zip(sim, want_python, out_dir):
     if want_python:
         for f in _python(data, sim):
             files.append(f)
-    with zipfile.ZipFile(
-        str(path),
-        mode="w",
-        compression=zipfile.ZIP_DEFLATED,
-        allowZip64=True,
-    ) as z:
+    with sirepo.util.write_zip(str(path)) as z:
         for f in files:
             z.write(str(f), f.basename)
         z.writestr(

--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -4,9 +4,6 @@ var srlog = SIREPO.srlog;
 var srdbg = SIREPO.srdbg;
 
 SIREPO.app.config(() => {
-    SIREPO.appDownloadLinks = `
-        <li data-export-statepoints-link="" ></li>
-    `;
     SIREPO.appReportTypes = `
         <div data-ng-switch-when="geometry3d" data-geometry-3d="" class="sr-plot" data-model-name="{{ modelKey }}" data-report-cfg="reportCfg" data-report-id="reportId"></div>
     `;
@@ -196,32 +193,6 @@ SIREPO.app.directive('appHeader', function(appState, cloudmcService, panelState)
               </app-header-right-sim-list>
             </div>
         `,
-    };
-});
-
-SIREPO.app.directive('exportStatepointsLink', function(appState, cloudmcService, panelState, requestSender) {
-    return {
-        restrict: 'A',
-        scope: {},
-        template: `
-            <a data-ng-href="{{ exportStatepointsUrl() }}" target="_blank">Statepoints</a>
-        `,
-        controller: function($scope) {
-            $scope.exportStatepointsUrl = function() {
-                if (! appState.isLoaded()) {
-                    return null;
-                }
-                return requestSender.formatUrl('downloadDataFile', {
-                    '<simulation_id>': appState.models.simulation.simulationId,
-                    '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
-                    '<model>': cloudmcService.computeModel(
-                        panelState.findParentAttribute($scope, 'modelKey'),
-                    ),
-                    '<frame>': 1,
-                    '<suffix>': 'zip',
-                });
-            };
-        },
     };
 });
 

--- a/sirepo/pkcli/cloudmc.py
+++ b/sirepo/pkcli/cloudmc.py
@@ -18,8 +18,8 @@ import re
 import sirepo.sim_data.cloudmc
 import sirepo.simulation_db
 import sirepo.template.cloudmc
+import sirepo.util
 import uuid
-import zipfile
 
 
 _DATA_DIR = "data"
@@ -232,7 +232,7 @@ def _vtk_to_bin(vol_id):
         vti[n].ref.id = fn
         vti[n].size = int(len(v[n]))
         fns.append(f"{_DATA_DIR}/{fn}")
-    with zipfile.ZipFile(f"{vol_id}.zip", "w") as f:
+    with sirepo.util.write_zip(f"{vol_id}.zip") as f:
         f.writestr("index.json", json.dumps(vti))
         for fn in fns:
             f.write(fn)

--- a/sirepo/template/cloudmc.py
+++ b/sirepo/template/cloudmc.py
@@ -62,7 +62,14 @@ def get_data_file(run_dir, model, frame, options):
     if model == "openmcAnimation":
         if options.suffix == "log":
             return template_common.text_data_file(template_common.RUN_LOG, run_dir)
+        elif options.suffix == "zip":
+            o = "statepoints.zip"
+            with util.write_zip(o) as z:
+                for f in pkio.sorted_glob(run_dir.join("statepoint*h5")):
+                    z.write(str(f.basename))
+            return PKDict(filename=run_dir.join(o))
         return PKDict(filename=run_dir.join(f"{sim_in.models.tally.name}.json"))
+    raise AssertionError("no data file for model={model} and options={options}")
 
 
 def python_source_for_model(data, model):

--- a/sirepo/template/cloudmc.py
+++ b/sirepo/template/cloudmc.py
@@ -62,12 +62,6 @@ def get_data_file(run_dir, model, frame, options):
     if model == "openmcAnimation":
         if options.suffix == "log":
             return template_common.text_data_file(template_common.RUN_LOG, run_dir)
-        elif options.suffix == "zip":
-            o = "statepoints.zip"
-            with util.write_zip(o) as z:
-                for f in pkio.sorted_glob(run_dir.join("statepoint*h5")):
-                    z.write(str(f.basename))
-            return PKDict(filename=run_dir.join(o))
         return PKDict(filename=run_dir.join(f"{sim_in.models.tally.name}.json"))
     raise AssertionError("no data file for model={model} and options={options}")
 

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -1164,8 +1164,6 @@ def _save_field_csv(field_type, vectors, scipy_rotation, path):
 # zip file - data plus index.  This will likely be used to generate files for a range
 # of gaps later
 def _save_field_srw(field_type, gap, vectors, scipy_rotation, path):
-    import zipfile
-
     # no whitespace in filenames
     base_name = re.sub(r"\s", "_", path.purebasename)
     data_path = path.dirpath().join(f"{base_name}_{gap}.dat")
@@ -1198,12 +1196,7 @@ def _save_field_srw(field_type, gap, vectors, scipy_rotation, path):
     files = [data_path, index_path]
 
     # zip file
-    with zipfile.ZipFile(
-        str(path),
-        mode="w",
-        compression=zipfile.ZIP_DEFLATED,
-        allowZip64=True,
-    ) as z:
+    with sirepo.util.write_zip(str(path)) as z:
         for f in files:
             z.write(str(f), f.basename)
 

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -460,12 +460,7 @@ def export_rsopt_config(data, filename):
         )
     readme = template_common.render_jinja(SIM_TYPE, v, v.readmeFileName)
 
-    with zipfile.ZipFile(
-        fz,
-        mode="w",
-        compression=zipfile.ZIP_DEFLATED,
-        allowZip64=True,
-    ) as z:
+    with sirepo.util.write_zip(fz) as z:
         for t in tf:
             z.writestr(tf[t].file, tf[t].content)
         z.writestr(v.readmeFileName, readme)

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -410,6 +410,14 @@ def url_safe_hash(value):
     return hashlib.md5(pkcompat.to_bytes(value)).hexdigest()
 
 
+def write_zip(path):
+    return zipfile.ZipFile(
+        path,
+        mode="w",
+        compression=zipfile.ZIP_DEFLATED,
+    )
+
+
 def _raise(exc, fmt, *args, **kwargs):
     import werkzeug.exceptions
 


### PR DESCRIPTION
Add a "Statepoints" link in the DAGMC Gemoetry report panel that downloads
a zip of all statepoint files output by the simulation.

In addition, create sirepo.util.write_zip which encapsulates all of the
args commonly supplied when creating a zipfile.