### PR TITLE
fix #5210 show existing reports when return to the visualization page

### DIFF
--- a/react/src/data/report.js
+++ b/react/src/data/report.js
@@ -1,4 +1,4 @@
-import { getSimulationFrame, pollRunReport } from "../utility/compute";
+import { getSimulationFrame, pollRunReport, runStatus } from "../utility/compute";
 import { v4 as uuidv4 } from 'uuid';
 
 export class ReportEventManager {
@@ -10,6 +10,29 @@ export class ReportEventManager {
         let reportListeners = this.reportEventListeners[report] || [];
         reportListeners.push(callback);
         this.reportEventListeners[report] = reportListeners;
+    }
+
+    runStatus = ({
+        appName,
+        models,
+        simulationId,
+        report,
+        callback,
+    }) => {
+        runStatus({
+            appName,
+            models,
+            simulationId,
+            report,
+            forceRun: false,
+            callback: (simulationData) => {
+                let reportListeners = this.reportEventListeners[report] || [];
+                for(let reportListener of reportListeners) {
+                    reportListener(simulationData);
+                }
+                callback(simulationData);
+            }
+        })
     }
 
     startReport = ({

--- a/react/src/hook/stopwatch.js
+++ b/react/src/hook/stopwatch.js
@@ -41,6 +41,11 @@ class Stopwatch {
     isComplete() {
         return this.times.startTime !== undefined && this.times.endTime !== undefined;
     }
+
+    setElapsedSeconds(seconds) {
+        this.times.endTime = new Date();
+        this.times.startTime = new Date(this.times.endTime.getTime() - 1000 * seconds);
+    }
 }
 
 export function useStopwatch() {

--- a/react/src/utility/component.js
+++ b/react/src/utility/component.js
@@ -48,24 +48,24 @@ function useRefSize(ref) {
         height: 1000,
     });
     useLayoutEffect(() => {
-        if (! ref || ! ref.current) {
+        if (! ref || ! ref.current || ! ref.current.offsetWidth) {
             return;
         }
         const handleResize = debounce(() => {
-            if (! ref || ! ref.current) {
-                return;
+            const w = Number.parseInt(ref.current.offsetWidth);
+            if (dim.width != w) {
+                setDim({
+                    width: w,
+                    height: Number.parseInt(ref.current.offsetHeight),
+                });
             }
-            setDim({
-                width: Number.parseInt(ref.current.offsetWidth),
-                height: Number.parseInt(ref.current.offsetHeight),
-            });
         }, 250);
         window.addEventListener('resize', handleResize);
         handleResize();
         return _ => {
             window.removeEventListener('resize', handleResize);
         };
-    }, [ref]);
+    });
     return [dim, setDim];
 }
 

--- a/react/src/utility/compute.js
+++ b/react/src/utility/compute.js
@@ -71,13 +71,30 @@ export function pollRunReport({ appName, models, simulationId, report, pollInter
         let { nextRequest, state } = respObj;
 
         callback(respObj);
-        
+
         if (!state || state === 'pending' || state === 'running') {
             setTimeout(() => doPoll(nextRequest).then(iterate), pollInterval);
         }
-    } 
+    }
 
     doFetch().then(iterate);
+}
+
+export function runStatus({ appName, models, simulationId, report, callback, forceRun }) {
+    let doStatus = () => fetch('/run-status', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            models,
+            forceRun,
+            report,
+            simulationId,
+            simulationType: appName
+        }),
+    });
+    doStatus().then(async lastResp => callback(await lastResp.json()));
 }
 
 export function cancelReport({ appName, models, simulationId, report }) {


### PR DESCRIPTION
- added compute.runStatus()
- add ReportEventManager.runStatus()
- added Stopwatch.setElapsedSeconds()
- call ReportEventManager.runStatus in SimulationStartLayout to determine if there is existing data to plot
- changed component.useRefSize() to recalculate anytime ref.current.offsetWidth changes, important for offscreen reports which have size 0 and then get rendered later