### PR TITLE
fix #5234, #5255: better report state handling

### DIFF
--- a/react/src/component/reusable/heatplot.tsx
+++ b/react/src/component/reusable/heatplot.tsx
@@ -29,9 +29,9 @@ function HeatplotImage({ xScaleDomain, yScaleDomain, xRange, yRange, width, heig
     let zmin = Math.min(...zMatrix.map(row => Math.min(...row)));
     let zmax = Math.max(...zMatrix.map(row => Math.max(...row)));
 
-    console.log(`zmin: ${zmin}, zmax: ${zmax}`);
+    //console.log(`zmin: ${zmin}, zmax: ${zmax}`);
 
-    let scaleZScalar = (v) => (v - zmin) / zmax;
+    let scaleZScalar = (v) => (v - zmin) / (zmax - zmin);
 
     for (let yi = cacheCanvas.height - 1, p = -1; yi >= 0; --yi) {
         for (let xi = 0; xi < cacheCanvas.width; ++xi) {

--- a/react/src/data/report.ts
+++ b/react/src/data/report.ts
@@ -87,7 +87,6 @@ export class ReportEventManager {
             models,
             simulationId,
             report,
-            pollInterval: 500,
             forceRun: true,
             callback: (simulationData) => {
                 this.handleSimulationData(report, simulationData);

--- a/react/src/data/report.ts
+++ b/react/src/data/report.ts
@@ -1,54 +1,77 @@
-import { getSimulationFrame, pollRunReport, runStatus } from "../utility/compute";
+import { getSimulationFrame, pollRunReport, ResponseHasState, getRunStatusOnce } from "../utility/compute";
 import { v4 as uuidv4 } from 'uuid';
 import React from "react";
 import { ModelStates } from "../store/models";
+import { mapProperties } from "../utility/object";
 
 export const CReportEventManager = React.createContext<ReportEventManager>(undefined);
 
-export type ReportEventSubscriber = (simulationData: any) => void;
+export type ReportEventSubscriber = {
+    /**
+     * Called once for every simulationData received (including during completion)
+     */
+    onReportData?: (simulationData: ResponseHasState) => void;
+    /**
+     * Called once when reports are starting to be generated
+     */
+    onStart?: () => void;
+    /**
+     * Called once when reports are finished being generated
+     */
+    onComplete?: () => void;
+}
+
+type RunStatusParams = {
+    appName: string,
+    models: ModelStates,
+    simulationId: string,
+    report: string
+}
 
 export class ReportEventManager {
-    reportEventListeners: {[reportName: string]: ReportEventSubscriber[]} = {}
+    reportEventListeners: {[reportName: string]: {[key: string]: ReportEventSubscriber}} = {}
 
-    constructor() {
-    }
-
-    onReportData = (reportName: string, callback: ReportEventSubscriber): void => {
-        let reportListeners = this.reportEventListeners[reportName] || [];
-        reportListeners.push(callback);
+    addListener = (key: string, reportName: string, listener: ReportEventSubscriber): void => {
+        let reportListeners = this.reportEventListeners[reportName] || {};
+        //reportListeners.push(callback);
+        reportListeners[key] = listener;
         this.reportEventListeners[reportName] = reportListeners;
     }
 
-    runStatus = ({
+    clearListenersForKey = (key: string) => {
+        this.reportEventListeners = mapProperties(this.reportEventListeners, (_, listeners) => Object.fromEntries(Object.entries(listeners).filter(([k,]) => k !== key)));
+    }
+
+    getListenersForReport: (report: string) => ReportEventSubscriber[] = (report: string) => {
+        return Object.entries(this.reportEventListeners[report] || {}).map(([, listener]) => listener);
+    }
+
+    handleSimulationData: (report: string, simulationData: ResponseHasState) => void = (report: string, simulationData: ResponseHasState) => {
+        this.getListenersForReport(report).forEach(l => l.onReportData && l.onReportData(simulationData));
+        if(simulationData.state === 'completed') {
+            this.getListenersForReport(report).forEach(l => l.onComplete && l.onComplete());
+        }
+    }
+
+    getRunStatusOnce: (params: RunStatusParams) => Promise<ResponseHasState> = ({
         appName,
         models,
         simulationId,
-        report,
-        callback,
-    }: {
-        appName: string,
-        models: ModelStates,
-        simulationId: string,
-        report: string,
-        callback: (resp: any) => void
+        report
     }) => {
-        runStatus({
+        return getRunStatusOnce({
             appName,
             models,
             simulationId,
             report,
-            forceRun: false,
-            callback: (simulationData) => {
-                let reportListeners = this.reportEventListeners[report] || [];
-                for(let reportListener of reportListeners) {
-                    reportListener(simulationData);
-                }
-                callback(simulationData);
-            }
+            forceRun: false
+        }).then(d => {
+            this.handleSimulationData(report, d)
+            return d;
         })
     }
 
-    startReport = ({
+    pollRunStatus = ({
         appName,
         models,
         simulationId,
@@ -67,11 +90,28 @@ export class ReportEventManager {
             pollInterval: 500,
             forceRun: true,
             callback: (simulationData) => {
-                let reportListeners = this.reportEventListeners[report] || [];
-                for(let reportListener of reportListeners) {
-                    reportListener(simulationData);
-                }
+                this.handleSimulationData(report, simulationData);
             }
+        })
+    }
+
+    startReport = ({
+        appName,
+        models,
+        simulationId,
+        report
+    }: {
+        appName: string,
+        models: ModelStates,
+        simulationId: string,
+        report: string
+    }) => {
+        this.getListenersForReport(report).forEach(l => l.onStart && l.onStart());
+        this.pollRunStatus({
+            appName,
+            models,
+            simulationId,
+            report
         })
     }
 }
@@ -96,6 +136,11 @@ function getFrameId({
     ]
 
     return frameIdElements.join('*');
+}
+
+export type SimulationFrame<T = unknown> = {
+    index: number,
+    data: T
 }
 
 // Note this accepts hookedFrameIdFields but provides no mechanism for updating them.
@@ -134,15 +179,20 @@ export class AnimationReader {
         this.presentationVersionNum = uuidv4();
     }
 
-    getFrame = (frameIndex) => {
+    getFrame = (frameIndex): Promise<SimulationFrame> => {
         if(frameIndex < 0 || frameIndex >= this.frameCount) {
             throw new Error(`frame index out of bounds: ${frameIndex}, frame count was ${this.frameCount}`)
         }
 
-        return getSimulationFrame(this.getFrameId(frameIndex));
+        return getSimulationFrame(this.getFrameId(frameIndex)).then(data => {
+            return {
+                index: frameIndex,
+                data
+            }
+        });
     }
 
-    getNextFrame = () => {
+    getNextFrame = (): Promise<SimulationFrame> => {
         return this.getFrame(this.nextFrameIndex++);
     }
 
@@ -154,7 +204,7 @@ export class AnimationReader {
         return this.nextFrameIndex - 2 >= 0;
     }
 
-    getPreviousFrame = () => {
+    getPreviousFrame = (): Promise<SimulationFrame> => {
         return this.getFrame((--this.nextFrameIndex) - 1);
     }
 
@@ -179,27 +229,27 @@ export class AnimationReader {
 
         let activePresentationVersion = this.presentationVersionNum;
 
-        if(direction == 'forward') {
+        if(direction === 'forward') {
             dir = 1;
-        } else if(direction == 'backward') {
+        } else if(direction === 'backward') {
             dir = -1;
         } else {
             throw new Error(`invalid direction for presentation: ${direction}`);
         }
 
         let handlePresentationFrame = (simulationData) => {
-            if(activePresentationVersion == this.presentationVersionNum) {
+            if(activePresentationVersion === this.presentationVersionNum) {
                 callback(simulationData);
             }
         }
 
         let itFuncs = {
-            hasNext: dir == 1 ? this.hasNextFrame : this.hasPreviousFrame,
-            next: dir == 1 ? this.getNextFrame : this.getPreviousFrame
+            hasNext: dir === 1 ? this.hasNextFrame : this.hasPreviousFrame,
+            next: dir === 1 ? this.getNextFrame : this.getPreviousFrame
         }
 
         let presentationInterval = setInterval(() => {
-            if(activePresentationVersion != this.presentationVersionNum) {
+            if(activePresentationVersion !== this.presentationVersionNum) {
                 clearInterval(presentationInterval);
                 return;
             }

--- a/react/src/layout/input/enum.tsx
+++ b/react/src/layout/input/enum.tsx
@@ -77,7 +77,6 @@ export class ComputeResultEnumInputLayout extends InputLayout<ComputeResultEnumC
             let enumOptionsPromise = new Promise((resolve, reject) => {
                 simulationInfoPromise.then(({simulationId, version}) => {
                     pollStatefulCompute({
-                        pollInterval: 500,
                         method: this.config.computeMethod,
                         appName,
                         simulationId,

--- a/react/src/layout/report.tsx
+++ b/react/src/layout/report.tsx
@@ -1,7 +1,7 @@
-import { useContext, useState, useRef, useEffect, useLayoutEffect } from "react";
+import { useContext, useState, useRef, useEffect } from "react";
 import { Dependency } from "../data/dependency";
 import { LayoutProps, Layout } from "./layout";
-import { cancelReport, pollRunReport, ResponseHasState, SrState } from "../utility/compute";
+import { cancelReport, pollRunReport, ResponseHasState } from "../utility/compute";
 import { v4 as uuidv4 } from 'uuid';
 import { useStore } from "react-redux";
 import { ProgressBar, Stack, Button } from "react-bootstrap";
@@ -73,7 +73,6 @@ export class AutoRunReportLayout extends Layout<AutoRunReportConfig, {}> {
                     models,
                     simulationId,
                     report: report,
-                    pollInterval: 2000,
                     forceRun: false,
                     callback: (simulationData) => {
                         // guard concurrency

--- a/react/src/layout/report.tsx
+++ b/react/src/layout/report.tsx
@@ -399,6 +399,7 @@ export class SimulationStartLayout extends Layout<SimulationStartConfig, {}> {
                         return (
                             <Stack gap={2}>
                                 <span><FontAwesomeIcon fixedWidth icon={Icon.faHourglass}/>{` Pending...`}</span>
+                                <ProgressBar animated now={100}/>
                                 {endSimulationButton}
                             </Stack>
                         )
@@ -406,7 +407,7 @@ export class SimulationStartLayout extends Layout<SimulationStartConfig, {}> {
                         return (
                             <Stack gap={2}>
                                 <span>{`Running`}</span>
-                                <ProgressBar animated now={(simState.percentComplete !== undefined) ? simState.percentComplete : 0}></ProgressBar>
+                                <ProgressBar animated now={Math.max((simState.percentComplete !== undefined) ? simState.percentComplete : 100, 5)}/>
                                 {endSimulationButton}
                             </Stack>
                         )

--- a/react/src/layout/report.tsx
+++ b/react/src/layout/report.tsx
@@ -1,14 +1,14 @@
-import { useContext, useState, useRef, useEffect } from "react";
+import { useContext, useState, useRef, useEffect, useLayoutEffect } from "react";
 import { Dependency } from "../data/dependency";
 import { LayoutProps, Layout } from "./layout";
-import { cancelReport, pollRunReport } from "../utility/compute";
+import { cancelReport, pollRunReport, ResponseHasState, SrState } from "../utility/compute";
 import { v4 as uuidv4 } from 'uuid';
 import { useStore } from "react-redux";
 import { ProgressBar, Stack, Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as Icon from "@fortawesome/free-solid-svg-icons";
 import { useStopwatch } from "../hook/stopwatch";
-import { AnimationReader, CReportEventManager } from "../data/report";
+import { AnimationReader, CReportEventManager, SimulationFrame } from "../data/report";
 import { useShown } from "../hook/shown";
 import React from "react";
 import { CPanelController } from "../data/panel";
@@ -73,7 +73,7 @@ export class AutoRunReportLayout extends Layout<AutoRunReportConfig, {}> {
                     models,
                     simulationId,
                     report: report,
-                    pollInterval: 500,
+                    pollInterval: 2000,
                     forceRun: false,
                     callback: (simulationData) => {
                         // guard concurrency
@@ -140,39 +140,53 @@ export class ManualRunReportLayout extends Layout<ManualRunReportConfig, {}> {
 
         let frameIdAccessor = new ModelsAccessor(modelsWrapper, frameIdDependencies);
 
-        let [animationReader, updateAnimationReader] = useState(undefined);
+        let [animationReader, updateAnimationReader] = useState<AnimationReader>(undefined);
 
         useEffect(() => {
             panelController.setShown(false);
         }, [0])
 
         useEffect(() => {
-            let reportEventsVersion = uuidv4();
-            reportEventsVersionRef.current = reportEventsVersion;
-
-            reportEventManager.onReportData(reportGroupName, (simulationData) => {
-                if(reportEventsVersionRef.current !== reportEventsVersion) {
-                    return; // guard against concurrency with older versions
-                }
-
-                let { state } = simulationData;
-                if(state === "completed") {
+            reportEventManager.addListener(reportEventsVersionRef.current, reportGroupName, {
+                onStart: () => {
+                    updateAnimationReader(undefined);
+                    panelController.setShown(false);
+                },
+                onReportData: (simulationData: ResponseHasState) => {
                     simulationInfoPromise.then(({simulationId}) => {
                         let { computeJobHash, computeJobSerial } = simulationData;
-                        let frameCount = !!frameCountFieldName ? simulationData[frameCountFieldName] : 1;
-                        let animationReader = new AnimationReader({
-                            reportName,
-                            simulationId,
-                            appName,
-                            computeJobSerial,
-                            computeJobHash,
-                            frameIdValues: frameIdAccessor.getValues().map(fv => fv.value),
-                            frameCount
-                        })
-                        updateAnimationReader(animationReader);
+                        let frameCount = frameCountFieldName ? simulationData[frameCountFieldName] : (simulationData.state === 'completed' ? 1 : 0);
+                        if(frameCount !== animationReader?.frameCount) {
+                            if(frameCount > 0) {
+                                let newAnimationReader = new AnimationReader({
+                                    reportName,
+                                    simulationId,
+                                    appName,
+                                    computeJobSerial,
+                                    computeJobHash,
+                                    frameIdValues: frameIdAccessor.getValues().map(fv => fv.value),
+                                    frameCount
+                                })
+
+                                /*// if the reader is at the old end or was not previously defined
+                                if(!animationReader || animationReader.nextFrameIndex >= animationReader.frameCount - 1) {
+                                    // seek end
+                                    console.log("seeking end");
+                                    newAnimationReader.seekEnd();
+                                } else {
+                                    console.log(`seeking same; next=${animationReader.nextFrameIndex} oldcount=${animationReader.frameCount} newcount=${newAnimationReader.frameCount}`);
+                                    newAnimationReader.seekFrame(animationReader.nextFrameIndex);
+                                }*/
+                                
+                                updateAnimationReader(newAnimationReader);
+                            } else {
+                                updateAnimationReader(undefined);
+                            }
+                        }
                     })
                 }
             })
+            return () => reportEventManager.clearListenersForKey(reportEventsVersionRef.current);
         })
 
         // set the key as the key for the latest request sent to make a brand new report component for each new request data
@@ -189,21 +203,20 @@ export function ReportAnimationController(props: { animationReader: AnimationRea
 
     let panelController = useContext(CPanelController);
 
-    let [currentReportData, updateCurrentReportData] = useState(undefined);
+    let [currentFrame, updateCurrentFrame] = useState<SimulationFrame>(undefined);
 
-    let reportDataCallback = (simulationData) => updateCurrentReportData(simulationData);
+    let reportDataCallback = (simulationData) => updateCurrentFrame(simulationData);
     let presentationIntervalMs = 1000;
 
     useEffect(() => {
-        if(currentReportData === undefined) {
-            animationReader.getNextFrame().then(reportDataCallback);
-        }
-    }, [0])
+        animationReader.seekEnd();
+        animationReader.getNextFrame().then(reportDataCallback);
+    }, [animationReader?.frameCount])
 
     useEffect(() => {
-        let s = shown && !!currentReportData && reportLayout.canShow(currentReportData);
+        let s = animationReader && animationReader.frameCount > 0 && shown && !!currentFrame && reportLayout.canShow(currentFrame?.data);
         panelController.setShown(s);
-    }, [shown, !!currentReportData])
+    }, [shown, !!currentFrame, animationReader?.frameCount])
 
     let animationControlButtons = (
         <div className="d-flex flex-row justify-content-center w-100">
@@ -243,13 +256,13 @@ export function ReportAnimationController(props: { animationReader: AnimationRea
     )
 
     let LayoutComponent = reportLayout.component;
-    let canShowReport = reportLayout.canShow(currentReportData);
-    let reportLayoutConfig = reportLayout.getConfigFromApiResponse(currentReportData);
+    let canShowReport = reportLayout.canShow(currentFrame?.data);
+    let reportLayoutConfig = reportLayout.getConfigFromApiResponse(currentFrame?.data);
 
     return (
         <>
             {
-                canShowReport && shown && currentReportData && (
+                canShowReport && shown && currentFrame && (
                     <>
                         <LayoutComponent data={reportLayoutConfig}/>
                         {animationReader.getFrameCount() > 1 && animationControlButtons}
@@ -291,46 +304,60 @@ export class SimulationStartLayout extends Layout<SimulationStartConfig, {}> {
         let store = useStore();
 
 
-        let [lastSimulationData, updateLastSimulationData] = useState(undefined);
+        let [lastSimState, updateSimState] = useState<ResponseHasState>(undefined);
         let stopwatch = useStopwatch();
 
         let simulationPollingVersionRef = useRef(uuidv4())
 
+        let listenForReportData = () => {
+            reportEventManager.addListener(simulationPollingVersionRef.current, reportGroupName, {
+                onStart: () => {
+                    updateSimState(undefined);
+                    stopwatch.reset();
+                    stopwatch.start();
+                },
+                onReportData: (simulationData: ResponseHasState) => {
+                    updateSimState(simulationData);
+                },
+                onComplete: () => {
+                    stopwatch.stop();
+                }
+            })
+        }
 
         useEffect(() => {
-            simulationInfoPromise.then(({ models, simulationId, simulationType, version }) => {
-
-                simulationInfoPromise.then(({simulationId}) => {
-                    reportEventManager.runStatus({
-                        appName,
-                        models: getModelValues(modelNames, modelsWrapper, store.getState()),
-                        simulationId,
-                        report: reportGroupName,
-                        callback: (simulationData) => {
-                            if (simulationData.state === 'completed') {
-                                stopwatch.setElapsedSeconds(simulationData.elapsedTime);
-                                updateLastSimulationData(simulationData);
-                            }
-                        }
-                    })
+            // recover from previous runs on server
+            simulationInfoPromise.then(({simulationId}) => {
+                let models = getModelValues(modelNames, modelsWrapper, store.getState());
+                reportEventManager.getRunStatusOnce({
+                    appName,
+                    models,
+                    simulationId,
+                    report: reportGroupName
+                }).then(simulationData => {
+                    // catch running reports after page refresh
+                    updateSimState(simulationData);
+                    if (simulationData.state === 'running') {
+                        listenForReportData();
+                        reportEventManager.pollRunStatus({
+                            appName,
+                            models,
+                            simulationId,
+                            report: reportGroupName
+                        })
+                    }
+                    if (simulationData.elapsedTime) {
+                        stopwatch.setElapsedSeconds(simulationData.elapsedTime);
+                    }
                 })
-            });
+            })
+
+            return () => reportEventManager.clearListenersForKey(simulationPollingVersionRef.current);
         }, []);
 
 
         let startSimulation = () => {
-            updateLastSimulationData(undefined);
-            stopwatch.reset();
-            stopwatch.start();
-            let pollingVersion = uuidv4();
-            simulationPollingVersionRef.current = pollingVersion;
-
-            reportEventManager.onReportData(reportGroupName, (simulationData) => {
-                if(simulationPollingVersionRef.current === pollingVersion) {
-                    updateLastSimulationData(simulationData);
-                    stopwatch.stop();
-                }
-            })
+            listenForReportData();
 
             simulationInfoPromise.then(({simulationId}) => {
                 reportEventManager.startReport({
@@ -343,7 +370,7 @@ export class SimulationStartLayout extends Layout<SimulationStartConfig, {}> {
         }
 
         let endSimulation = () => {
-            updateLastSimulationData(undefined);
+            updateSimState(undefined);
             stopwatch.reset();
             simulationPollingVersionRef.current = uuidv4();
 
@@ -365,12 +392,10 @@ export class SimulationStartLayout extends Layout<SimulationStartConfig, {}> {
             return <Component></Component>
         });
 
-        if(lastSimulationData) {
-            let { state } = lastSimulationData;
+        if(lastSimState) {
             let elapsedTimeSeconds = stopwatch.isComplete() ? Math.ceil(stopwatch.getElapsedSeconds()) : undefined;
-            let getStateBasedElement = (state) => {
-
-                switch(state) {
+            let getStateBasedElement = (simState: ResponseHasState) => {
+                switch(simState.state) {
                     case 'pending':
                         return (
                             <Stack gap={2}>
@@ -382,7 +407,7 @@ export class SimulationStartLayout extends Layout<SimulationStartConfig, {}> {
                         return (
                             <Stack gap={2}>
                                 <span>{`Running`}</span>
-                                <ProgressBar animated now={100}></ProgressBar>
+                                <ProgressBar animated now={(simState.percentComplete !== undefined) ? simState.percentComplete : 0}></ProgressBar>
                                 {endSimulationButton}
                             </Stack>
                         )
@@ -395,7 +420,16 @@ export class SimulationStartLayout extends Layout<SimulationStartConfig, {}> {
                                 {startSimulationButton}
                             </Stack>
                         )
+                    case 'canceled':
+                        return (
+                            <Stack gap={2}>
+                                <span>{'Simulation Canceled'}</span>
+                                <div>{children}</div>
+                                {startSimulationButton}
+                            </Stack>
+                        )
                     case 'error':
+                    case 'srException':
                         return (
                             <Stack gap={2}>
                                 <span>{'Simulation Error'}</span>
@@ -404,12 +438,14 @@ export class SimulationStartLayout extends Layout<SimulationStartConfig, {}> {
                                 {startSimulationButton}
                             </Stack>
                         )
+                    case 'missing':
+                        return <>{startSimulationButton}</>
                 }
-                throw new Error("state was not handled for run-status: " + state);
+                throw new Error(`state was not handled for run-status: ${simState.state}`);
             }
 
             return (
-                <>{getStateBasedElement(state)}</>
+                <>{getStateBasedElement(lastSimState)}</>
             )
         }
         return (<>


### PR DESCRIPTION
also fixes:
- reports will 'carry on' polling and showing status after refresh
- heatplots do their min/max math correctly now
- reports will seek latest frame on refresh
- theres a WIP type for the status returned by requests like run-status
- additional states can be handled by the start simulation layout like missing and error