### PR TITLE
Fix #4882 Remove werkzeug exceptions

### DIFF
--- a/etc/run-auth-basic.sh
+++ b/etc/run-auth-basic.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -eou pipefail
+# go to the run directory
+_uid=$(cd "$(dirname "$0")"/../run/user && ls -d ???????? | head -1)
+echo "using uid=$_uid"
+export PYKERN_PKDEBUG_WANT_PID_TIME=1
+export SIREPO_AUTH_BASIC_PASSWORD=password
+export SIREPO_AUTH_BASIC_UID=$_uid
+export SIREPO_AUTH_METHODS=email:basic
+export SIREPO_FEATURE_CONFIG_API_MODULES=status
+cat <<EOF
+To test:
+
+curl -u "$_uid:$SIREPO_AUTH_BASIC_PASSWORD" http://localhost:8000/server-status
+
+EOF
+exec sirepo service http

--- a/etc/run-auth-bluesky.sh
+++ b/etc/run-auth-bluesky.sh
@@ -1,19 +1,6 @@
 #!/bin/bash
 set -eou pipefail
-# See run-auth-moderate.sh for using local mail delivery.
-# This echo's the URL to the logs (SIREPO_SMTP_SERVER=dev)
-export SIREPO_AUTH_BLUESKY_SECRET=bluesky-secret
-export SIREPO_AUTH_METHODS=email:bluesky
-export SIREPO_FROM_EMAIL=support@radiasoft.net
-export SIREPO_FROM_NAME='RadiaSoft Support'
-export SIREPO_SMTP_PASSWORD=vagrant
-# POSIT: same as sirepo.smtp.DEV_SMTP_SERVER
-export SIREPO_SMTP_SERVER=dev
-export SIREPO_SMTP_USER=vagrant
-cat <<EOF
-To test, you need a simulation:
 
-curl -H 'Content-Type: application/json' -D - -X POST http://localhost:8000/auth-bluesky-login -d '{"simulationId": "kRfyDC2q", "simulationType": "srw"}'
-
-EOF
-exec sirepo service http
+SIREPO_AUTH_METHODS=bluesky \
+    SIREPO_AUTH_BLUESKY_SECRET=bluesky \
+    bash -l etc/run-jupyterhub.sh

--- a/etc/run-auth-bluesky.sh
+++ b/etc/run-auth-bluesky.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eou pipefail
+# See run-auth-moderate.sh for using local mail delivery.
+# This echo's the URL to the logs (SIREPO_SMTP_SERVER=dev)
+export SIREPO_AUTH_BLUESKY_SECRET=bluesky-secret
+export SIREPO_AUTH_METHODS=email:bluesky
+export SIREPO_FROM_EMAIL=support@radiasoft.net
+export SIREPO_FROM_NAME='RadiaSoft Support'
+export SIREPO_SMTP_PASSWORD=vagrant
+# POSIT: same as sirepo.smtp.DEV_SMTP_SERVER
+export SIREPO_SMTP_SERVER=dev
+export SIREPO_SMTP_USER=vagrant
+cat <<EOF
+To test, you need a simulation:
+
+curl -H 'Content-Type: application/json' -D - -X POST http://localhost:8000/auth-bluesky-login -d '{"simulationId": "kRfyDC2q", "simulationType": "srw"}'
+
+EOF
+exec sirepo service http

--- a/etc/run-auth-bluesky.sh
+++ b/etc/run-auth-bluesky.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -eou pipefail
+export PYKERN_PKDEBUG_WANT_PID_TIME=1
+export SIREPO_AUTH_BLUESKY_SECRET=bluesky-secret
+export SIREPO_AUTH_METHODS=email:bluesky
+export SIREPO_FROM_EMAIL=$USER+support@localhost.localdomain
+export SIREPO_FROM_NAME='RadiaSoft Support'
+# POSIT: same as sirepo.smtp.DEV_SMTP_SERVER
+export SIREPO_SMTP_SERVER='dev'
+export SIREPO_SMTP_SERVER=localhost
+export SIREPO_SMTP_USER='vagrant'
+cat <<EOF
+To test, you need a sim, but this is the structure:
 
