### PR TITLE
Fix #5311 radia shift move shapes single axis

### DIFF
--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -2041,25 +2041,45 @@ SIREPO.app.directive('3dBuilder', function(appState, geometry, layoutService, pa
                 });
             }
 
-            //TODO(mvk): live update of virtual shapes
             function d3DragShape(shape) {
+                
                 if (! shape.draggable) {
                     return;
                 }
                 didDrag = true;
                 draggedShape = shape;
+                let axis;
+                if (d3.event.sourceEvent.shiftKey) {
+                    if (Math.abs(dragDelta.x) > Math.abs(dragDelta.y)) {
+                        axis = 'x';
+                    }
+                    else {
+                        axis = 'y';
+                    }
+                }
                 SIREPO.SCREEN_DIMS.forEach(dim => {
                     if (appState.models.threeDBuilder.snapToGrid) {
                         dragDelta[dim] = snap(shape, dim);
                         return;
                     }
-                    dragDelta[dim] = d3.event[dim];
+                    if (axis) {
+                        if (dim === axis) {
+                            dragDelta[dim] = d3.event[dim];
+                        }
+                        else {
+                            dragDelta[dim] = 0;
+                        }
+                    }
+                    else {
+                        dragDelta[dim] = d3.event[dim];
+                    }
                     const numPixels = scaledPixels(dim, dragDelta[dim]);
                     shape[dim] = dragInitialShape[dim] + numPixels;
                     shape.center[dim] = dragInitialShape.center[dim] + numPixels;
                 });
                 d3.select(shapeSelectionId(shape)).call(updateShapeAttributes);
                 showShapeLocation(shape);
+                //TODO(mvk): restore live update of virtual shapes
                 shape.runLinks().forEach(linkedShape => {
                     d3.select(shapeSelectionId(linkedShape)).call(updateShapeAttributes);
                 });

--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -2050,10 +2050,6 @@ SIREPO.app.directive('3dBuilder', function(appState, geometry, layoutService, pa
 
             function d3DragShape(shape) {
 
-                function axisDelta(dim) {
-                    return canDrag(dim) ? d3.event[dim] : 0;
-                }
-
                 if (! shape.draggable) {
                     return;
                 }
@@ -2064,7 +2060,7 @@ SIREPO.app.directive('3dBuilder', function(appState, geometry, layoutService, pa
                         dragDelta[dim] = snap(shape, dim);
                         return;
                     }
-                    dragDelta[dim] = axisDelta(dim);
+                    dragDelta[dim] = canDrag(dim) ? d3.event[dim] : 0;
                     const numPixels = scaledPixels(dim, dragDelta[dim]);
                     shape[dim] = dragInitialShape[dim] + numPixels;
                     shape.center[dim] = dragInitialShape.center[dim] + numPixels;


### PR DESCRIPTION
When the shift key is down, the shape moves only along the axis with the largest displacement.  Works for free movement and when snapped to grid.