### PR TITLE
Fix #5085 radia rotated shapes jump

### DIFF
--- a/sirepo/package_data/static/html/radia-source.html
+++ b/sirepo/package_data/static/html/radia-source.html
@@ -1,7 +1,7 @@
 <div class="container-fluid">
   <div data-ng-if="src.showDesigner()">
     <div class="row">
-        <div data-toolbar="src.toolbarSections" data-ng-show="src.isEditable()" data-parent-controller="src"></div>
+        <div data-toolbar="src.toolbarSections" data-parent-controller="src"></div>
     </div>
     <div>
         <div data-3d-builder="" data-model-name="geometryReport" data-cfg="src.builderCfg" data-controller="src"></div>

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -931,18 +931,13 @@ SIREPO.app.controller('RadiaSourceController', function (appState, geometry, pan
     }
 
     function rotateFn(xform, i) {
-        return function(shape1, shape2) {
+        return (shape1, shape2) => {
             const scale = SIREPO.APP_SCHEMA.constants.objectScale;
-            const ctr =  radiaService.scaledArray(xform.center, scale);
-            const axis =  radiaService.scaledArray(xform.axis, scale);
-            // need a 4-vector to account for translation
-            const shapeCtr4 = shape1.getCenterCoords();
-            shapeCtr4.push(0);
-            const angle = Math.PI * parseFloat(xform.angle) / 180.0;
-            const a = i * angle;
-            const m = geometry.rotationMatrix(ctr, axis, a);
-            shape2.setCenter(geometry.vectorMult(m, shapeCtr4));
-            shape2.rotationAngle = -180.0 * a / Math.PI;
+            shape2.rotationMatrix = new SIREPO.GEOMETRY.RotationMatrix(
+                radiaService.scaledArray(xform.axis, scale),
+                radiaService.scaledArray(xform.center, scale),
+                i * Math.PI * parseFloat(xform.angle) / 180.0
+            );
             return shape2;
         };
     }

--- a/sirepo/package_data/static/js/sirepo-geometry.js
+++ b/sirepo/package_data/static/js/sirepo-geometry.js
@@ -63,6 +63,15 @@ class GeometryUtils {
     }
 
     /**
+     * Normalize a vector
+     * @param {[number]} vector
+     * @returns {[number]}
+     */
+    static normalize(vector) {
+        return vector.map(c => c / Math.hypot(vector[0], vector[1], vector[2]));
+    }
+
+    /**
      * Sort (with optional reversal) the point array by the values in the given dimension.
      * Array is cloned first so the original is unchanged
      * @param {[Point]} points - the points to sort
@@ -465,14 +474,97 @@ class SquareMatrix extends Matrix {
         }
         return new SquareMatrix(m);
     }
+
 }
 
 /*
  * The 2-dimensional identity matrix
  */
 class IdentityMatrix extends SquareMatrix {
-    constructor() {
-        super([[1, 0, 0], [0, 1, 0], [0, 0, 1]]);
+    /**
+     * @param {number} size - number of rows/columms
+     */
+    constructor(size=3) {
+        const m = [];
+        for (let i = 0; i < size; ++i) {
+            const n = [];
+            for (let j = 0; j < size; ++j) {
+                n.push(i === j ? 1 : 0);
+            }
+            m.push(n);
+        }
+        super(m);
+    }
+}
+
+/*
+ * Rotation about arbitrary axis - note this is 4 x 4 and will need to multiply a vector [x, y, z, 0]
+ */
+class RotationMatrix extends SquareMatrix {
+
+    /**
+     * @param {[number]} axis - axis of rotation
+     * @param {[number]} point - a point that the axis contains
+     * @param {number} angle - rotation angle in radians
+     * @throws - if the number of rows and columns differ
+     */
+    constructor(axis, point, angle) {
+        const cs = Math.cos(angle);
+        const cs1 = 1 - cs;
+        const s = Math.sin(angle);
+
+        const A = point[0];
+        const B = point[1];
+        const C = point[2];
+
+        const nv = GeometryUtils.normalize(axis);
+        const u = nv[0];
+        const v = nv[1];
+        const w = nv[2];
+        const m = [
+            [
+                u * u + (v * v + w * w) * cs,
+                u * v * cs1 - w * s,
+                u * w * cs1 + v * s,
+                (A * (v * v + w * w) - u * (B * v + C * w)) * cs1 + (B * w - C * v) * s
+            ],
+            [
+                u * v * cs1 + w * s,
+                v * v + (u * u + w * w) * cs,
+                v * w * cs1 - u * s,
+                (B * (u * u + w * w) - v * (A * u + C * w)) * cs1 + (C * u - A * w) * s
+            ],
+            [
+                u * w * cs1 - v * s,
+                v * w * cs1 + u * s,
+                w * w + (u * u + v * v) * cs,
+                (C * (u * u + v * v) - w * (A * u + B * v)) * cs1 + (A * v - B * u) * s
+            ],
+            [0, 0, 0, 1]
+        ];
+        super(m);
+    }
+
+    toEuler(toDegrees=false) {
+        let theta = -Math.asin(this.val[2][0]);
+        const c = Math.cos(theta);
+        let psi = 0;
+        let phi = 0;
+        if (c === 0) {
+            if (this.val[2][0] === -1) {
+                theta = Math.PI / 2;
+                psi = phi + Math.atan2(this.val[0][1], this.val[0][0]);
+            }
+            else {
+                theta = -Math.PI / 2;
+                psi = -phi + Math.atan2(-this.val[0][1], -this.val[0][0]);
+            }
+        }
+        else {
+            psi = Math.atan2(this.val[2][1] / c, this.val[2][2] / c);
+            phi = Math.atan2(this.val[1][0] / c, this.val[0][0] / c);
+        }
+        return [psi, theta, phi].map(x => toDegrees ? 180.0 * x / Math.PI : x);
     }
 }
 
@@ -1772,43 +1864,6 @@ SIREPO.app.service('geometry', function(utilities) {
         });
     };
 
-    // for rotation about arbitrary axis - note this is 4 x 4 and will need to multiply a vector [x, y, z, 0]
-    this.rotationMatrix = function(pointCoords, vector, angle) {
-        var cs = Math.cos(angle);
-        var cs1 = 1 - cs;
-        var s = Math.sin(angle);
-
-        var A = pointCoords[0];
-        var B = pointCoords[1];
-        var C = pointCoords[2];
-
-        var nv = svc.normalize(vector);
-        var u = nv[0];
-        var v = nv[1];
-        var w = nv[2];
-        return [
-            [
-                u * u + (v * v + w * w) * cs,
-                u * v * cs1 - w * s,
-                u * w * cs1 + v * s,
-                (A * (v * v + w * w) - u * (B * v + C * w)) * cs1 + (B * w - C * v) * s
-            ],
-            [
-                u * v * cs1 + w * s,
-                v * v + (u * u + w * w) * cs,
-                v * w * cs1 - u * s,
-                (B * (u * u + w * w) - v * (A * u + C * w)) * cs1 + (C * u - A * w) * s
-            ],
-            [
-                u * w * cs1 - v * s,
-                v * w * cs1 + u * s,
-                w * w + (u * u + v * v) * cs,
-                (C * (u * u + v * v) - w * (A * u + B * v)) * cs1 + (A * v - B * u) * s
-            ],
-            [0, 0, 0, 1]
-        ];
-    };
-
     this.transform = function (matrix) {
 
         var identityMatrix = [
@@ -2081,6 +2136,7 @@ SIREPO.GEOMETRY = {
     Matrix: Matrix,
     Point: Point,
     Rect: Rect,
+    RotationMatrix: RotationMatrix,
     SquareMatrix: SquareMatrix,
     Transform: Transform,
 };

--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -2088,13 +2088,6 @@ SIREPO.app.directive('3dBuilder', function(appState, geometry, layoutService, pa
                 );
             }
 
-            function stringToFloatArray(str) {
-                return str.split(/\s*,\s*/)
-                    .map(function (v) {
-                        return objectScale * parseFloat(v);
-                    });
-            }
-
             function formatObjectLength(val) {
                 return utilities.roundToPlaces(invObjScale * val, 4);
             }
@@ -2137,6 +2130,25 @@ SIREPO.app.directive('3dBuilder', function(appState, geometry, layoutService, pa
                 var labDim = shape.elev[dim].axis;
                 return axes[dim].scale(shape.center[labDim]);
             }
+
+            function shapeRotation(shape) {
+                const e = shape.rotationMatrix.toEuler(true);
+                const angle = e[SIREPO.GEOMETRY.GeometryUtils.BASIS().indexOf(shape.elev.axis)];
+                const c = shape.getCenterCoords();
+                const rc = shape.rotationMatrix.multiply(
+                    new SIREPO.GEOMETRY.Matrix([...c, 0])
+                ).val;
+                const t = {x: 0, y: 0};
+                for (const dim in t) {
+                    const i = SIREPO.GEOMETRY.GeometryUtils.BASIS().indexOf(shape.elev[dim].axis);
+                    t[dim] = axes[dim].scale(rc[i]) - axes[dim].scale(c[i]);
+                }
+                return `
+                    rotate(${-angle},${shapeCenter(shape, 'x')},${shapeCenter(shape, 'y')}) 
+                    translate(${t.x},${t.y})
+                `;
+            }
+
 
             function linePoints(shape) {
                 if (! shape.line || shape.elev.coordPlane !== shape.coordPlane) {
@@ -2245,8 +2257,8 @@ SIREPO.app.directive('3dBuilder', function(appState, geometry, layoutService, pa
                         return d.strokeStyle === 'dashed' ? (d.dashes || "5,5") : "";
                     })
                     .attr('transform', function (d) {
-                        if (d.rotationAngle !== 0 && d.rotationAngle) {
-                            return `rotate(${d.rotationAngle},${shapeCenter(d, 'x')},${shapeCenter(d, 'y')})`;
+                        if (d.rotationMatrix) {
+                            return shapeRotation(d);
                         }
                         return '';
                     });


### PR DESCRIPTION
Notes:
- We now perform a translation on the svg shape instead of changing the object's center.
- This means that the "center" of the object does not change to reflect the new position - it is the pre-rotated center. This allows the user to drag the shape without it jumping
- Also fixes #5095 by supplying the full rotation matrix instead of a single angle