-SIREPO_AUTH_METHODS=bluesky \
-    SIREPO_AUTH_BLUESKY_SECRET=bluesky \
-    bash -l etc/run-jupyterhub.sh
+curl -H 'Content-Type: application/json' -D - -X POST http://localhost:8000/auth-bluesky-login -d '{"simulationId": "kRfyDC2q", "simulationType": "srw"}'
+
+EOF
+exec sirepo service http

--- a/etc/run-bluesky.sh
+++ b/etc/run-bluesky.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -eou pipefail
-
-SIREPO_AUTH_METHODS=bluesky \
-    SIREPO_AUTH_BLUESKY_SECRET=bluesky \
-    bash -l etc/run-jupyterhub.sh

--- a/sirepo/api_auth.py
+++ b/sirepo/api_auth.py
@@ -46,7 +46,7 @@ def check_api_call(qcall, func):
         pass
     elif expect == a.INTERNAL_TEST:
         if not pkconfig.channel_in_internal_test():
-            sirepo.util.raise_forbidden("Only available in internal test")
+            raise sirepo.util.Forbidden("Only available in internal test")
     elif expect in (a.ALLOW_COOKIELESS_SET_USER, a.ALLOW_COOKIELESS_REQUIRE_USER):
         qcall.cookie.set_sentinel()
         if expect == a.ALLOW_COOKIELESS_REQUIRE_USER:

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -171,7 +171,7 @@ class _Auth(sirepo.quest.Attr):
             oauth.raise_authorize_redirect(self.qcall, sirepo.auth_role.sim_type(r))
         if r in sirepo.auth_role.for_moderated_sim_types():
             auth_role_moderation.raise_control_for_user(self.qcall, u, r, t)
-        sirepo.util.raise_forbidden(f"uid={u} does not have access to sim_type={t}")
+        raise sirepo.util.Forbidden(f"uid={u} does not have access to sim_type={t}")
 
     def complete_registration(self, name=None):
         """Update the database with the user's display_name and sets state to logged-in.
@@ -457,7 +457,7 @@ class _Auth(sirepo.quest.Attr):
         if not self.qcall.auth_db.model("UserRole").has_role(
             role=sirepo.auth_role.ROLE_ADM,
         ):
-            sirepo.util.raise_forbidden(f"uid={u} role=ROLE_ADM not found")
+            raise sirepo.util.Forbidden(f"uid={u} role=ROLE_ADM not found")
 
     def require_auth_basic(self):
         m = _METHOD_MODULES["basic"]
@@ -472,7 +472,7 @@ class _Auth(sirepo.quest.Attr):
         i = self.require_user()
         m = self._qcall_bound_method()
         if m != METHOD_EMAIL:
-            sirepo.util.raise_forbidden(f"method={m} is not email for uid={i}")
+            raise sirepo.util.Forbidden(f"method={m} is not email for uid={i}")
 
     def require_user(self):
         """Asserts whether user is logged in

--- a/sirepo/auth/bluesky.py
+++ b/sirepo/auth/bluesky.py
@@ -68,7 +68,7 @@ def auth_hash(http_post, verify=False):
     now = int(time.time())
     if not "authNonce" in http_post:
         if verify:
