### PR TITLE
Fix #4850: analysis jobs now have run_dir arg

### DIFF
--- a/sirepo/template/elegant.py
+++ b/sirepo/template/elegant.py
@@ -1458,18 +1458,10 @@ def _sdds_init():
     _SDDS_STRING_TYPE = _s.SDDS_STRING
 
 
-def analysis_job_log_to_html(data):
-    r = simulation_db.simulation_run_dir(
-        PKDict(
-            simulationType=data.simulationType,
-            simulationId=data.simulationId,
-            report=data.computeModel,
-        )
-    )
-
+def analysis_job_log_to_html(data, run_dir, **kwargs):
     return PKDict(
         html=pygments.highlight(
-            pkio.read_text(r.join(ELEGANT_LOG_FILE)),
+            pkio.read_text(run_dir.join(ELEGANT_LOG_FILE)),
             pygments.lexers.get_lexer_by_name("text"),
             pygments.formatters.HtmlFormatter(
                 noclasses=False,

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -9,6 +9,7 @@ from pykern import pkio
 from pykern import pkjinja
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdc, pkdlog, pkdp, pkdexc
+from sirepo import simulation_db
 from sirepo.template import code_variable
 import math
 import os
@@ -243,10 +244,17 @@ class ParticleEnergy:
 
 def analysis_job_dispatch(data):
     t = sirepo.template.import_module(data.simulationType)
+    d = simulation_db.simulation_run_dir(
+        PKDict(
+            simulationType=data.simulationType,
+            simulationId=data.simulationId,
+            report=data.computeModel,
+        )
+    )
     return getattr(
         t,
         f"analysis_job_{_validate_method(t, data)}",
-    )(data)
+    )(data, d)
 
 
 def compute_field_range(args, compute_range):

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -9,7 +9,6 @@ from pykern import pkio
 from pykern import pkjinja
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdc, pkdlog, pkdp, pkdexc
-from sirepo import simulation_db
 from sirepo.template import code_variable
 import math
 import os
@@ -243,18 +242,13 @@ class ParticleEnergy:
 
 
 def analysis_job_dispatch(data):
+    from sirepo import simulation_db
+
     t = sirepo.template.import_module(data.simulationType)
-    d = simulation_db.simulation_run_dir(
-        PKDict(
-            simulationType=data.simulationType,
-            simulationId=data.simulationId,
-            report=data.computeModel,
-        )
-    )
     return getattr(
         t,
         f"analysis_job_{_validate_method(t, data)}",
-    )(data, d)
+    )(data, simulation_db.simulation_run_dir(data))
 
 
 def compute_field_range(args, compute_range):


### PR DESCRIPTION
Calls to simulation_db.simulation_run_dir have been removed and now analysis jobs take a run_dir arg.
Analysis jobs now take **kwargs.
