### PR TITLE
Fix #2447: CancelledError inherits from BaseException on > py 3.8

### DIFF
--- a/sirepo/const.py
+++ b/sirepo/const.py
@@ -4,7 +4,10 @@
 :copyright: Copyright (c) 2021 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+import asyncio
 from pykern.pkcollections import PKDict
+
+ASYNC_CANCELED_ERROR = asyncio.CancelledError
 
 JSON_SUFFIX = ".json"
 

--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -12,10 +12,12 @@ import importlib
 import pykern.pkio
 import re
 import sirepo.auth
+import sirepo.const
 import sirepo.events
 import sirepo.sim_db_file
 import sirepo.simulation_db
 import sirepo.tornado
+import sirepo.util
 import tornado.gen
 import tornado.ioloop
 import tornado.locks
@@ -273,7 +275,7 @@ class DriverBase(PKDict):
                 # POSIT: Canceled errors aren't smothered by any of the below calls
                 await self.kill()
                 await self._do_agent_start(op)
-            except Exception as e:
+            except (Exception, sirepo.const.ASYNC_CANCELED_ERROR) as e:
                 pkdlog("{} error={} stack={}", self, e, pkdexc())
                 self.free_resources(internal_error="failure starting agent")
                 raise

--- a/sirepo/job_driver/docker.py
+++ b/sirepo/job_driver/docker.py
@@ -124,10 +124,6 @@ class DockerDriver(job_driver.DriverBase):
             await self._cmd(
                 ("stop", "--time={}".format(job_driver.KILL_TIMEOUT_SECS), self._cname),
             )
-        except sirepo.util.ASYNC_CANCELED_ERROR:
-            # CanceledErrors need to make it back out to be handled
-            # by callers (ex job_supervisor.api_runSimulation)
-            raise
         except Exception as e:
             if not c and "No such container" in str(e):
                 # Make kill response idempotent

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -170,8 +170,6 @@ disown
                     write_to_log(
                         o, e, f"remote-{'before' if before_start else 'after'}-start"
                     )
-            except sirepo.util.ASYNC_CANCELED_ERROR:
-                raise
             except Exception as e:
                 pkdlog(
                     "{} e={} stack={}",

--- a/sirepo/pkcli/test_http.py
+++ b/sirepo/pkcli/test_http.py
@@ -18,6 +18,7 @@ import inspect
 import random
 import re
 import signal
+import sirepo.const
 import sirepo.pkcli.service
 import sirepo.sim_data
 import sirepo.util
@@ -139,7 +140,7 @@ def default_command():
             await t
         except Exception as e:
             await _cancel_all_tasks(s)
-            if isinstance(e, sirepo.util.ASYNC_CANCELED_ERROR):
+            if isinstance(e, sirepo.const.ASYNC_CANCELED_ERROR):
                 # Will only be canceled by a signal handler
                 return
             pkdlog("error={} stack={} sims={}", e, pkdexc(), _sims)
@@ -415,7 +416,7 @@ class _Sim(PKDict):
                     finally:
                         if c:
                             await self._cancel(error=e)
-            except sirepo.util.ASYNC_CANCELED_ERROR:
+            except sirepo.const.ASYNC_CANCELED_ERROR:
                 # Don't log on cancel error, we initiate cancels so not interesting
                 raise
             except Exception as e:

--- a/sirepo/tornado.py
+++ b/sirepo/tornado.py
@@ -5,7 +5,7 @@
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from pykern.pkdebug import pkdlog, pkdexc
-import sirepo.util
+import sirepo.const
 import tornado.locks
 import tornado.queues
 
@@ -47,11 +47,11 @@ class Queue(tornado.queues.Queue):
             # on the queue and before this task finishes the await.
             x = super().get()
             return await x
-        except sirepo.util.ASYNC_CANCELED_ERROR:
+        except sirepo.const.ASYNC_CANCELED_ERROR:
             if x:
                 try:
                     r = x.result()
-                except Exception:
+                except BaseException:
                     # there are many exceptions that can happen,
                     # including throwing an exception on the Future.
                     # However, none need to be cascaded as the task
@@ -62,7 +62,7 @@ class Queue(tornado.queues.Queue):
                         # got a valid result so put it back.
                         self.task_done()
                         self.put_nowait(r)
-                    except Exception as e:
+                    except BaseException as e:
                         # at this point, the task is canceled so
                         # we can't raise another exception, but we
                         # should log that an error has occurred.

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -8,30 +8,23 @@ from pykern import pkcompat
 from pykern import pkconfig
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdlog, pkdp, pkdexc, pkdc
-import asyncio
 import base64
-import concurrent.futures
 import hashlib
 import importlib
 import inspect
 import numconv
-import posixpath
 import pykern.pkinspect
 import pykern.pkio
 import pykern.pkjson
 import re
 import random
 import six
-import sys
 import threading
 import unicodedata
 import zipfile
 
 
 cfg = None
-
-#: All types of errors async code may throw when canceled
-ASYNC_CANCELED_ERROR = (asyncio.CancelledError, concurrent.futures.CancelledError)
 
 #: Http auth header name
 AUTH_HEADER = "Authorization"


### PR DESCRIPTION
Change the code to:
- Catch CancelledError explicitly when needed in cases where we were relying on it to be a subclass of Exception previously.
- Remove any code that does nothing but raise on CancelledError. This pattern was used to not smother CancelledError in cases where we had an `except Exception`. Those will no longer smother the error.

In addition, in sirepo.job_supervisro.run re-raise the CancelledError and remove check for return of False from _send_op. This has no actual behavior change. We don't await _run so it doesn't matter if the CancelledError makes it out. But, it is more "correct" to not smother CancelledError and have it propagate all the way out so a cancel happens fully.