### PR TITLE
Fix #4932: move all databroker calls out of sirepo.

### DIFF
--- a/sirepo/pkcli/raydata.py
+++ b/sirepo/pkcli/raydata.py
@@ -9,35 +9,6 @@ from pykern.pkdebug import pkdp, pkdlog
 from sirepo.template import template_common
 
 
-def create_scans(num_scans, catalog_name, delay=True):
-    from sirepo.template import raydata
-    import bluesky
-    import bluesky.plans
-    import databroker
-    import ophyd.sim
-    import time
-
-    num_scans = int(num_scans)
-    assert num_scans > 0, f"num_scans={num_scans} must be > 0"
-    d = databroker.Broker.named(raydata.catalog(catalog_name).name)
-    RE = bluesky.RunEngine({})
-    RE.subscribe(d.insert)
-    for i in range(num_scans):
-        RE(
-            bluesky.plans.count(
-                [ophyd.sim.det1, ophyd.sim.det2],
-                num=5,
-                md={
-                    "T_sample_": i,
-                    "owner": "foo",
-                    "sequence id": i,
-                },
-            )
-        )
-        if delay:
-            time.sleep(2)
-
-
 def run(cfg_dir):
     _run()
     template_common.write_sequential_result(PKDict())

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -7,8 +7,6 @@
 from pykern import pkjson
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp, pkdlog, pkdformat, pkdexc
-import databroker
-import databroker.queries
 import requests
 import requests.exceptions
 import sirepo.feature_config
@@ -20,35 +18,13 @@ import sirepo.util
 
 _SIM_DATA, SIM_TYPE, SCHEMA = sirepo.sim_data.template_globals()
 
-_DEFAULT_COLUMNS = ["start", "stop", "suid"]
-
-# TODO(e-carlin): tune this number
-_MAX_NUM_SCANS = 1000
-
-_NON_DISPLAY_SCAN_FIELDS = "uid"
-
-
-def catalog(scans_data_or_catalog_name):
-    return databroker.catalog[
-        scans_data_or_catalog_name.catalogName
-        if isinstance(
-            scans_data_or_catalog_name,
-            PKDict,
-        )
-        else scans_data_or_catalog_name
-    ]
-
 
 def stateless_compute_analysis_output(data):
     return _request_scan_monitor(PKDict(method="analysis_output", uid=data.args.uid))
 
 
-def stateless_compute_catalog_names(data):
-    return PKDict(
-        data=PKDict(
-            catalogs=[str(s) for s in databroker.catalog.keys()],
-        )
-    )
+def stateless_compute_catalog_names(_):
+    return _request_scan_monitor(PKDict(method="catalog_names"))
 
 
 def stateless_compute_begin_replay(data):
@@ -56,40 +32,11 @@ def stateless_compute_begin_replay(data):
 
 
 def stateless_compute_scans(data):
-    if data.args.analysisStatus == "executed":
-        assert data.args.searchStartTime and data.args.searchStopTime, pkdformat(
-            "must have both searchStartTime and searchStopTime data={}", data.args
-        )
-        l = []
-        c = catalog(data.args)
-        for s in _request_scan_monitor(
-            PKDict(method="executed_analyses", catalog_name=data.args.catalogName)
-        ).scans:
-            m = c[s.uid].metadata
-            if (
-                m["start"]["time"] >= data.args.searchStartTime
-                and m["stop"]["time"] <= data.args.searchStopTime
-            ):
-                l.append(s)
-    elif data.args.analysisStatus == "queued":
-        l = _request_scan_monitor(
-            PKDict(method="queued_analyses", catalog_name=data.args.catalogName)
-        ).scans
-    else:
-        raise AssertionError("unrecognized scanStatus={data.scanStatus}")
-
-    s = []
-    for i, v in enumerate(l):
-        if i > _MAX_NUM_SCANS:
-            raise sirepo.util.UserAlert(
-                f"More than {_MAX_NUM_SCANS} scans found. Please reduce your query.",
-            )
-        s.append(_scan_info(v.uid, data.args, status=v.status))
-    return _scan_info_result(s)
+    return _request_scan_monitor(PKDict(method="get_scans", data=data))
 
 
 def stateless_compute_scan_fields(data):
-    return PKDict(columns=list(catalog(data.args)[-1].metadata["start"].keys()))
+    return _request_scan_monitor(PKDict(method="scan_fields", data=data))
 
 
 def _request_scan_monitor(data):
@@ -107,34 +54,3 @@ def _request_scan_monitor(data):
             pkdexc(),
         )
     return pkjson.load_any(r.content)
-
-
-def _scan_info(scan_uuid, scans_data, status=None):
-    m = catalog(scans_data)[scan_uuid].metadata
-    # POSIT: uid is no displayed but all of the code expects uid field to exist
-    d = PKDict(uid=scan_uuid, status=status)
-    for c in _DEFAULT_COLUMNS:
-        d[c] = PKDict(
-            start=lambda metadata: metadata["start"]["time"],
-            stop=lambda metadata: metadata["stop"]["time"],
-            suid=lambda metadata: _suid(metadata["start"]["uid"]),
-        )[c](m)
-
-    for c in scans_data.get("selectedColumns", []):
-        d[c] = m["start"].get(c)
-    return d
-
-
-def _scan_info_result(scans):
-    return PKDict(
-        data=PKDict(
-            scans=sorted(scans, key=lambda e: e.start),
-            cols=[k for k in scans[0].keys() if k not in _NON_DISPLAY_SCAN_FIELDS]
-            if scans
-            else [],
-        )
-    )
-
-
-def _suid(scan_uuid):
-    return scan_uuid.split("-")[0]


### PR DESCRIPTION
They were moved into the raydata scan_monitor. There will be a companion PR there.