### PR TITLE
Fix #4811: dat vs bkp slurm

### DIFF
--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -2324,8 +2324,6 @@ def _set_magnetic_measurement_parameters(run_dir, v):
 
 
 def _set_parameters(v, data, plot_reports, run_dir):
-    # TODO (gurhar1133): undo this later
-    # v.sbatchBackup = "1"
     report = data.report
     is_for_rsopt = _is_for_rsopt(report)
     dm = data.models

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -41,6 +41,7 @@ _CANVAS_MAX_SIZE = 65535
 
 _OUTPUT_FOR_MODEL = PKDict(
     coherenceXAnimation=PKDict(
+        check_backup=True,
         title="",
         filename="res_int_pr_me_dcx.dat",
         dimensions=3,
@@ -48,6 +49,7 @@ _OUTPUT_FOR_MODEL = PKDict(
         units=["m", "m", ""],
     ),
     coherenceYAnimation=PKDict(
+        check_backup=True,
         title="",
         filename="res_int_pr_me_dcy.dat",
         dimensions=3,
@@ -94,6 +96,7 @@ _OUTPUT_FOR_MODEL = PKDict(
         units=["m", "m", "m"],
     ),
     multiElectronAnimation=PKDict(
+        check_backup=True,
         title="E={photonEnergy} eV",
         filename="res_int_pr_me.dat",
         dimensions=3,
@@ -366,6 +369,10 @@ def _extract_coherent_modes(model, out_info):
     )
     return out_file
 
+def _check_backup(animation_meta_data):
+    # get most recent unless most recent has less lines
+    # this would mean it is partially written
+    pass
 
 def extract_report_data(sim_in):
     r = sim_in.report
@@ -379,6 +386,8 @@ def extract_report_data(sim_in):
         return _extract_trajectory_report(dm.trajectoryReport, out.filename)
     if r == _SIM_DATA.EXPORT_RSOPT:
         return out
+    if out.get("check_backup"):
+        out.filename = _check_backup(out)
     # TODO(pjm): remove fixup after dcx/dcy files can be read by uti_plot_com
     if r in ("coherenceXAnimation", "coherenceYAnimation"):
         _fix_file_header(out.filename)
@@ -584,6 +593,7 @@ def sim_frame(frame_args):
         # some reports may be written at the same time as the reader
         # if the file is invalid, wait a bit and try again
         for i in (1, 2, 3):
+            # TODO (gurhar1133): maybe test here
             try:
                 return extract_report_data(frame_args.sim_in)
             except Exception:
@@ -2289,6 +2299,8 @@ def _set_magnetic_measurement_parameters(run_dir, v):
 
 
 def _set_parameters(v, data, plot_reports, run_dir):
+    # TODO (gurhar1133): undo this later
+    v.sbatchBackup = "1"
     report = data.report
     is_for_rsopt = _is_for_rsopt(report)
     dm = data.models

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -381,9 +381,15 @@ def _get_recent(data_filename, backup_data_filename):
         )
 
 
+def _count_lines(text):
+    return len(pkio.read_text(text).splitlines())
+
+
+def _recent_has_more_lines(recent, old):
+    return _count_lines(recent) >= _count_lines(old)
+
+
 def _check_backup(animation_meta_data):
-    import os
-    from pykern import pkio
     # get most recent unless most recent has less lines
     # this would mean it is partially written
     b = animation_meta_data.filename + ".bkp"
@@ -391,9 +397,10 @@ def _check_backup(animation_meta_data):
         pkdp("\n\n\n no .bkp \n\n\n")
         return animation_meta_data.filename
     i = _get_recent(animation_meta_data.filename, b)
-    if len(pkio.read_text(i.recent).splitlines()) >= len(pkio.read_text(i.old).splitlines()):
+    if _recent_has_more_lines(i.recent, i.old):
         return i.recent
     return i.old
+
 
 def extract_report_data(sim_in):
     r = sim_in.report

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -370,7 +370,6 @@ def _extract_coherent_modes(model, out_info):
     return out_file
 
 def _get_recent(data_filename, backup_data_filename):
-    pkdp("\n\n\n .dat time: {}, .bkp time: {}", os.path.getmtime(data_filename), os.path.getmtime(backup_data_filename))
     if os.path.getmtime(backup_data_filename) > os.path.getmtime(data_filename):
         return PKDict(
             recent=backup_data_filename,
@@ -389,10 +388,9 @@ def _check_backup(animation_meta_data):
     # this would mean it is partially written
     b = animation_meta_data.filename + ".bkp"
     if not pkio.py_path(b).check():
+        pkdp("\n\n\n no .bkp \n\n\n")
         return animation_meta_data.filename
     i = _get_recent(animation_meta_data.filename, b)
-    pkdp("\n\n\n i: {}", i)
-    pkdp("\n\n\n linecounts: {}, {}", len(pkio.read_text(i.recent).splitlines()), len(pkio.read_text(i.old).splitlines()))
     if len(pkio.read_text(i.recent).splitlines()) >= len(pkio.read_text(i.old).splitlines()):
         return i.recent
     return i.old
@@ -411,7 +409,7 @@ def extract_report_data(sim_in):
         return out
     if out.get("check_backup"):
         # TODO (gurhar1133): might want to change this check v.sbatchBackup == '1' or something?
-        # to see if v.
+        # to see if v
         out.filename = _check_backup(out)
         pkdp("\n\n\n out.filename for {} is -> {}", r, out.filename)
     # TODO(pjm): remove fixup after dcx/dcy files can be read by uti_plot_com
@@ -619,7 +617,6 @@ def sim_frame(frame_args):
         # some reports may be written at the same time as the reader
         # if the file is invalid, wait a bit and try again
         for i in (1, 2, 3):
-            # TODO (gurhar1133): maybe test here
             try:
                 return extract_report_data(frame_args.sim_in)
             except Exception:
@@ -2326,7 +2323,7 @@ def _set_magnetic_measurement_parameters(run_dir, v):
 
 def _set_parameters(v, data, plot_reports, run_dir):
     # TODO (gurhar1133): undo this later
-    v.sbatchBackup = "1"
+    # v.sbatchBackup = "1"
     report = data.report
     is_for_rsopt = _is_for_rsopt(report)
     dm = data.models

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -388,8 +388,11 @@ def _check_backup(animation_meta_data):
     # get most recent unless most recent has less lines
     # this would mean it is partially written
     b = animation_meta_data.filename + ".bkp"
+    if not pkio.py_path(b).check():
+        return animation_meta_data.filename
     i = _get_recent(animation_meta_data.filename, b)
     pkdp("\n\n\n i: {}", i)
+    pkdp("\n\n\n linecounts: {}, {}", len(pkio.read_text(i.recent).splitlines()), len(pkio.read_text(i.old).splitlines()))
     if len(pkio.read_text(i.recent).splitlines()) >= len(pkio.read_text(i.old).splitlines()):
         return i.recent
     return i.old
@@ -410,7 +413,7 @@ def extract_report_data(sim_in):
         # TODO (gurhar1133): might want to change this check v.sbatchBackup == '1' or something?
         # to see if v.
         out.filename = _check_backup(out)
-        pkdp("\n\n\n out.filename for {} is {}", r, out.filename)
+        pkdp("\n\n\n out.filename for {} is -> {}", r, out.filename)
     # TODO(pjm): remove fixup after dcx/dcy files can be read by uti_plot_com
     if r in ("coherenceXAnimation", "coherenceYAnimation"):
         _fix_file_header(out.filename)

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -369,6 +369,7 @@ def _extract_coherent_modes(model, out_info):
     )
     return out_file
 
+
 def _get_recent(data_filename, backup_data_filename):
     if os.path.getmtime(backup_data_filename) > os.path.getmtime(data_filename):
         return PKDict(
@@ -376,28 +377,25 @@ def _get_recent(data_filename, backup_data_filename):
             old=data_filename,
         )
     return PKDict(
-            recent=data_filename,
-            old=backup_data_filename,
-        )
+        recent=data_filename,
+        old=backup_data_filename,
+    )
 
 
 def _count_lines(text):
     return len(pkio.read_text(text).splitlines())
 
 
-def _recent_has_more_lines(recent, old):
+def _recent_has_sufficient_lines(recent, old):
     return _count_lines(recent) >= _count_lines(old)
 
 
 def _check_backup(animation_meta_data):
-    # get most recent unless most recent has less lines
-    # this would mean it is partially written
     b = animation_meta_data.filename + ".bkp"
     if not pkio.py_path(b).check():
-        pkdp("\n\n\n no .bkp \n\n\n")
         return animation_meta_data.filename
     i = _get_recent(animation_meta_data.filename, b)
-    if _recent_has_more_lines(i.recent, i.old):
+    if _recent_has_sufficient_lines(i.recent, i.old):
         return i.recent
     return i.old
 
@@ -415,10 +413,7 @@ def extract_report_data(sim_in):
     if r == _SIM_DATA.EXPORT_RSOPT:
         return out
     if out.get("check_backup"):
-        # TODO (gurhar1133): might want to change this check v.sbatchBackup == '1' or something?
-        # to see if v
         out.filename = _check_backup(out)
-        pkdp("\n\n\n out.filename for {} is -> {}", r, out.filename)
     # TODO(pjm): remove fixup after dcx/dcy files can be read by uti_plot_com
     if r in ("coherenceXAnimation", "coherenceYAnimation"):
         _fix_file_header(out.filename)


### PR DESCRIPTION
.bkp will never be selected if does not exist
if does exist, and is more recent and has sufficient line count, then .bkp is selected