### PR TITLE
fix #4786 beamline editor with optional panel tabs

### DIFF
--- a/sirepo/package_data/static/css/ext/bootstrap-colxl.css
+++ b/sirepo/package_data/static/css/ext/bootstrap-colxl.css
@@ -165,6 +165,13 @@
   .col-xl-offset-0 {
     margin-left: 0;
   }
+  tr.visible-xl {
+    display: table-row !important;
+  }
+  th.visible-xl,
+  td.visible-xl {
+    display: table-cell !important;
+  }
 }
 
 .visible-xxl {
@@ -332,5 +339,12 @@
   }
   .col-xxl-offset-0 {
     margin-left: 0;
+  }
+  tr.visible-xxl {
+    display: table-row !important;
+  }
+  th.visible-xxl,
+  td.visible-xxl {
+    display: table-cell !important;
   }
 }

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -3532,30 +3532,43 @@ SIREPO.app.directive('modelArray', function() {
             field: '=',
         },
         template: `
-            <div  style="position: relative; top: -25px">
-            <div class="row">
-              <div class="col-sm-11"><div class="row">
-                <div data-ng-if="pad > 0" data-ng-attr-class="col-sm-{{ pad }}"></div>
-                <div class="col-sm-3 text-center" data-ng-repeat="heading in headings track by $index">
-<div data-label-with-tooltip="" data-label="{{ heading[0] }}" data-tooltip="{{ heading[3] }}"></div>
-                </div></div>
-              </div>
-            </div>
-            <div class="form-group form-group-sm" data-ng-show="showRow($index)" data-ng-repeat="m in modelArray() track by $index">
-              <div class="col-sm-11"><div class="row">
-                <div data-ng-if="pad > 0" data-ng-attr-class="col-sm-{{ pad }}"></div>
-                <div class="col-sm-3" data-ng-repeat="f in fields track by $index">
-                  <input data-string-to-number="" data-ng-model="m[f]" class="form-control" style="text-align: right" data-lpignore="true" />
+            <div style="position: relative; top: -25px">
+              <div class="row">
+                <div class="col-sm-11">
+                  <div class="row">
+                    <div data-ng-if="pad > 0" data-ng-attr-class="col-sm-{{ pad }}"></div>
+                    <div class="col-sm-3 text-center"
+                      data-ng-repeat="heading in headings track by $index">
+                      <div data-label-with-tooltip="" data-label="{{ heading[0] }}"
+                        data-tooltip="{{ heading[3] }}"></div>
+                    </div>
+                  </div>
                 </div>
-              </div></div>
-              <div class="col-sm-1"><button style="margin-left: -15px; margin-top: 5px" data-ng-show="! isEmpty($index)" data-ng-click="deleteRow($index)" class="btn btn-danger btn-xs"><span class="glyphicon glyphicon-remove"></span></button></div>
-            </div>
+              </div>
+              <div class="form-group form-group-sm" data-ng-show="showRow($index)"
+                data-ng-repeat="m in modelArray() track by $index">
+                <div class="col-sm-11">
+                  <div class="row">
+                    <div data-ng-if="pad > 0" data-ng-attr-class="col-sm-{{ pad }}"></div>
+                    <div class="col-sm-3" data-ng-repeat="f in fields track by $index">
+                      <input data-string-to-number="" data-ng-model="m[f]" class="form-control"
+                        style="text-align: right" data-lpignore="true" />
+                    </div>
+                  </div>
+                </div>
+                <div class="col-sm-1">
+                  <button style="margin-left: -15px; margin-top: 5px"
+                    data-ng-show="! isEmpty($index)" data-ng-click="deleteRow($index)"
+                    class="btn btn-danger btn-xs"><span class="glyphicon glyphicon-remove"></span>
+                  </button>
+                </div>
+              </div>
             </div>
         `,
         controller: function(appState, $scope) {
             const mView = SIREPO.APP_SCHEMA.view[$scope.field];
             $scope.fields = mView.advanced;
-            $scope.headings = SIREPO.APP_SCHEMA.model[$scope.field];
+            $scope.headings = $scope.fields.map(f => SIREPO.APP_SCHEMA.model[$scope.field][f]);
             $scope.pad = (4 - $scope.fields.length) * 3;
 
             function initArray() {

--- a/sirepo/package_data/static/js/sirepo-lattice.js
+++ b/sirepo/package_data/static/js/sirepo-lattice.js
@@ -2840,9 +2840,11 @@ SIREPO.app.directive('rpnValue', function(appState, rpnService) {
                 requestIndex++;
                 var currentRequestIndex = requestIndex;
                 if (ngModel.$isEmpty(value)) {
+                    scope.isBusy = false;
                     return null;
                 }
                 if (SIREPO.NUMBER_REGEXP.test(value)) {
+                    scope.isBusy = false;
                     var v = parseFloat(value);
                     if (rpnVariableName) {
                         rpnService.recomputeCache(rpnVariableName, v);

--- a/sirepo/package_data/static/js/sirepo-lattice.js
+++ b/sirepo/package_data/static/js/sirepo-lattice.js
@@ -588,8 +588,11 @@ SIREPO.app.service('rpnService', function(appState, requestSender, $rootScope) {
 SIREPO.app.directive('beamlineEditor', function(appState, latticeService, panelState, rpnService, $document, $rootScope, $window) {
     return {
         restrict: 'A',
+        // transcluded data contains html for tab panels defined with headerTabInfo
+        transclude: true,
         scope: {
             shiftClickHandler: '&?',
+            headerTabInfo: '=',
         },
         template: `
             <div data-ng-show="showEditor()" class="panel panel-info" style="margin-bottom: 0">
@@ -597,8 +600,15 @@ SIREPO.app.directive('beamlineEditor', function(appState, latticeService, panelS
                 <div class="sr-panel-options pull-right">
                   <a href data-ng-show="hasBeamlineView()" data-ng-click="showBeamlineNameModal()" title="Edit"><span class="sr-panel-heading glyphicon glyphicon-pencil"></span></a>
                 </div>
+                <div data-ng-if="headerTabInfo" class="sr-panel-options pull-right hidden-md hidden-sm hidden-xs" style="margin-top: -2px">
+                  <ul class="nav nav-tabs">
+                    <li data-ng-class="{active: headerTabInfo.selected == t}" data-ng-repeat="t in headerTabInfo.names"><a href ng-click="headerTabInfo.selected = t">{{ t }}</a></li>
+                  </ul>
+                  <div class="clearfix"></div>
+                </div>
               </div>
-              <div data-ng-attr-style="height: {{ editorHeight() }}" class="panel-body sr-lattice-editor-panel" data-ng-drop="true" data-ng-drop-success="dropPanel($data)" data-ng-drag-start="dragStart($data)">
+              <div class="sr-lattice-editor-panel">
+              <div data-ng-show="! headerTabInfo || headerTabInfo.selected == headerTabInfo.elementsTabName" data-ng-attr-style="height: {{ editorHeight() }}" class="panel-body" data-ng-drop="true" data-ng-drop-success="dropPanel($data)" data-ng-drag-start="dragStart($data)">
                 <p class="lead text-center"><small><em>drag and drop elements here to define the beamline</em><span data-sr-tooltip="{{ tooltip }}"></span></small></p>
                 <div data-ng-repeat="item in beamlineItems track by item.itemId" class="sr-lattice-item-holder" data-ng-drop="true" data-ng-drop-success="dropItem($index, $data)">
                   <div style="display: inline-block;" class="sr-editor-item-hover">
@@ -610,6 +620,8 @@ SIREPO.app.directive('beamlineEditor', function(appState, latticeService, panelS
                   <div style="visibility: hidden" class="badge sr-lattice-item sr-badge-icon"><span>last</span></div>
                 </div>
               </div>
+              </div>
+              <div data-ng-transclude=""></div>
             </div>
             <div data-confirmation-modal="" data-id="sr-delete-lattice-item-dialog" data-title="{{ latticeService.selectedItem.name }}" data-ok-text="Delete" data-ok-clicked="deleteSelectedItem()">Delete item <strong>{{ latticeService.selectedItem.name }}</strong>?</div>
             <div data-confirmation-modal="" data-id="sr-beamline-from-elements-dialog" data-title="Create Beamline From Elements" data-ok-text="Save Changes" data-ok-clicked="createBeamlineFromElements()">


### PR DESCRIPTION
- the beamlineEditor directive now has an option headerTabInfo argument for arranging tabbed
  panels within the panel heading
- fixed Object.keys() order assumption in modelArray directive and reformatted html
- added missing table css for xl and xxl layouts