### PR TITLE
Fix #5283 - copy begin, end points

### DIFF
--- a/sirepo/package_data/template/radia/radia_export.py.jinja
+++ b/sirepo/package_data/template/radia/radia_export.py.jinja
@@ -184,9 +184,10 @@ field_points = {{ fieldPoints }}
 {% endif %}
 
 {% for fp in fieldPaths %}
-{% if fp["type"] == "line" %}
-p1 = [{{ fp["begin"] }}]
-p2 = [{{ fp["end"] }}]
+{% if fp.type == "line" or fp.type == "axis" %}
+# {{ fp.name }}
+p1 = {{ fp.begin }}
+p2 = {{ fp.end }}
 {% for fieldType in INTEGRABLE_FIELD_TYPES %}
 {{ fieldType.lower() }} = field_integral(g_id, "{{ fieldType }}", p1, p2)
 {% endfor %}

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -450,8 +450,8 @@ def _build_field_points(paths):
 
 
 def _build_field_line_pts(f_path):
-    p1 = f_path.begin
-    p2 = f_path.end
+    p1 = list(f_path.begin)
+    p2 = list(f_path.end)
     res = p1
     r = range(len(p1))
     n = int(f_path.numPoints) - 1


### PR DESCRIPTION
_build_field_line_pts was modifying the start point of the path; this uses copies instead. The jinja also had unnecessary brackets around the start and end points.