### PR TITLE
Fix #4974: move Raydata examples into Sirepo

### DIFF
--- a/sirepo/package_data/template/raydata/examples/chx.json
+++ b/sirepo/package_data/template/raydata/examples/chx.json
@@ -10,7 +10,7 @@
         "simulation": {
             "folder": "/Examples",
             "isExample": true,
-            "name": "XPCS SAXS Analysis"
+            "name": "CHX Analysis"
         },
         "catalog": {
             "catalogName": "chx"

--- a/sirepo/package_data/template/raydata/examples/csx.json
+++ b/sirepo/package_data/template/raydata/examples/csx.json
@@ -1,0 +1,33 @@
+{
+    "models": {
+        "analysisAnimation": {},
+        "inputFiles": {
+            "mask": null
+        },
+        "metadataColumns": {
+            "selected": []
+        },
+        "simulation": {
+            "folder": "/Examples",
+            "isExample": true,
+            "name": "CSX Analysis"
+        },
+        "catalog": {
+            "catalogName": "csx"
+        },
+        "executedScans": {
+            "searchStartTime": null,
+            "searchStopTime": null,
+            "scans": []
+        },
+        "queuedScans": {
+            "scans": []
+        },
+        "replay": {
+            "sourceCatalogName": null,
+            "destinationCatalogName": null,
+            "numScans": null
+        }
+    },
+    "simulationType": "raydata"
+}

--- a/sirepo/package_data/template/raydata/examples/xpcs-saxs.json
+++ b/sirepo/package_data/template/raydata/examples/xpcs-saxs.json
@@ -1,0 +1,33 @@
+{
+    "models": {
+        "analysisAnimation": {},
+        "inputFiles": {
+            "mask": null
+        },
+        "metadataColumns": {
+            "selected": []
+        },
+        "simulation": {
+            "folder": "/Examples",
+            "isExample": true,
+            "name": "XPCS SAXS Analysis"
+        },
+        "catalog": {
+            "catalogName": "chx"
+        },
+        "executedScans": {
+            "searchStartTime": null,
+            "searchStopTime": null,
+            "scans": []
+        },
+        "queuedScans": {
+            "scans": []
+        },
+        "replay": {
+            "sourceCatalog": null,
+            "destinationCatalog": null,
+            "numScans": null
+        }
+    },
+    "simulationType": "raydata"
+}


### PR DESCRIPTION
They previously lived in the private raydata repo. By moving them into Sirepo then Sirepo can create the raydata examples w/o being taught about a special place to look for them (ex package_path).