### PR TITLE
#4816 - restructured hdf5 file

### DIFF
--- a/sirepo/package_data/template/srw/README.txt.jinja
+++ b/sirepo/package_data/template/srw/README.txt.jinja
@@ -23,11 +23,11 @@ Please note:
 
 The final consolidated input and output data for use in ML is in the hdf5 file "results.h5" under the "datasets" folder.
 It has the following structure:
-    - "/params": the parameters in the format <element name>_<param name>, e.g.
-        "Aperture_horizontalSize"
-    - "/paramVals": array of size {{ totalSamples }} containing the parameter values for each run
-    - "/beamIntensities": array of size {{ totalSamples }} containing the propagated single-electron intensity
+    - "/metadata": array of size {{ totalSamples }} containing the parameter values for each run
+    - "/images": array of size {{ totalSamples }} containing the propagated single-electron intensity
         distribution vs horizontal and vertical position for each run
+The parameter names are stored in an attribute named "parameters" on the metadata dataset
+in the format <element name>_<param name>, e.g. "Aperture_horizontalSize".
 
 Intermediate output is also available under the ensemble/worker[n]/sim[m] directories:
 

--- a/sirepo/package_data/template/srw/exportRsOpt_post.py.jinja
+++ b/sirepo/package_data/template/srw/exportRsOpt_post.py.jinja
@@ -27,9 +27,9 @@ def main():
         )
         param_vals.append(r["x"])
     with h5py.File("results.h5", "w") as f:
-        f.create_dataset("params", data=[{{ rsOptFuctionSignature(true) }}])
-        f.create_dataset("paramVals", data=param_vals)
-        f.create_dataset("beamIntensities", data=beams)
+        m = f.create_dataset("metadata", data=param_vals)
+        m.attrs.create("parameters",  [{{ rsOptFuctionSignature(true) }}])
+        f.create_dataset("images", data=beams)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As discussed, this puts the unnormalized beam intensities into "/images" and the param values into "/metadata". Instead of a separate dataset, the parameter names now live in an attribute named "parameters" on the metadata dataset. To retrieve them, e.g.:
```python
import h5py
with h5py.File("results.h5", "r") as f:
    d = f["metadata"]
    p = d.attrs["parameters"]
```
This also updates the README accordingly.