### PR TITLE
Fix #4973 - removed default fieldPath, do not run if no paths

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1840,7 +1840,7 @@ SIREPO.app.directive('fieldLineoutAnimation', function(appState, persistentSimul
                 $scope.dataCleared = false;
             });
 
-            $scope.$on('fieldLineoutAnimation.changed', function () {
+            $scope.$on('fieldLineoutAnimation.saved', function () {
                 if ($scope.showFieldLineoutPanel()) {
                     // Dont run automatically for sbatch or nersc
                     if (['sequential', 'parallel'].includes(appState.models.fieldLineoutAnimation.jobRunMode)) {

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1834,7 +1834,7 @@ SIREPO.app.directive('fieldLineoutAnimation', function(appState, persistentSimul
             };
 
             $scope.$on('radiaViewer.loaded', () => {
-                if ($scope.dataCleared) {
+                if ($scope.dataCleared && $scope.hasPaths()) {
                     $scope.simState.runSimulation();
                 }
                 $scope.dataCleared = false;
@@ -3624,7 +3624,7 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
                 }
                 const r = 'fieldLineoutAnimation';
                 for (const p of appState.models.fieldPaths.paths) {
-                    if (p.id === appState.models[r].fieldPath.id) {
+                    if (! appState.models[r].fieldPath || p.id === appState.models[r].fieldPath.id) {
                         appState.models[r].fieldPath = p;
                         appState.saveChanges(r);
                         break;

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -935,7 +935,6 @@
             "sbatchProject": ["Project", "OptionalString", ""]
         },
         "fieldLineoutAnimation": {
-            "fieldPath": ["_", "model.fieldPath", {}],
             "fieldPaths": ["Path", "FieldPaths", []],
             "fieldType": ["Field", "FieldType", "B"],
             "inProgressText": ["_", "String", "Calculating"],


### PR DESCRIPTION
The default value for a fieldPath model is an id and an empty name, with no data besides, which causes problems if the app tries to use it. This removes that from the schema, and also prevents fieldLineoutReport from running if there is no path defined.