### PR TITLE
Fix #5305: better datafile error for missing .h5 data file

### DIFF
--- a/sirepo/package_data/static/js/activait.js
+++ b/sirepo/package_data/static/js/activait.js
@@ -1076,6 +1076,7 @@ SIREPO.app.directive('imagePreviewPanel', function(requestSender) {
           <div data-ng-if="isLoading()" class="progress">
             <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{ simState.getPercentComplete() }}" aria-valuemin="0" aria-valuemax="100" data-ng-attr-style="width: {{ simState.getPercentComplete() || 100 }}%"></div>
           </div>
+          <div data-ng-if="showFileMissing">{{ fileName }} is missing</div>
           <div data-ng-if="! isLoading()">
             <div class="pull-left">
               <button class="btn btn-primary" title="first" data-ng-click="first()">|<</button>
@@ -1093,6 +1094,7 @@ SIREPO.app.directive('imagePreviewPanel', function(requestSender) {
             let loading = true;
             let numPages = 0;
             let uris;
+            $scope.showFileMissing = false;
 
             $scope.canUpdateUri = increment => {
                 return idx + increment >= 0 && idx + increment < numPages;
@@ -1119,6 +1121,10 @@ SIREPO.app.directive('imagePreviewPanel', function(requestSender) {
             function setImageFromUriIndex(index) {
                 if ($('.srw-processed-image').length && uris) {
                     $('.srw-processed-image')[0].src = uris[index];
+                }
+                if (! uris) {
+                    $scope.showFileMissing = true;
+                    $scope.fileName = appState.models.dataFile.file;
                 }
             }
 

--- a/sirepo/package_data/static/js/activait.js
+++ b/sirepo/package_data/static/js/activait.js
@@ -1117,7 +1117,7 @@ SIREPO.app.directive('imagePreviewPanel', function(requestSender) {
             };
 
             function setImageFromUriIndex(index) {
-                if ($('.srw-processed-image').length) {
+                if ($('.srw-processed-image').length && uris) {
                     $('.srw-processed-image')[0].src = uris[index];
                 }
             }

--- a/sirepo/package_data/static/js/activait.js
+++ b/sirepo/package_data/static/js/activait.js
@@ -1076,7 +1076,7 @@ SIREPO.app.directive('imagePreviewPanel', function(requestSender) {
           <div data-ng-if="isLoading()" class="progress">
             <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{ simState.getPercentComplete() }}" aria-valuemin="0" aria-valuemax="100" data-ng-attr-style="width: {{ simState.getPercentComplete() || 100 }}%"></div>
           </div>
-          <div data-ng-if="showFileMissing">{{ fileName }} is missing</div>
+          <div data-ng-if="showFileMissing">Data file {{ fileName }} is missing</div>
           <div data-ng-if="! isLoading()">
             <div class="pull-left">
               <button class="btn btn-primary" title="first" data-ng-click="first()">|<</button>

--- a/sirepo/package_data/static/js/activait.js
+++ b/sirepo/package_data/static/js/activait.js
@@ -1076,7 +1076,7 @@ SIREPO.app.directive('imagePreviewPanel', function(requestSender) {
           <div data-ng-if="isLoading()" class="progress">
             <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{ simState.getPercentComplete() }}" aria-valuemin="0" aria-valuemax="100" data-ng-attr-style="width: {{ simState.getPercentComplete() || 100 }}%"></div>
           </div>
-          <div data-ng-if="showFileMissing">Data file {{ fileName }} is missing</div>
+          <div data-ng-if="dataFileMissing">Data file {{ fileName }} is missing</div>
           <div data-ng-if="! isLoading()">
             <div class="pull-left">
               <button class="btn btn-primary" title="first" data-ng-click="first()">|<</button>
@@ -1094,7 +1094,7 @@ SIREPO.app.directive('imagePreviewPanel', function(requestSender) {
             let loading = true;
             let numPages = 0;
             let uris;
-            $scope.showFileMissing = false;
+            $scope.dataFileMissing = false;
 
             $scope.canUpdateUri = increment => {
                 return idx + increment >= 0 && idx + increment < numPages;
@@ -1123,7 +1123,7 @@ SIREPO.app.directive('imagePreviewPanel', function(requestSender) {
                     $('.srw-processed-image')[0].src = uris[index];
                 }
                 if (! uris) {
-                    $scope.showFileMissing = true;
+                    $scope.dataFileMissing = true;
                     $scope.fileName = appState.models.dataFile.file;
                 }
             }

--- a/sirepo/template/activait.py
+++ b/sirepo/template/activait.py
@@ -366,7 +366,7 @@ def stateful_compute_sample_images(data):
         if info.dtypeKind[idx] in {"U", "S"}:
             io.output.label_path = info.header[idx]
             break
-    pkdp("\n\n\n\nHELLO f={}\n\n\n", data.args)
+
     with h5py.File(_filepath(data.args.dataFile.file), "r") as f:
         x = f[io.input.path]
         y = f[io.output.path]

--- a/sirepo/template/activait.py
+++ b/sirepo/template/activait.py
@@ -366,7 +366,7 @@ def stateful_compute_sample_images(data):
         if info.dtypeKind[idx] in {"U", "S"}:
             io.output.label_path = info.header[idx]
             break
-
+    pkdp("\n\n\n\nHELLO f={}\n\n\n", data.args)
     with h5py.File(_filepath(data.args.dataFile.file), "r") as f:
         x = f[io.input.path]
         y = f[io.output.path]


### PR DESCRIPTION
If uris is undefined wont try to access items within it and will display that data file is missing in the image viewer on source. (Already displays missing data file message in sim status panel if you try to run sim)