-            util.raise_unauthorized("authNonce: missing field in request")
+            raise util.Unauthorized("authNonce: missing field in request")
         http_post.authNonce = str(now) + _AUTH_NONCE_SEPARATOR + util.random_base62()
     h = hashlib.sha256()
     h.update(
@@ -90,7 +90,7 @@ def auth_hash(http_post, verify=False):
         http_post.authHash = res
         return
     if res != http_post.authHash:
-        util.raise_unauthorized(
+        raise util.Unauthorized(
             "{}: hash mismatch expected={} nonce={}",
             http_post.authHash,
             res,
@@ -100,14 +100,14 @@ def auth_hash(http_post, verify=False):
     try:
         t = int(t)
     except ValueError as e:
-        util.raise_unauthorized(
+        raise util.Unauthorized(
             "{}: auth_nonce prefix not an int: nonce={}",
             t,
             http_post.authNonce,
         )
     delta = now - t
     if abs(delta) > _AUTH_NONCE_REPLAY_SECS:
-        util.raise_unauthorized(
+        raise util.Unauthorized(
             "{}: auth_nonce time outside replay window={} now={} nonce={}",
             t,
             _AUTH_NONCE_REPLAY_SECS,

--- a/sirepo/auth/email.py
+++ b/sirepo/auth/email.py
@@ -42,7 +42,7 @@ class API(sirepo.quest.API):
         Token must exist in db and not be expired.
         """
         if self.sreq.is_spider():
-            sirepo.util.raise_forbidden("robots not allowed")
+            raise sirepo.util.Forbidden("robots not allowed")
         req = self.parse_params(type=simulation_type)
         with sirepo.util.THREAD_LOCK:
             m = self.auth_db.model(UserModel)

--- a/sirepo/auth_role_moderation.py
+++ b/sirepo/auth_role_moderation.py
@@ -169,7 +169,7 @@ def raise_control_for_user(qcall, uid, role, sim_type):
     if s in _ACTIVE:
         raise sirepo.util.SRException("moderationPending", PKDict(sim_type=sim_type))
     if s == sirepo.auth_role.ModerationStatus.DENY:
-        sirepo.util.raise_forbidden(f"uid={uid} role={role} already denied")
+        raise sirepo.util.Forbidden(f"uid={uid} role={role} already denied")
     assert s is None, f"Unexpected status={s} for uid={uid} and role={role}"
     qcall.auth.require_email_user()
     raise sirepo.util.SRException("moderationRequest", PKDict(sim_type=sim_type))

--- a/sirepo/http_reply.py
+++ b/sirepo/http_reply.py
@@ -344,6 +344,10 @@ def _gen_exception_reply(qcall, exc):
     return f(qcall, exc.sr_args)
 
 
+def _gen_exception_reply_BadRequest(qcall, args):
+    return _gen_http_exception(400)
+
+
 def _gen_exception_reply_Error(qcall, args):
     try:
         t = qcall.sim_type_uget(args.pkdel("sim_type"))

--- a/sirepo/http_reply.py
+++ b/sirepo/http_reply.py
@@ -48,6 +48,14 @@ _SUBPROCESS_ERROR_RE = re.compile(
 _RELOAD_JS_ROUTES = None
 
 
+# HTTP/1.0 401 UNAUTHORIZED
+# WWW-Authenticate: Basic realm="*"
+# Content-Type: text/html; charset=utf-8
+# X-Sirepo-UserAgentId: None
+# Access-Control-Allow-Origin: *
+# Content-Length: 0
+
+
 def gen_exception(qcall, exc):
     """Generate from an Exception
 

--- a/sirepo/http_reply.py
+++ b/sirepo/http_reply.py
@@ -20,7 +20,6 @@ import sirepo.http_request
 import sirepo.resource
 import sirepo.uri
 import sirepo.util
-import werkzeug.exceptions
 
 
 #: data.state for srException
@@ -61,8 +60,6 @@ def gen_exception(qcall, exc):
     # to the server, which will have code to handle this case.
     if isinstance(exc, sirepo.util.Reply):
         return _gen_exception_reply(qcall, exc)
-    if isinstance(exc, werkzeug.exceptions.HTTPException):
-        return _gen_exception_werkzeug(qcall, exc)
     return _gen_exception_error(qcall, exc)
 
 
@@ -471,10 +468,6 @@ def _gen_exception_reply_WWWAuthenticate(qcall, args):
         status=401,
         headers={"WWW-Authenticate": 'Basic realm="*"'},
     )
-
-
-def _gen_exception_werkzeug(qcall, exc):
-    raise exc
 
 
 def _gen_http_exception(code):

--- a/sirepo/http_request.py
+++ b/sirepo/http_request.py
@@ -23,7 +23,7 @@ def parse_json(qcall):
     if d:
         return d
     if not qcall.sreq.content_type_eq("application/json"):
-        sirepo.util.raise_bad_request(
+        raise sirepo.util.BadRequest(
             "Content-Type={} must be application/json",
             qcall.sreq.header_uget("Content-Type"),
         )

--- a/sirepo/http_request.py
+++ b/sirepo/http_request.py
@@ -108,6 +108,6 @@ def parse_post(qcall, kwargs):
         kwargs.pkdel("check_sim_exists")
         and not simulation_db.sim_data_file(res.type, res.id, qcall=qcall).exists()
     ):
-        sirepo.util.raise_not_found("type={} sid={} does not exist", res.type, res.id)
+        raise sirepo.util.NotFound("type={} sid={} does not exist", res.type, res.id)
     assert not kwargs, "unexpected kwargs={}".format(kwargs)
     return res

--- a/sirepo/importer.py
+++ b/sirepo/importer.py
@@ -27,7 +27,7 @@ def do_form(form, qcall):
     from sirepo import simulation_db
 
     if not "zip" in form:
-        sirepo.util.raise_not_found("missing zip in form")
+        raise sirepo.util.NotFound("missing zip in form")
     data = read_zip(base64.decodebytes(pkcompat.to_bytes(form["zip"])), qcall)
     data.models.simulation.folder = "/Import"
     data.models.simulation.isExample = False

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -105,7 +105,7 @@ class API(sirepo.quest.API):
             finally:
                 if t:
                     pykern.pkio.unchecked_remove(t)
-            raise sirepo.util.raise_not_found(
+            raise sirepo.util.NotFound(
                 f"frame={frame} not found sid={req.id} sim_type={req.type}",
             )
 

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -663,7 +663,7 @@ class _ComputeJob(_Supervisor):
 
     def _raise_if_purged_or_missing(self, req):
         if self.db.status in (job.MISSING, job.JOB_RUN_PURGED):
-            sirepo.util.raise_not_found("purged or missing {}", req)
+            raise sirepo.util.NotFound("purged or missing {}", req)
 
     async def _receive_api_analysisJob(self, req):
         return await self._send_op_analysis(req, "analysis_job")
@@ -828,7 +828,7 @@ class _ComputeJob(_Supervisor):
 
     async def _receive_api_simulationFrame(self, req):
         if not self._req_is_valid(req):
-            sirepo.util.raise_not_found("invalid req={}", req)
+            raise sirepo.util.NotFound("invalid req={}", req)
         self._raise_if_purged_or_missing(req)
         return await self._send_op_analysis(req, "get_simulation_frame")
 
@@ -845,7 +845,7 @@ class _ComputeJob(_Supervisor):
         r = req.content.get("jobRunMode", self.db.jobRunMode)
         if r not in sirepo.simulation_db.JOB_RUN_MODE_MAP:
             # happens only when config changes, and only when sbatch is missing
-            sirepo.util.raise_not_found("invalid jobRunMode={} req={}", r, req)
+            raise sirepo.util.NotFound("invalid jobRunMode={} req={}", r, req)
         k = (
             job.PARALLEL
             if self.db.isParallel and opName != job.OP_ANALYSIS

--- a/sirepo/oauth.py
+++ b/sirepo/oauth.py
@@ -41,7 +41,7 @@ def check_authorized_callback(qcall, github_auth=False):
         return c, t
     except Exception as e:
         pkdlog("url={} exception={} stack={}", qcall.sreq.http_request_uri, e, pkdexc())
-    sirepo.util.raise_forbidden(f"user denied access from sim_type={t}")
+    raise sirepo.util.Forbidden(f"user denied access from sim_type={t}")
 
 
 def raise_authorize_redirect(qcall, sim_type, github_auth=False):

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -34,13 +34,14 @@ import socket
 import socket
 import subprocess
 import time
-import werkzeug.serving
 
 
 __cfg = None
 
 
 def flask():
+    from werkzeug import serving
+
     with pkio.save_chdir(_run_dir()) as r:
         sirepo.pkcli.setup_dev.default_command()
         # above will throw better assertion, but just in case
@@ -52,7 +53,7 @@ def flask():
         # avoid WARNING: Do not use the development server in a production environment.
         app.env = "development"
 
-        werkzeug.serving.click = None
+        serving.click = None
         app.run(
             exclude_patterns=[str(r.join("*"))],
             extra_files=sirepo.util.files_to_watch_for_reload("json"),

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -58,6 +58,7 @@ def flask():
             extra_files=sirepo.util.files_to_watch_for_reload("json"),
             host=_cfg().ip,
             port=_cfg().port,
+            reloader_type="stat",
             threaded=True,
             use_reloader=_cfg().use_reloader,
         )

--- a/sirepo/request.py
+++ b/sirepo/request.py
@@ -43,6 +43,9 @@ class _Request(sirepo.quest.Attr):
         return self.__content_type().get("charset")
 
     def content_type_eq(self, value):
+        c = self.__content_type()._key
+        if c is None:
+            return False
         return self.__content_type()._key.lower() == value.lower()
 
     def header_uget(self, key):

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -142,7 +142,7 @@ class API(sirepo.quest.API):
             return self.reply_attachment(p, filename=n)
         except Exception as e:
             if pkio.exception_is_not_found(e):
-                sirepo.util.raise_not_found("lib_file={} not found", p)
+                raise sirepo.util.NotFound("lib_file={} not found", p)
             raise
 
     @sirepo.quest.Spec("allow_visitor", spec="ErrorLoggingSpec")
@@ -189,7 +189,7 @@ class API(sirepo.quest.API):
 
     @sirepo.quest.Spec("allow_visitor")
     def api_forbidden(self):
-        sirepo.util.raise_forbidden("app forced forbidden")
+        raise sirepo.util.Forbidden("app forced forbidden")
 
     @sirepo.quest.Spec(
         "require_user",
@@ -252,7 +252,7 @@ class API(sirepo.quest.API):
                 )
                 break
             else:
-                sirepo.util.raise_not_found(
+                raise sirepo.util.NotFound(
                     "simulation not found by name={} type={}",
                     simulation_name,
                     req.type,
@@ -375,7 +375,7 @@ class API(sirepo.quest.API):
         def _data(req):
             f = getattr(req.template, "export_jupyter_notebook", None)
             if not f:
-                sirepo.util.raise_not_found(f"API not supported for tempate={req.type}")
+                raise sirepo.util.NotFound(f"API not supported for tempate={req.type}")
             return f(
                 simulation_db.read_simulation_json(req.type, sid=req.id, qcall=self),
                 qcall=self,
@@ -405,7 +405,7 @@ class API(sirepo.quest.API):
 
     @sirepo.quest.Spec("allow_visitor")
     def api_notFound(self):
-        sirepo.util.raise_not_found("app forced not found (uri parsing error)")
+        raise sirepo.util.NotFound("app forced not found (uri parsing error)")
 
     @sirepo.quest.Spec(
         "require_user",
@@ -458,7 +458,7 @@ class API(sirepo.quest.API):
         u = sirepo.uri.unchecked_root_redirect(path_info)
         if u:
             return self.reply_redirect(u)
-        sirepo.util.raise_not_found(f"unknown path={path_info}")
+        raise sirepo.util.NotFound(f"unknown path={path_info}")
 
     @sirepo.quest.Spec("require_user", sid="SimId", data="SimData all_input")
     def api_saveSimulationData(self):
@@ -487,7 +487,7 @@ class API(sirepo.quest.API):
 
         def _not_found(req):
             if not simulation_db.find_global_simulation(req.type, req.id):
-                sirepo.util.raise_not_found(
+                raise sirepo.util.NotFound(
                     "stype={} sid={} global simulation not found", req.type, req.id
                 )
             return self.headers_for_no_cache(self.reply_json(_redirect(req)))
@@ -566,7 +566,7 @@ class API(sirepo.quest.API):
             Response: reply with file
         """
         if not path_info:
-            sirepo.util.raise_not_found("empty path info")
+            raise sirepo.util.NotFound("empty path info")
         self._proxy_react("static/" + path_info)
         p = sirepo.resource.static(sirepo.util.validate_path(path_info))
         if _google_tag_manager and re.match(r"^en/[^/]+html$", path_info):

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -571,7 +571,7 @@ class API(sirepo.quest.API):
         if not path_info:
             sirepo.util.raise_not_found("empty path info")
         self._proxy_react("static/" + path_info)
-        p = sirepo.resource.static(sirepo.util.safe_path(path_info))
+        p = sirepo.resource.static(sirepo.util.validate_path(path_info))
         if _google_tag_manager and re.match(r"^en/[^/]+html$", path_info):
             return self.headers_for_cache(
                 self.reply(
@@ -681,10 +681,10 @@ class API(sirepo.quest.API):
                 raise sirepo.util.Redirect(f"/react/{path}")
             else:
                 p = path
-            # call call api due to recursion of proxy_react
+            # do not call api_staticFile due to recursion of proxy_react
             raise sirepo.util.Response(
                 flask.send_file(
-                    sirepo.resource.static(sirepo.util.safe_path(f"react/{p}")),
+                    sirepo.resource.static(sirepo.util.validate_path(f"react/{p}")),
                     conditional=True,
                 ),
             )

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -21,7 +21,6 @@ import sirepo.uri
 import sirepo.util
 import urllib
 import urllib.parse
-import werkzeug
 import werkzeug.exceptions
 
 

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -46,7 +46,7 @@ class API(sirepo.quest.API):
     def api_migrateJupyterhub(self):
         self.parse_params(type=_SIM_TYPE)
         if not _cfg.rs_jupyter_migrate:
-            sirepo.util.raise_forbidden("migrate not enabled")
+            raise sirepo.util.Forbidden("migrate not enabled")
         d = self.parse_json()
         if not d.doMigration:
             create_user(self)

--- a/sirepo/simulation_db.py
+++ b/sirepo/simulation_db.py
@@ -172,13 +172,13 @@ def find_global_simulation(sim_type, sid, checked=False):
         return str(paths[0])
     if len(paths) == 0:
         if checked:
-            util.raise_not_found(
+            raise util.NotFound(
                 "{}/{}: global simulation not found",
                 sim_type,
                 sid,
             )
         return None
-    util.raise_not_found(
+    raise util.NotFound(
         "{}: more than one path found for simulation={}/{}",
         paths,
         sim_type,
@@ -387,7 +387,7 @@ def open_json_file(sim_type, path=None, sid=None, fixup=True, save=False, qcall=
     p = path or sim_data_file(sim_type, sid, qcall=qcall)
     if not p.exists():
         if path:
-            util.raise_not_found("path={} not found", path)
+            raise util.NotFound("path={} not found", path)
         raise util.SPathNotFound(sim_type=sim_type, sid=sid, uid=_uid_arg(qcall))
     data = None
     try:

--- a/sirepo/template/synergia.py
+++ b/sirepo/template/synergia.py
@@ -23,7 +23,6 @@ import re
 import sirepo.const
 import sirepo.sim_data
 import sirepo.util
-import werkzeug
 
 
 _SIM_DATA, SIM_TYPE, SCHEMA = sirepo.sim_data.template_globals()

--- a/sirepo/template/zgoubi.py
+++ b/sirepo/template/zgoubi.py
@@ -21,7 +21,6 @@ import numpy as np
 import py.path
 import re
 import sirepo.sim_data
-import werkzeug
 import zipfile
 
 _SIM_DATA, SIM_TYPE, SCHEMA = sirepo.sim_data.template_globals()

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -242,8 +242,6 @@ class _URIParams(PKDict):
 
 
 def _call_api(parent, route, kwargs, data=None):
-    import werkzeug.exceptions
-
     def _response(res):
         if isinstance(res, dict):
             return sirepo.http_reply.gen_json(res)
@@ -275,7 +273,7 @@ def _call_api(parent, route, kwargs, data=None):
             r = _response(getattr(qcall, qcall.uri_route.func_name)(**kwargs))
             c = True
         except Exception as e:
-            if isinstance(e, (sirepo.util.Reply, werkzeug.exceptions.HTTPException)):
+            if isinstance(e, (sirepo.util.Reply):
                 if isinstance(e, sirepo.util.OKReply):
                     c = True
                 pkdc("api={} exception={} stack={}", qcall.uri_route.name, e, pkdexc())

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -273,7 +273,7 @@ def _call_api(parent, route, kwargs, data=None):
             r = _response(getattr(qcall, qcall.uri_route.func_name)(**kwargs))
             c = True
         except Exception as e:
-            if isinstance(e, (sirepo.util.Reply):
+            if isinstance(e, sirepo.util.Reply):
                 if isinstance(e, sirepo.util.OKReply):
                     c = True
                 pkdc("api={} exception={} stack={}", qcall.uri_route.name, e, pkdexc())

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -85,6 +85,12 @@ class Reply(Exception):
         return self.__repr__()
 
 
+class BadRequest(Reply):
+    """Raised for bad request"""
+
+    pass
+
+
 class OKReply(Reply):
     """When a Reply exception is a successful response"""
 

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -351,18 +351,6 @@ def json_dump(obj, path=None, pretty=False, **kwargs):
     return res
 
 
-def raise_forbidden(*args, **kwargs):
-    _raise("Forbidden", *args, **kwargs)
-
-
-def raise_not_found(*args, **kwargs):
-    _raise("NotFound", *args, **kwargs)
-
-
-def raise_unauthorized(*args, **kwargs):
-    _raise("Unauthorized", *args, **kwargs)
-
-
 def random_base62(length=32):
     """Returns a safe string of sufficient length to be a nonce
 
@@ -494,10 +482,6 @@ def write_zip(path):
         mode="w",
         compression=zipfile.ZIP_DEFLATED,
     )
-
-
-def _raise(exc, *args, **kwargs):
-    raise globals().get(exc, ServerError)
 
 
 cfg = pkconfig.init(

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -496,9 +496,7 @@ def write_zip(path):
     )
 
 
-def _raise(exc, fmt, *args, **kwargs):
-    kwargs["pkdebug_frame"] = inspect.currentframe().f_back.f_back
-    pkdlog(fmt, *args, **kwargs)
+def _raise(exc, *args, **kwargs):
     raise globals().get(exc, ServerError)
 
 

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -464,7 +464,6 @@ def validate_path(uri):
         raise AssertionError(f"empty uri")
     res = []
     for p in uri.split("/"):
-        pkdp(p)
         if _INVALID_PATH_CHARS.search(p):
             raise AssertionError(f"illegal char(s) in component={p} uri={uri}")
         if p == "":

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -24,6 +24,7 @@ import random
 import six
 import sys
 import threading
+import unicodedata
 import zipfile
 
 
@@ -439,7 +440,8 @@ def secure_filename(path):
             " ",
         )
     )
-    return _INVALID_PATH_CHARS.sub("", "_".join(p.split())).strip("._")
+    p = _INVALID_PATH_CHARS.sub("", "_".join(p.split())).strip("._")
+    return "file" if p is "" else p
 
 
 def setattr_imports(imports):

--- a/tests/auth/bluesky1_test.py
+++ b/tests/auth/bluesky1_test.py
@@ -22,7 +22,7 @@ def test_srw_auth_hash(monkeypatch):
     from pykern import pkcollections
     from pykern.pkunit import pkexcept, pkre
     import time
-    import werkzeug.exceptions
+    from sirepo import util
 
     monkeypatch.setattr(bluesky, "_AUTH_NONCE_REPLAY_SECS", 1)
     req = pkcollections.Dict(
@@ -32,7 +32,7 @@ def test_srw_auth_hash(monkeypatch):
     bluesky.auth_hash(req)
     bluesky.auth_hash(req, verify=True)
     time.sleep(2)
-    with pkexcept(werkzeug.exceptions.Unauthorized):
+    with pkexcept(util.Unauthorized):
         bluesky.auth_hash(req, verify=True)
 
 

--- a/tests/auth/bluesky2_test.py
+++ b/tests/auth/bluesky2_test.py
@@ -23,7 +23,6 @@ def test_srw_auth_login():
     )
     from sirepo import simulation_db
     from sirepo.auth import bluesky
-    import werkzeug.exceptions
 
     sim_type = "srw"
     uid = fc.sr_login_as_guest(sim_type)

--- a/tests/server1_test.py
+++ b/tests/server1_test.py
@@ -12,6 +12,27 @@ import pytest
 _MIN_SERIAL = 10000000
 
 
+def test_bad_request(fc):
+    from pykern import pkunit
+    from pykern.pkcollections import PKDict
+    from pykern.pkdebug import pkdp, pkdpretty
+
+    fc.sr_login_as_guest()
+    r = fc.sr_post_form("listSimulations", PKDict(), raw_response=True)
+    pkunit.pkeq(400, r.status_code)
+
+
+def test_elegant_server_upgraded(fc):
+    from pykern.pkdebug import pkdp, pkdpretty
+    from pykern.pkunit import pkexcept
+    from pykern.pkcollections import PKDict
+
+    d = fc.sr_sim_data("Backtracking")
+    d.version = d.version[:-1] + str(int(d.version[-1]) - 1)
+    with pkexcept("serverupgraded"):
+        fc.sr_post("saveSimulationData", d)
+
+
 def test_srw_serial_stomp(fc):
     from pykern.pkdebug import pkdp, pkdpretty
     from pykern.pkunit import pkfail, pkok
@@ -53,14 +74,3 @@ def test_srw_serial_stomp(fc):
         new_serial,
         curr_serial,
     )
-
-
-def test_elegant_server_upgraded(fc):
-    from pykern.pkdebug import pkdp, pkdpretty
-    from pykern.pkunit import pkexcept
-    from pykern.pkcollections import PKDict
-
-    d = fc.sr_sim_data("Backtracking")
-    d.version = d.version[:-1] + str(int(d.version[-1]) - 1)
-    with pkexcept("serverupgraded"):
-        fc.sr_post("saveSimulationData", d)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -7,6 +7,16 @@
 import pytest
 
 
+def test_secure_filename():
+    from sirepo import util
+    from pykern import pkunit
+
+    pkunit.pkeq("file", util.secure_filename(""))
+    pkunit.pkeq("file", util.secure_filename("/"))
+    pkunit.pkeq("a_b", util.secure_filename("/a/b"))
+    pkunit.pkeq("b", util.secure_filename(".b."))
+
+
 def test_validate_path():
     from sirepo import util
     from pykern import pkunit

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""test uri
+
+:copyright: Copyright (c) 2022 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+import pytest
+
+
+def test_validate_path():
+    from sirepo import util
+    from pykern import pkunit
+
+    with pkunit.pkexcept("empty uri"):
+        util.validate_path("")
+    with pkunit.pkexcept("illegal char"):
+        util.validate_path("a*")
+    with pkunit.pkexcept("empty component"):
+        util.validate_path("a//b")
+    with pkunit.pkexcept("empty component"):
+        util.validate_path("/a")
+    with pkunit.pkexcept("empty component"):
+        util.validate_path("a/")
+    with pkunit.pkexcept("dot prefix"):
+        util.validate_path("a/../b")
+    with pkunit.pkexcept("dot prefix"):
+        util.validate_path(".a")


### PR DESCRIPTION
- All exceptions raised are subclass of sirepo.util.Reply 
- Removed all references to werkzeug except in sirepo.pkcli.service.flask. 
- Rewrote util.secure_filename with a restricted implementation
- Replaced util.safe_path with util.validate_path with a much restricted interface to match our use
- Added run-auth-bluesky.sh and run-auth-basic.sh
