### PR TITLE
fix radiasoft/raydata#38: loading indicator for scans table

### DIFF
--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -320,7 +320,10 @@ SIREPO.app.directive('scansTable', function() {
                     </tr>
                   </tbody>
                 </table>
-                <div ng-if="awaitingScans">Loading scans...</div>
+                <div style="height: 20px;">
+                  <div ng-if="awaitingScans" data-dots-animation="" data-text="Checking for new scans"></div>
+                  <div ng-if="noScansReturned">No matching scans returned.</div>
+                </div>
               </div>
             </div>
             <div data-column-picker="" data-title="Add Column" data-id="sr-columnPicker-editor" data-available-columns="availableColumns" data-save-column-changes="saveColumnChanges"></div>
@@ -365,6 +368,7 @@ SIREPO.app.directive('scansTable', function() {
             // POSIT: status + sirepo.template.raydata._DEFAULT_COLUMNS
             $scope.defaultColumns = ['status', 'start', 'stop', 'suid'];
             $scope.images = null;
+            $scope.noScansReturned = false;
             $scope.orderByColumn = 'start';
             $scope.reverseSortScans = false;
             $scope.scans = [];
@@ -419,11 +423,15 @@ SIREPO.app.directive('scansTable', function() {
                 }
                 function doRequest() {
                     $scope.awaitingScans = true;
+                    $scope.noScansReturned = false;
                     requestSender.sendStatelessCompute(
                         appState,
                         (json) => {
                             $scope.awaitingScans = false;
                             $scope.scans = json.data.scans.slice();
+                            if ($scope.scans.length === 0) {
+                                $scope.noScansReturned = true;
+                            }
                         },
                         {
                             method: 'scans',

--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -322,7 +322,7 @@ SIREPO.app.directive('scansTable', function() {
                 </table>
                 <div style="height: 20px;">
                   <div ng-if="awaitingScans" data-dots-animation="" data-text="Checking for new scans"></div>
-                  <div ng-if="noScansReturned">No matching scans returned.</div>
+                  <div ng-if="noScansReturned">No scans found</div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
> Just a thought - how about show "Checking for new scans..." where the "..." changes every second, . . ...
And when it finds a new one, it could change to "Fetching scan" for a second, or until the new scan is available, and then immediately change back to "Checking for new scans..."?

Had to make a change from @moellep's [comment](https://github.com/radiasoft/sirepo/pull/4977#discussion_r1014258261), the time interval for "Fetching scan" was so short that it wouldn't show at all. So for now "Checking for new scans..." is still popping up and disappearing. I'm open to more suggestions.