### PR TITLE
Fix #4810: rename tasksPerNode label

### DIFF
--- a/sirepo/package_data/static/json/flash-schema.json
+++ b/sirepo/package_data/static/json/flash-schema.json
@@ -97,7 +97,7 @@
     "model": {
         "animation": {
             "jobRunMode": ["Execution Mode", "JobRunMode", "parallel"],
-            "tasksPerNode": ["Tasks per node", "Integer", 32],
+            "tasksPerNode": ["Processes per node", "Integer", 32],
             "sbatchCores": ["Cores", "Integer", 128],
             "sbatchHours": ["Hours", "Float", 0.4],
             "sbatchQueue": ["Queue", "NERSCQueue", "debug"],

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -915,7 +915,7 @@
             "precision": ["Precision (T)", "Float", 0.00010, "", ""],
             "result": ["Result", "String", ""],
             "jobRunMode": ["Execution Mode", "JobRunMode", "parallel"],
-            "tasksPerNode": ["Tasks per node", "Integer", 32],
+            "tasksPerNode": ["Processes per node", "Integer", 32],
             "sbatchHours": ["Hours", "Float", 0.4],
             "sbatchQueue": ["Queue", "NERSCQueue", "debug"],
             "sbatchCores": ["Cores", "Integer", 1],

--- a/sirepo/package_data/static/json/srw-schema.json
+++ b/sirepo/package_data/static/json/srw-schema.json
@@ -513,7 +513,7 @@
         "coherentModesAnimation": {
             "_super": ["_", "model", "_INTENSITY_REPORT"],
             "jobRunMode": ["Execution Mode", "JobRunMode", "parallel"],
-            "tasksPerNode": ["Tasks per node", "Integer", 32],
+            "tasksPerNode": ["Processes per node", "Integer", 32],
             "sbatchCores": ["Cores", "Integer", 128],
             "sbatchHours": ["Hours", "Float", 0.4],
             "sbatchQueue": ["Queue", "NERSCQueue", "debug"],
@@ -836,7 +836,7 @@
         "multiElectronAnimation": {
             "_super": ["_", "model", "_INTENSITY_REPORT"],
             "jobRunMode": ["Execution Mode", "JobRunMode", "parallel"],
-            "tasksPerNode": ["Tasks per node", "Integer", 32],
+            "tasksPerNode": ["Processes per node", "Integer", 32],
             "sbatchCores": ["Cores", "Integer", 128],
             "sbatchHours": ["Hours", "Float", 0.4],
             "sbatchQueue": ["Queue", "NERSCQueue", "debug"],

--- a/sirepo/package_data/static/json/warppba-schema.json
+++ b/sirepo/package_data/static/json/warppba-schema.json
@@ -161,7 +161,7 @@
         "animation": {
             "sbatchCores": ["Cores", "Integer", 4],
             "jobRunMode": ["Execution Mode", "JobRunMode", "parallel"],
-            "tasksPerNode": ["Tasks per node", "Integer", 32],
+            "tasksPerNode": ["Processes per node", "Integer", 32],
             "sbatchHours": ["Hours", "Float", 0.4],
             "sbatchQueue": ["Queue", "NERSCQueue", "debug"],
             "sbatchProject": ["Project", "OptionalString", ""]


### PR DESCRIPTION
tasksPerNode label renamed to 'processes per node'