### PR TITLE
Fix #5007 init_apis not called if supervisor

### DIFF
--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -109,11 +109,12 @@ def init_for_flask(app):
     app.add_url_rule("/", "_dispatch_empty", _dispatch_empty, methods=("GET", "POST"))
 
 
-def init_module(**imports):
+def init_module(want_apis, **imports):
     """Convert route map to dispatchable callables
 
     Initializes `_uri_to_route`
     """
+    global _uri_to_route
 
     def _api_modules():
         m = (
@@ -124,10 +125,13 @@ def init_module(**imports):
             return m + ("auth_role_moderation",)
         return m
 
-    if _uri_to_route:
+    if _uri_to_route is not None:
         return
     # import simulation_db
     sirepo.util.setattr_imports(imports)
+    if not want_apis:
+        _uri_to_route = PKDict()
+        return
     for n in _api_modules():
         register_api_module("sirepo." + n)
     _register_sim_api_modules()

--- a/tests/pkcli/admin_test.py
+++ b/tests/pkcli/admin_test.py
@@ -4,7 +4,6 @@
 :copyright: Copyright (c) 2021 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 import pytest
 
 


### PR DESCRIPTION
This is tricky, because quest.start calls modules.import_and_init always. This probably needs to be made more efficient, but that's how it was implemented. modules will not reinitialize if they have been already initialized. job_supervisor calls import_and_init first, which initializes uri_router without apis. When quest.start calls import_and_init('sirepo.auth'), it will be a no-op.