### PR TITLE
Fix #5003 remove version lock on pyIsEmail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ pykern.pksetup.setup(
         "futures",
         "numconv",
         "numpy",
-        "pyIsEmail==1.3.2",
+        "pyIsEmail",
         "pykern",
         "pytz",
         "requests",


### PR DESCRIPTION
pyIsEmail v2.0.1 should work as expected and v2.0.0 is now yanked so can't be installed without an explicit request. As such, we no longer need to lock to a lower version than the most current one.

Apologies for the bump!