### PR TITLE
Fix #5007 guess: default flask.app.config.PROPAGATE_EXCEPTIONS to False

### DIFF
--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -748,7 +748,6 @@ def init_app(uwsgi=None, use_reloader=False, is_server=False):
         __name__,
         static_folder=None,
     )
-    _app.config["PROPAGATE_EXCEPTIONS"] = True
     _app.sirepo_uwsgi = uwsgi
     _app.sirepo_use_reloader = use_reloader
     for e, _ in simulation_db.SCHEMA_COMMON["customErrors"].items():


### PR DESCRIPTION
We were setting PROPAGATE_EXCEPTIONS, which doesn't seem right. It is for interactive debugging. The code for ctx popping looks at exceptions and doesn't pop contexts when exceptions are present. Not convinced this fixes it, but it's an attempt. It is not reproducible on dev.