### PR TITLE
Fix #5524: Resurrect the hellweg app

### DIFF
--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -45,6 +45,7 @@ _NON_PROD_FOSS_CODES = frozenset(
         "myapp",
         "silas",
         "omega",
+        "rshellweg",
     )
 )
 

--- a/sirepo/package_data/static/html/rshellweg-lattice.html
+++ b/sirepo/package_data/static/html/rshellweg-lattice.html
@@ -1,0 +1,30 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="text-center bg-info" style="padding: 1em">
+        <div data-ng-repeat="item in ::lattice.toolbarItems" class="hellweg-icon" data-ng-drag="true" data-ng-drag-data="item"><span class="badge">{{ ::lattice.itemName(item) }}</span></div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-8 col-md-6 col-md-offset-3 col-sm-offset-2">
+      <p data-ng-drop="true" data-ng-drop-success="lattice.dropLast($data)" class="lead text-center hellweg-drop-zone"><small><em>drag and drop elements here to define the beamline</em></small></p>
+      <div class="hellweg-editor-holder">
+      <table class="table table-hover table-condensed hellweg-beamline-table">
+        <tr data-ng-repeat="item in lattice.appState.models.beamline">
+          <td data-ng-drop="true" data-ng-drop-success="lattice.dropItem($index, $data)" data-ng-drag-start="lattice.selectItem($data)">
+            <div class="sr-button-bar-parent pull-right"><div class="sr-button-bar"><button class="btn btn-info btn-xs"  data-ng-disabled="$index == 0" data-ng-click="moveItem(-1, item)"><span class="glyphicon glyphicon-arrow-up"></span></button> <button class="btn btn-info btn-xs" data-ng-disabled="$index == lattice.appState.models.beamline.length - 1" data-ng-click="moveItem(1, item)"><span class="glyphicon glyphicon-arrow-down"></span></button> <button class="btn btn-info btn-xs sr-hover-button" data-ng-click="lattice.copyItem(item)">Copy</button> <button class="btn btn-info btn-xs sr-hover-button" data-ng-click="lattice.editItem(item)">Edit</button> <button data-ng-click="lattice.deleteItem(item)" class="btn btn-danger btn-xs"><span class="glyphicon glyphicon-remove"></span></button></div></div>
+            <div class="hellweg-icon" data-ng-drag="true" data-ng-drag-data="item"><a href data-ng-click="lattice.selectItem(item)" data-ng-dblclick="lattice.editItem(item)"><span class="badge" data-ng-class="{'sr-item-selected': lattice.isSelected(item)}">{{ lattice.itemName(item.type) }}</span></a>{{ lattice.itemValues(item) }}</div>
+          </td>
+        </tr>
+        <tr><td style="height: 4em" data-ng-drop="true" data-ng-drop-success="lattice.dropLast($data)"> </td></tr>
+      </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div data-confirmation-modal="" data-id="hellweg-delete-element-confirmation" data-title="Delete Element?" data-ok-text="Delete" data-ok-clicked="lattice.deleteSelected()">Delete element &quot;{{ lattice.selectedItemName() }}&quot;?</div>
+<div data-ng-drag-clone=""><div class="hellweg-icon"><span class="badge sr-item-selected">{{ lattice.itemName(clonedData) }}</span></div></div>
+
+<div data-modal-editor="" view-name="saveElement" data-parent-controller="lattice"></div>

--- a/sirepo/package_data/static/html/rshellweg-source.html
+++ b/sirepo/package_data/static/html/rshellweg-source.html
@@ -1,0 +1,20 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-6">
+      <div class="row">
+        <div class="col-sm-12">
+          <div data-basic-editor-panel="" data-view-name="solenoid" data-parent-controller="source"></div>
+        </div>
+        <div class="col-sm-12">
+          <div data-basic-editor-panel="" data-view-name="beam" data-parent-controller="source"></div>
+        </div>
+        <div class="col-sm-12">
+          <div data-report-panel="2d" data-model-name="beamHistogramReport" data-panel-title="Beam Plot"></div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div data-report-panel="3d" data-model-name="beamReport" data-panel-title="Beam Report"><div data-summary-table="beamReport"></div></div>
+    </div>
+  </div>
+</div>

--- a/sirepo/package_data/static/html/rshellweg-visualization.html
+++ b/sirepo/package_data/static/html/rshellweg-visualization.html
@@ -1,0 +1,27 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-6 col-xl-4">
+      <div data-simple-panel="simulationSettings">
+        <div data-sim-status-panel="visualization.simState"></div>
+        <div data-summary-table="animation"></div>
+      </div>
+    </div>
+    <div class="col-md-6 col-xl-4" data-ng-if="visualization.simState.hasFrames()">
+      <div data-report-panel="3d" data-model-name="beamAnimation">
+        <div data-ng-if="visualization.isComputingRanges" class="text-center text-info">Computing plot range across frames...</div>
+      </div>
+    </div>
+    <div class="col-md-6 col-xl-4" data-ng-if="visualization.simState.hasFrames()">
+      <div data-report-panel="parameter" data-model-name="parameterAnimation"></div>
+    </div>
+    <div class="col-md-6 col-xl-4" data-ng-if="visualization.simState.hasFrames()">
+      <div data-report-panel="particle" data-model-name="particleAnimation"></div>
+    </div>
+    <div class="col-md-6 col-xl-4" data-ng-if="visualization.simState.hasFrames()">
+      <div data-report-panel="2d" data-model-name="beamHistogramAnimation"></div>
+    </div>
+  </div>
+</div>
+
+<!-- modal dialogs -->
+<div data-modal-editor="" view-name="beamAnimation" data-parent-controller="visualization"></div>

--- a/sirepo/package_data/static/js/rshellweg.js
+++ b/sirepo/package_data/static/js/rshellweg.js
@@ -1,0 +1,423 @@
+'use strict';
+
+var srlog = SIREPO.srlog;
+var srdbg = SIREPO.srdbg;
+
+SIREPO.app.config(function() {
+    SIREPO.PLOTTING_SUMMED_LINEOUTS = true;
+});
+
+SIREPO.app.factory('hellwegService', function(appState) {
+    var self = {};
+
+    self.computeModel = function(analysisModel) {
+        return 'animation';
+    };
+
+    appState.setAppService(self);
+
+    return self;
+});
+
+SIREPO.app.controller('HellwegLatticeController', function (appState, panelState, $scope) {
+    var self = this;
+    self.appState = appState;
+    //self.toolbarItems = ['powerElement', 'cellElement', 'cellsElement', 'driftElement', 'saveElement'];
+    self.toolbarItems = ['powerElement', 'cellElement', 'cellsElement', 'driftElement'];
+
+    function isElementModelName(modelName) {
+        return modelName.indexOf('Element') >= 0;
+    }
+
+    function itemIndex(item) {
+        var beamline = appState.models.beamline;
+        for (var i = 0; i < beamline.length; i++) {
+            if (beamline[i].id == item.id) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    function newItem(modelName) {
+        return appState.setModelDefaults({
+            type: modelName,
+        }, modelName);
+    }
+
+    function updateSaveElementFields() {
+        var m = appState.models.saveElement;
+        if (m) {
+            panelState.showField('saveElement', 'particleLimit', m.particleRange == 'count');
+            ['particleStart', 'particleEnd'].forEach(function(f) {
+                panelState.showField('saveElement', f, m.particleRange == 'range');
+            });
+        }
+    }
+
+    self.deleteItem = function(item) {
+        if (! item) {
+            return;
+        }
+        self.selectItem(item);
+        $('#hellweg-delete-element-confirmation').modal('show');
+    };
+
+    self.deleteSelected = function() {
+        if (self.selectedItem) {
+            var index = itemIndex(self.selectedItem);
+            if (index >= 0) {
+                self.selectedItem = null;
+                appState.models.beamline.splice(index, 1);
+                appState.saveChanges('beamline');
+            }
+        }
+    };
+
+    self.dropItem = function(index, item) {
+        if (! item) {
+            return;
+        }
+        if (angular.isObject(item)) {
+            var beamline = appState.models.beamline;
+            var i = itemIndex(item);
+            if (index == i) {
+                return;
+            }
+            item = beamline.splice(i, 1)[0];
+            if (i < index) {
+                index--;
+            }
+            beamline.splice(index, 0, item);
+            appState.saveChanges('beamline');
+            self.selectItem(item);
+        }
+        else {
+            self.selectedIndex = index;
+            self.editItem(newItem(item));
+        }
+    };
+
+    // expects a negative number to move up, positive to move down
+    $scope.moveItem = function(direction, item) {
+        var d = direction == 0 ? 0 : (direction > 0 ? 1 : -1);
+        var currentIndex = itemIndex(item);
+        var beamline = appState.models.beamline;
+        var newIndex = currentIndex + d;
+        if(newIndex >= 0 && newIndex < beamline.length) {
+            var tmp = beamline[newIndex];
+            beamline[newIndex] = item;
+            beamline[currentIndex] = tmp;
+            appState.saveChanges('beamline');
+        }
+    };
+    self.copyItem= function(item) {
+        var itemCopy = newItem(item.type);
+        var iIndex = itemIndex(item);
+        for(var prop in item) {
+            if(prop != 'id' && prop != '$$hashKey') {
+                itemCopy[prop] = item[prop];
+            }
+        }
+        self.selectedIndex = iIndex + 1;
+        self.editItem(itemCopy);
+    };
+
+    self.dropLast = function(item) {
+        self.dropItem(appState.models.beamline.length, item);
+    };
+
+    self.editItem = function(item) {
+        appState.models[item.type] = item;
+        panelState.showModalEditor(item.type);
+    };
+
+    self.handleModalShown = function(name) {
+        if (name == 'saveElement') {
+            updateSaveElementFields();
+        }
+    };
+
+    self.isSelected = function(item) {
+        if (self.selectedItem) {
+            return item.id == self.selectedItem.id;
+        }
+        return false;
+    };
+
+    self.itemName = function(item) {
+        var modelName = angular.isObject(item) ? item.type : item;
+        if (modelName) {
+            return appState.viewInfo(modelName).title;
+        }
+        return '';
+    };
+
+    self.itemValues = function(item) {
+        return appState.viewInfo(item.type).advanced.map(function(f) {
+            return item[f];
+        }).join(' ');
+    };
+
+    self.selectItem = function(item) {
+        self.selectedItem = angular.isObject(item) ? item : null;
+    };
+
+    self.selectedItemName = function() {
+        if (self.selectedItem) {
+            return self.itemName(self.selectedItem) + ' ' + self.itemValues(self.selectedItem);
+        }
+        return '';
+    };
+
+    $scope.$on('cancelChanges', function(e, name) {
+        if (isElementModelName(name)) {
+            appState.removeModel(name);
+            appState.cancelChanges('beamline');
+        }
+    });
+
+    $scope.$on('modelChanged', function(e, name) {
+        if (isElementModelName(name)) {
+            if (! appState.models[name].id) {
+                appState.models[name].id = appState.maxId(appState.models.beamline) + 1;
+                appState.models.beamline.splice(self.selectedIndex, 0, appState.models[name]);
+                self.selectedItem = appState.models[name];
+            }
+            appState.removeModel(name);
+            appState.saveChanges('beamline');
+        }
+    });
+
+    appState.watchModelFields($scope, ['saveElement.particleRange'], updateSaveElementFields);
+});
+
+SIREPO.app.controller('HellwegSourceController', function (appState, panelState, $scope) {
+    var self = this;
+
+    function isActiveField(model, field) {
+        var fieldClass = '.model-' + model + '-' + field;
+        return $(fieldClass).find('input').is(':focus');
+    }
+
+    function updateAllFields() {
+        updateBeamFields();
+        updateSolenoidFields();
+    }
+
+    function updateBeamFields() {
+        var beam = appState.models.beam;
+        if (beam.transversalDistribution == 'sph2d') {
+            updateCurvature();
+        }
+        var isDistribution = beam.beamDefinition == 'transverse_longitude';
+        panelState.showField('beam', 'spaceChargeCore', beam.spaceCharge == 'coulomb' || beam.spaceCharge == 'elliptic');
+        panelState.showTab('beam', 2, isDistribution && beam.transversalDistribution == 'twiss4d');
+        panelState.showTab('beam', 3, isDistribution && beam.transversalDistribution == 'sph2d');
+        panelState.showTab('beam', 4, isDistribution && beam.transversalDistribution == 'ell2d');
+        panelState.showTab('beam', 5, isDistribution && beam.longitudinalDistribution == 'norm2d');
+        panelState.showTab('beam', 6, beam.beamDefinition == 'cst_pid' || (isDistribution && beam.longitudinalDistribution == 'file1d'));
+        panelState.showField('energyPhaseDistribution', 'energyDeviation', beam.longitudinalDistribution == 'norm2d' && appState.models.energyPhaseDistribution.distributionType == 'gaussian');
+        panelState.showField('energyPhaseDistribution', 'phaseDeviation', (beam.longitudinalDistribution == 'norm2d' || beam.longitudinalDistribution == 'file1d') && appState.models.energyPhaseDistribution.distributionType == 'gaussian');
+        panelState.showField('beam', 'cstCompress', beam.beamDefinition == 'cst_pit');
+        ['transversalDistribution', 'longitudinalDistribution'].forEach(function(f) {
+            panelState.showField('beam', f, isDistribution);
+        });
+        panelState.showField('beam', 'transversalFile2d', beam.transversalDistribution == 'file2d');
+        panelState.showField('beam', 'transversalFile4d', beam.transversalDistribution == 'file4d');
+        panelState.showField('beam', 'longitudinalFile1d', beam.longitudinalDistribution == 'file1d');
+        panelState.showField('beam', 'longitudinalFile2d', beam.longitudinalDistribution == 'file2d');
+        panelState.showField('beam', 'cstFile', ! isDistribution);
+    }
+
+    function updateCurvature() {
+        var dist = appState.models.sphericalDistribution;
+        if (isActiveField('sphericalDistribution', 'curvatureFactor')) {
+            if (dist.curvatureFactor !== undefined) {
+                dist.curvature = dist.curvatureFactor > 0
+                    ? 'concave'
+                    : (dist.curvatureFactor < 0
+                       ? 'convex'
+                       : 'flat');
+            }
+        }
+        else {
+            if (dist.curvature == 'concave') {
+                if (dist.curvatureFactor === 0) {
+                    dist.curvatureFactor = 1;
+                }
+                else {
+                    dist.curvatureFactor = Math.abs(dist.curvatureFactor);
+                }
+            }
+            else if (dist.curvature == 'convex') {
+                if (dist.curvatureFactor === 0) {
+                    dist.curvatureFactor = -1;
+                }
+                else {
+                    dist.curvatureFactor = - Math.abs(dist.curvatureFactor);
+                }
+            }
+            else {
+                dist.curvatureFactor = 0;
+            }
+        }
+    }
+
+    function updateSolenoidFields() {
+        var solenoid = appState.models.solenoid;
+        ['fieldStrength', 'length', 'fringeRegion', 'z0'].forEach(function(f) {
+            panelState.showField('solenoid', f, solenoid.sourceDefinition == 'values');
+        });
+        panelState.showField('solenoid', 'solenoidFile', solenoid.sourceDefinition == 'file');
+    }
+
+    self.handleModalShown = function() {
+        updateAllFields();
+    };
+
+    appState.watchModelFields($scope, ['beam.transversalDistribution', 'beam.longitudinalDistribution', 'beam.spaceCharge', 'beam.beamDefinition', 'sphericalDistribution.curvature', 'sphericalDistribution.curvatureFactor', 'energyPhaseDistribution.distributionType'], updateBeamFields);
+    appState.watchModelFields($scope, ['solenoid.sourceDefinition'], updateSolenoidFields);
+    appState.whenModelsLoaded($scope, updateAllFields);
+});
+
+SIREPO.app.controller('HellwegVisualizationController', function (appState, frameCache, panelState, persistentSimulation, plotRangeService, hellwegService, $scope, $rootScope) {
+    var self = this;
+    self.simScope = $scope;
+    self.panelState = panelState;
+
+    self.simHandleStatus = function (data) {
+        if ('percentComplete' in data && ! data.error) {
+            plotRangeService.computeFieldRanges(self, 'beamAnimation', data.percentComplete);
+            ['beamAnimation', 'beamHistogramAnimation', 'particleAnimation', 'parameterAnimation'].forEach(function(modelName) {
+                appState.saveQuietly(modelName);
+            });
+            $rootScope.$broadcast('animation.summaryData', data.summaryData);
+            if (data.frameCount) {
+                frameCache.setFrameCount(1, 'particleAnimation');
+                frameCache.setFrameCount(1, 'parameterAnimation');
+            }
+        }
+        frameCache.setFrameCount(data.frameCount);
+    };
+
+    self.handleModalShown = function(name) {
+        if (name == 'beamAnimation') {
+            plotRangeService.processPlotRange(self, name);
+        }
+    };
+
+    appState.whenModelsLoaded($scope, function() {
+        appState.watchModelFields($scope, ['beamAnimation.plotRangeType'], function() {
+            plotRangeService.processPlotRange(self, 'beamAnimation');
+        });
+    });
+
+    self.simState = persistentSimulation.initSimulationState(self);
+});
+
+SIREPO.app.directive('appFooter', function() {
+    return {
+        restrict: 'A',
+        scope: {
+            nav: '=appFooter',
+        },
+        template: `
+            <div data-common-footer="nav"></div>
+            <div data-import-dialog=""></div>
+        `,
+    };
+});
+
+SIREPO.app.directive('appHeader', function(appState) {
+    return {
+        restrict: 'A',
+        scope: {
+            nav: '=appHeader',
+        },
+        template: `
+            <div data-app-header-brand="nav"></div>
+            <div data-app-header-left="nav"></div>
+            <div data-app-header-right="nav">
+              <app-header-right-sim-loaded>
+                <div data-sim-sections="">
+                    <li class="sim-section" data-ng-class="{active: nav.isActive(\'source\')}"><a href data-ng-click="nav.openSection(\'source\')"><span class="glyphicon glyphicon-flash"></span> Source</a></li>
+                    <li class="sim-section" data-ng-class="{active: nav.isActive(\'lattice\')}"><a href data-ng-click="nav.openSection(\'lattice\')"><span class="glyphicon glyphicon-option-horizontal"></span> Lattice</a></li>
+                    <li class="sim-section" data-ng-if="showVisualizationTab()" data-ng-class="{active: nav.isActive(\'visualization\')}"><a href data-ng-click="nav.openSection(\'visualization\')"><span class="glyphicon glyphicon-picture"></span> Visualization</a></li>
+                </div>
+              </app-header-right-sim-loaded>
+              <app-settings>
+              </app-settings>
+              <app-header-right-sim-list>
+                <ul class="nav navbar-nav sr-navbar-right">
+                  <li><a href data-ng-click="nav.showImportModal()"><span class="glyphicon glyphicon-cloud-upload"></span> Import</a></li>
+                </ul>
+              </app-header-right-sim-list>
+            </div>
+        `,
+        controller: function($scope) {
+            $scope.hasLattice = function() {
+                return appState.isLoaded();
+            };
+            $scope.showVisualizationTab = function() {
+                if (appState.isLoaded()) {
+                    return appState.models.beamline.length;
+                }
+                return false;
+            };
+        },
+    };
+});
+
+SIREPO.app.directive('summaryTable', function() {
+    return {
+        restrict: 'A',
+        scope: {
+            modelName: '@summaryTable',
+        },
+        template: `
+            <div class="col-sm-12">
+              <div class="lead" data-ng-if="summaryRows">Results</div>
+                <table>
+                <tr data-ng-repeat="item in summaryRows">
+                  <td data-ng-if="item.length == 1"><br /><strong>{{ item[0] }}</strong></td>
+                  <td data-ng-if="item.length > 1">{{ item[0] }}:</td>
+                  <td>&nbsp;</td>
+                  <td>{{ item[1] }}</td>
+                </tr>
+              </table>
+            </div>
+        `,
+        controller: function($scope) {
+            function parseSummaryRows(summaryText) {
+                var text = summaryText.replace(/^(\n|.)*RESULTS\n+==+/, '').replace(/==+/, '');
+                var label = null;
+                $scope.summaryRows = [];
+                text.split(/\n+/).forEach(function(line) {
+                    line.split(/\s*=\s*/).forEach(function(v) {
+                        if (label) {
+                            $scope.summaryRows.push([label, v]);
+                            label = null;
+                        }
+                        else if (v.indexOf(':') >= 0) {
+                            $scope.summaryRows.push([v]);
+                        }
+                        else {
+                            label = v;
+                        }
+                    });
+                });
+            }
+
+            function updateSummaryInfo(e, summaryText) {
+                if (summaryText) {
+                    parseSummaryRows(summaryText);
+                }
+                else {
+                    $scope.summaryRows = null;
+                }
+            }
+            $scope.$on($scope.modelName + '.summaryData', updateSummaryInfo);
+        }
+    };
+});

--- a/sirepo/package_data/static/json/rshellweg-schema.json
+++ b/sirepo/package_data/static/json/rshellweg-schema.json
@@ -138,21 +138,21 @@
         "source": {
             "config": {
                 "controller": "HellwegSourceController as source",
-                "templateUrl": "/static/html/hellweg-source.html"
+                "templateUrl": "/static/html/rshellweg-source.html"
             }
         },
         "lattice": {
             "route": "/lattice/:simulationId",
             "config": {
                 "controller": "HellwegLatticeController as lattice",
-                "templateUrl": "/static/html/hellweg-lattice.html"
+                "templateUrl": "/static/html/rshellweg-lattice.html"
             }
         },
         "visualization": {
             "route": "/visualization/:simulationId",
             "config": {
                 "controller": "HellwegVisualizationController as visualization",
-                "templateUrl": "/static/html/hellweg-visualization.html"
+                "templateUrl": "/static/html/rshellweg-visualization.html"
             }
         }
     },

--- a/sirepo/package_data/static/json/rshellweg-schema.json
+++ b/sirepo/package_data/static/json/rshellweg-schema.json
@@ -112,8 +112,10 @@
     "dynamicFiles": {
         "sirepoLibs": {
             "js": [
+                "rshellweg.js"
             ],
             "css": [
+                "rshellweg.css"
             ]
         }
     },

--- a/sirepo/package_data/static/json/rshellweg-schema.json
+++ b/sirepo/package_data/static/json/rshellweg-schema.json
@@ -1,0 +1,497 @@
+{
+    "enum": {
+        "BeamDefinition": [
+            ["cst_pid", "CST PID Input File"],
+            ["cst_pit", "CST PIT Input File"],
+            ["transverse_longitude", "Transverse/Longitude Definition"]
+        ],
+        "BeamHistogramReportType": [
+            ["w", "Energy Spectrum"],
+            ["phi", "Phase Spectrum"],
+            ["r", "Radial Spectrum"],
+            ["x", "Horizontal Spectrum"],
+            ["y", "Vertical Spectrum"]
+        ],
+        "BeamReportType": [
+            ["r-ar", "Radial Phase Space (r, r')"],
+            ["x-ax", "Horizontal Phase Space (x, x')"],
+            ["y-ay", "Vertical Phase Space (y, y')"],
+            ["x-y", "Beam Cross Section (x, y)"],
+            ["r-th", "Cylindrical Cross Section (theta, r)"],
+            ["th-ath", "Azmuthal Phase Space (theta, theta')"],
+            ["phi-w", "Longitudinal Phase Space (phi, W)"]
+        ],
+        "EnergyDistributionType": [
+            ["uniform", "Uniform"],
+            ["gaussian", "Gaussian"]
+        ],
+        "FramesPerSecond": [
+            ["1", "1"],
+            ["2", "2"],
+            ["5", "5"],
+            ["10", "10"],
+            ["15", "15"],
+            ["20", "20"]
+        ],
+        "LongitudinalDistribution": [
+            ["norm2d", "Uniform/Gaussian"],
+            ["file1d", "Energy Input File (W)"],
+            ["file2d", "Energy Input File (φ, W)"]
+        ],
+        "ParameterReportType": [
+            ["wav-wmax", "Energy"],
+            ["sbeta-bbeta", "Velocity"],
+            ["rb-ra", "Radius"],
+            ["prf-pbeam", "Power"],
+            ["e0-ereal", "Field Strength"],
+            ["er-enr", "Emittance (r)"],
+            ["ex-enx", "Emittance (x)"],
+            ["ey-eny", "Emittance (y)"],
+            ["e4d-e4dn", "Emittance (4D)"],
+            ["et-ent", "Emittance (th)"]
+        ],
+        "ParticleRange": [
+            ["all", "All Particles"],
+            ["count", "Particle Count"],
+            ["range", "Particle Range"]
+        ],
+        "ParticleRenderCount": [
+            ["1000", "1000"],
+            ["800", "800"],
+            ["500", "500"],
+            ["300", "300"],
+            ["100", "100"]
+        ],
+        "ParticleReportType": [
+            ["w", "Energy"],
+            ["phi", "Phase"],
+            ["r", "Radius (r)"],
+            ["x", "Radius (x)"],
+            ["y", "Radius (y)"]
+        ],
+        "PlotRangeType": [
+            ["none", "None"],
+            ["fit", "Fit Data"],
+            ["fixed", "Fixed"]
+        ],
+        "SaveFileFormat": [
+            ["PID", "CST PID Format"],
+            ["PIT", "CST PIT Format"],
+            ["ASTRA", "ASTRA Format"],
+            ["LIVE", "Live Particles"],
+            ["LOST", "Lost Particles"]
+        ],
+        "SolenoidDefinition": [
+            ["none", "None"],
+            ["values", "From Field Values"],
+            ["file", "From File"]
+        ],
+        "SpaceChargeAlgorithm": [
+            ["none", "None"],
+            ["coulomb", "Ellipsoid Bunch Approximation per Lapostolle Formula"],
+            ["elliptic", "Elliptic Integrals Form-Factors"]
+        ],
+        "SphericalCurvature": [
+            ["flat", "Flat"],
+            ["concave", "Concave"],
+            ["convex", "Convex"]
+        ],
+        "SplineInterpolation": [
+            ["0", "L-Spline"],
+            ["1", "C-Spline"],
+            ["2", "S-Spline"]
+        ],
+        "TransversalDistribution": [
+            ["twiss4d", "Twiss Parameters"],
+            ["sph2d", "Spherical"],
+            ["ell2d", "Elliptical"],
+            ["file2d", "Input File (r, r')"],
+            ["file4d", "Input File (x, x', y, y')"]
+        ]
+    },
+    "dynamicFiles": {
+        "sirepoLibs": {
+            "js": [
+            ],
+            "css": [
+            ]
+        }
+    },
+    "frameIdFields": {
+        "beamAnimation": [
+            "reportType",
+            "histogramBins",
+            "plotRangeType",
+            "horizontalSize",
+            "horizontalOffset",
+            "verticalSize",
+            "verticalOffset",
+            "isRunning"
+        ],
+        "beamHistogramAnimation": ["reportType", "histogramBins"],
+        "particleAnimation": ["reportType", "renderCount"],
+        "parameterAnimation": ["reportType"]
+    },
+    "localRoutes": {
+        "source": {
+            "config": {
+                "controller": "HellwegSourceController as source",
+                "templateUrl": "/static/html/hellweg-source.html"
+            }
+        },
+        "lattice": {
+            "route": "/lattice/:simulationId",
+            "config": {
+                "controller": "HellwegLatticeController as lattice",
+                "templateUrl": "/static/html/hellweg-lattice.html"
+            }
+        },
+        "visualization": {
+            "route": "/visualization/:simulationId",
+            "config": {
+                "controller": "HellwegVisualizationController as visualization",
+                "templateUrl": "/static/html/hellweg-visualization.html"
+            }
+        }
+    },
+    "model": {
+        "beam": {
+            "transversalDistribution": ["Transversal Distribution", "TransversalDistribution"],
+            "longitudinalDistribution": ["Longitudinal Distribution", "LongitudinalDistribution"],
+            "current": ["Current [A]", "Float"],
+            "numberOfParticles": ["Particle Limit", "Integer"],
+            "spaceCharge": ["Space Charge Algorithm", "SpaceChargeAlgorithm"],
+            "spaceChargeCore": ["Space Charge Ellipsoid Core (rms)", "Float", 3.0],
+            "beamDefinition": ["Beam Particle Definition", "BeamDefinition", "transverse_longitude"],
+            "cstCompress": ["Compress Particles into One Bunch", "Boolean"],
+            "transversalFile2d": ["Transversal File (r, r')", "InputFile"],
+            "transversalFile4d": ["Transversal File (x, x', y, y')", "InputFile"],
+            "longitudinalFile1d": ["Longitudinal File (W)", "InputFile"],
+            "longitudinalFile2d": ["Longitudinal File (φ, W)", "InputFile"],
+            "cstFile": ["CST File", "InputFile"]
+        },
+        "beamAnimation": {
+            "reportType": ["Report", "BeamReportType"],
+            "histogramBins": ["Number of Bins", "Integer"],
+            "framesPerSecond": ["Frames per Second", "FramesPerSecond"],
+            "colorMap": ["Color Map", "ColorMap", "viridis"],
+            "plotRangeType": ["Range", "PlotRangeType", "fit"],
+            "horizontalSize": ["Horizontal Size", "Float", 0],
+            "verticalSize": ["Vertical Size", "Float", 0],
+            "horizontalOffset": ["Horizontal Offset", "Float", 0.0],
+            "verticalOffset": ["Vertical Offset", "Float", 0.0],
+            "notes": ["Notes", "Text", ""]
+        },
+        "beamHistogramAnimation": {
+            "reportType": ["Report", "BeamHistogramReportType"],
+            "histogramBins": ["Number of Bins", "Integer"],
+            "framesPerSecond": ["Frames per Second", "FramesPerSecond"],
+            "notes": ["Notes", "Text", ""]
+        },
+        "beamHistogramReport": {
+            "reportType": ["Report", "BeamHistogramReportType"],
+            "histogramBins": ["Number of Bins", "Integer"],
+            "notes": ["Notes", "Text", ""]
+        },
+        "beamReport": {
+            "reportType": ["Report", "BeamReportType"],
+            "histogramBins": ["Number of Bins", "Integer"],
+            "colorMap": ["Color Map", "ColorMap", "viridis"],
+            "notes": ["Notes", "Text", ""]
+        },
+        "cellElement": {
+            "phaseAdvance": ["Phase Advance [deg]", "Float", 120],
+            "phaseVelocity": ["Relative Phase Velocity", "Float", 0.999],
+            "acceleratingInvariant": ["Accelerating Field Invariant (Eλ/√P)", "Float", 200.0],
+            "attenuation": ["Normalized Attenuation [√m]", "Float", 0.01],
+            "aperture": ["Normalized Aperture", "Float", 0.12]
+        },
+        "cellsElement": {
+            "repeat": ["Repeat Count", "Integer", 2],
+            "phaseAdvance": ["Phase Advance [deg]", "Float", 120],
+            "phaseVelocity": ["Relative Phase Velocity", "Float", 0.999],
+            "acceleratingInvariant": ["Accelerating Field Invariant (Eλ/√P)", "Float", 200.0],
+            "attenuation": ["Normalized Attenuation [√m]", "Float", 0.01],
+            "aperture": ["Normalized Aperture", "Float", 0.12]
+        },
+        "driftElement": {
+            "length": ["Length [cm]", "Float", 10.0],
+            "radius": ["Radius [cm]", "Float", 2.0],
+            "meshPoints": ["Mesh Points", "Integer", 20]
+        },
+        "ellipticalDistribution": {
+            "aX": ["a(x) [cm]", "Float"],
+            "bY": ["b(y) [cm]", "Float"],
+            "rotationAngle": ["Rotation Angle [deg]", "Float", 0],
+            "rmsDeviationFactor": ["RMS Deviation Factor (σ = a/factor)", "Float", 1]
+        },
+        "energyPhaseDistribution": {
+            "distributionType": ["Distribution Type", "EnergyDistributionType"],
+            "meanEnergy": ["Mean Energy [MeV]", "Float"],
+            "energySpread": ["Energy Spread [MeV]", "Float"],
+            "energyDeviation": ["Energy RMS Deviation [MeV]", "Float"],
+            "meanPhase": ["Mean Phase [deg]", "Float"],
+            "phaseLength": ["Phase Length [deg]", "Float"],
+            "phaseDeviation": ["Phase RMS Deviation [deg]", "Float"]
+        },
+        "parameterAnimation": {
+            "reportType": ["Report", "ParameterReportType", "wav-wmax"],
+            "notes": ["Notes", "Text", ""]
+        },
+        "particleAnimation": {
+            "reportType": ["Report", "ParticleReportType", "w"],
+            "renderCount": ["Particles to Render", "ParticleRenderCount", "300"],
+            "notes": ["Notes", "Text", ""]
+        },
+        "powerElement": {
+            "inputPower": ["Pulsed Input Power [MW]", "Float", 2.0],
+            "frequency": ["Operating Frequency [MHz]", "Float", 2856.0],
+            "phaseShift": ["Phase Shift [deg]", "Float", 0.0]
+        },
+        "saveElement": {
+            "name": ["File Name", "String", ""],
+            "particleRange": ["Particles", "ParticleRange", "all"],
+            "particleLimit": ["Particle Limit", "Integer", 500],
+            "particleStart": ["Particle Start", "Integer", 500],
+            "particleEnd": ["Particle End", "Integer", 1000],
+            "format": ["File Format", "SaveFileFormat", "PID"]
+        },
+        "simulation": {},
+        "simulationSettings": {
+            "allowBackwardWaves": ["Allow Backward Travelling Waves", "Boolean", "0"],
+            "meshPoints": ["Number of Mesh Points", "Integer", 20],
+            "splineInterpolation": ["Spline Interpolation", "SplineInterpolation", "0"],
+            "smoothing": ["Smoothing", "Float", 0.95]
+        },
+        "simulationStatus": {},
+        "solenoid": {
+            "sourceDefinition": ["Solenoid Definition", "SolenoidDefinition"],
+            "fieldStrength": ["Field Strength (Bz) [Gs]", "Float"],
+            "length": ["Length [cm]", "Float"],
+            "solenoidFile": ["Solenoid File", "InputFile"],
+            "z0": ["Longitudinal Coordinate of Start (Z₀) [cm]", "Float"],
+            "fringeRegion": ["Fringe Field Region [cm]", "Float"]
+        },
+        "sphericalDistribution": {
+            "radialLimit": ["Radial Limit [cm]", "Float"],
+            "curvature": ["Curvature", "SphericalCurvature"],
+            "curvatureFactor": ["Curvature Factor (r'=-sin(r/factor))", "Float"],
+            "thermalEmittance": ["Thermal Emittance [eV]", "Float"]
+        },
+        "twissDistribution": {
+            "horizontalEmittance": ["Horizontal Emittance [cm*rad]", "Float"],
+            "horizontalBeta": ["Horizontal Beta [cm/rad]", "Float"],
+            "horizontalAlpha": ["Horizontal Alpha", "Float"],
+            "verticalEmittance": ["Vertical Emittance [cm*rad]", "Float"],
+            "verticalBeta": ["Vertical Beta [cm/rad]", "Float"],
+            "verticalAlpha": ["Vertical Alpha", "Float"]
+        }
+    },
+    "view": {
+        "beam": {
+            "title": "Beam",
+            "basic": [
+                ["Main", [
+                    "current",
+                    "numberOfParticles",
+                    "spaceCharge",
+                    "spaceChargeCore",
+                    "transversalDistribution",
+                    "transversalFile2d",
+                    "transversalFile4d",
+                    "longitudinalDistribution",
+                    "longitudinalFile1d",
+                    "longitudinalFile2d",
+                    "cstFile",
+                    "cstCompress"
+                ]],
+                ["Transversal Distribution (Twiss)", [
+                    [
+                        ["Horizontal", [
+                            "twissDistribution.horizontalEmittance",
+                            "twissDistribution.horizontalBeta",
+                            "twissDistribution.horizontalAlpha"
+                        ]],
+                        ["Vertical", [
+                            "twissDistribution.verticalEmittance",
+                            "twissDistribution.verticalBeta",
+                            "twissDistribution.verticalAlpha"
+                        ]]
+                    ]
+                ]],
+                ["Transversal Distribution (Spherical)", [
+                    "sphericalDistribution.radialLimit",
+                    "sphericalDistribution.curvature",
+                    "sphericalDistribution.curvatureFactor",
+                    "sphericalDistribution.thermalEmittance"
+                ]],
+                ["Transversal Distribution (Elliptical)", [
+                    "ellipticalDistribution.aX",
+                    "ellipticalDistribution.bY",
+                    "ellipticalDistribution.rotationAngle",
+                    "ellipticalDistribution.rmsDeviationFactor"
+                ]],
+                ["Longitudinal Distribution", [
+                    "energyPhaseDistribution.distributionType",
+                    "energyPhaseDistribution.meanEnergy",
+                    "energyPhaseDistribution.energySpread",
+                    "energyPhaseDistribution.energyDeviation",
+                    "energyPhaseDistribution.meanPhase",
+                    "energyPhaseDistribution.phaseLength",
+                    "energyPhaseDistribution.phaseDeviation"
+                ]],
+                ["Phase Distribution", [
+                    "energyPhaseDistribution.distributionType",
+                    "energyPhaseDistribution.meanPhase",
+                    "energyPhaseDistribution.phaseLength",
+                    "energyPhaseDistribution.phaseDeviation"
+                ]]
+            ],
+            "advanced": []
+        },
+        "beamAnimation": {
+            "title": "Beam Animation",
+            "advanced": [
+                ["Main", [
+                    "reportType",
+                    "histogramBins",
+                    "framesPerSecond",
+                    "colorMap",
+                    "notes"
+                ]],
+                ["Plot Range", [
+                    "plotRangeType",
+                    [
+                        ["Horizontal", [
+                            "horizontalSize",
+                            "horizontalOffset"
+                        ]],
+                        ["Vertical", [
+                            "verticalSize",
+                            "verticalOffset"
+                        ]]
+                    ]
+                ]]
+            ]
+        },
+        "beamHistogramAnimation": {
+            "title": "Beam Graph Animation",
+            "advanced": [
+                "reportType",
+                "histogramBins",
+                "framesPerSecond",
+                "notes"
+            ]
+        },
+        "beamHistogramReport": {
+            "title": "Beam Graph",
+            "advanced": [
+                "reportType",
+                "histogramBins",
+                "notes"
+            ]
+        },
+        "beamReport": {
+            "title": "Beam Report",
+            "advanced": [
+                "reportType",
+                "histogramBins",
+                "colorMap",
+                "notes"
+            ]
+        },
+        "cellElement": {
+            "title": "Cell",
+            "advanced": [
+                "phaseAdvance",
+                "phaseVelocity",
+                "acceleratingInvariant",
+                "attenuation",
+                "aperture"
+            ]
+        },
+        "cellsElement": {
+            "title": "Cells",
+            "advanced": [
+                "repeat",
+                "phaseAdvance",
+                "phaseVelocity",
+                "acceleratingInvariant",
+                "attenuation",
+                "aperture"
+            ]
+        },
+        "driftElement": {
+            "title": "Drift",
+            "advanced": [
+                "length",
+                "radius",
+                "meshPoints"
+            ]
+        },
+        "parameterAnimation": {
+            "title": "Parameter Report",
+            "advanced": [
+                "reportType",
+                "notes"
+            ]
+        },
+        "particleAnimation": {
+            "title": "Particle Report",
+            "advanced": [
+                "reportType",
+                "renderCount",
+                "notes"
+            ]
+        },
+        "powerElement": {
+            "title": "Power",
+            "advanced": [
+                "inputPower",
+                "frequency",
+                "phaseShift"
+            ]
+        },
+        "saveElement": {
+            "title": "Save",
+            "advanced": [
+                "name",
+                "particleRange",
+                "particleLimit",
+                "particleStart",
+                "particleEnd",
+                "format"
+            ]
+        },
+        "simulation": {
+            "title": "Simulation",
+            "advanced": [
+                "name"
+            ]
+        },
+        "simulationSettings": {
+            "title" : "Simulation Settings",
+            "advanced": [
+                "allowBackwardWaves",
+                "meshPoints",
+                "splineInterpolation",
+                "smoothing"
+            ]
+        },
+        "simulationStatus": {
+            "title": "Simulation Status",
+            "advanced": []
+        },
+        "solenoid": {
+            "title": "Solenoid",
+            "basic": [
+                "sourceDefinition",
+                "fieldStrength",
+                "length",
+                "solenoidFile",
+                "z0"
+            ],
+            "advanced": []
+        }
+    }
+}

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -52,6 +52,10 @@
             "longName": "Raydata",
             "shortName": "Raydata"
         },
+        "rshellweg": {
+            "longName": "RSHellweg",
+            "shortName": "RSHellweg"
+        },
         "shadow": {
             "longName": "SHADOW",
             "shortName": "SHADOW"

--- a/sirepo/package_data/template/rshellweg/default-data.json
+++ b/sirepo/package_data/template/rshellweg/default-data.json
@@ -1,0 +1,85 @@
+{
+    "models": {
+        "beamline": [],
+        "beamAnimation": {
+            "framesPerSecond": "5",
+            "histogramBins": 100,
+            "reportType": "x-y",
+            "startTime": 1490386853
+        },
+        "simulation": {
+            "folder": "/",
+            "isExample": false,
+            "name": "hellweg example",
+            "outOfSessionSimulationId": "",
+            "simulationId": "gLicZdXs",
+            "simulationSerial": 1487981155340231
+        },
+        "simulationSettings": {
+            "allowBackwardWaves": "0",
+            "meshPoints": 20,
+            "smoothing": 0.95,
+            "splineInterpolation": "0"
+        },
+        "beam": {
+            "transversalDistribution": "twiss4d",
+            "longitudinalDistribution": "norm2d",
+            "current": 0.01,
+            "numberOfParticles": 1000,
+            "spaceCharge": "none",
+            "spaceChargeCore": 3.0
+        },
+        "beamReport": {
+            "reportType": "x-y",
+            "histogramBins": 100
+        },
+        "beamHistogramReport": {
+            "histogramBins": 100,
+            "reportType": "r"
+        },
+        "beamHistogramAnimation": {
+            "histogramBins": 100,
+            "reportType": "r",
+            "framesPerSecond": "5",
+            "startTime": 1490386853
+        },
+        "ellipticalDistribution": {
+            "aX": 2.0,
+            "bY": 0.5,
+            "rotationAngle": 0,
+            "rmsDeviationFactor": 1.0
+        },
+        "energyPhaseDistribution": {
+            "distributionType": "uniform",
+            "meanEnergy": 1.0,
+            "energySpread": 0.5,
+            "energyDeviation": 0.25,
+            "meanPhase": 90,
+            "phaseLength": 180,
+            "phaseDeviation": 20
+        },
+        "solenoid": {
+            "sourceDefinition": "values",
+            "fieldStrength": 1000,
+            "length": 20,
+            "z0": 0,
+            "fringeRegion": 1
+        },
+        "sphericalDistribution": {
+            "radialLimit": 0.564,
+            "curvature": "flat",
+            "curvatureFactor": 1.0,
+            "thermalEmittance": 0.0
+        },
+        "twissDistribution": {
+            "horizontalEmittance": 0.0005,
+            "horizontalBeta": 2.0,
+            "horizontalAlpha": 0.14,
+            "verticalEmittance": 0.0015,
+            "verticalBeta": 4.0,
+            "verticalAlpha": 0.28
+        }
+    },
+    "simulationType": "rshellweg",
+    "version": "20170214.000000"
+}

--- a/sirepo/package_data/template/rshellweg/examples/drift-tube.json
+++ b/sirepo/package_data/template/rshellweg/examples/drift-tube.json
@@ -1,0 +1,95 @@
+{
+    "models": {
+        "beam": {
+            "current": 0,
+            "longitudinalDistribution": "norm2d",
+            "numberOfParticles": 10000,
+            "spaceCharge": "none",
+            "spaceChargeCore": 3,
+            "transversalDistribution": "sph2d"
+        },
+        "beamAnimation": {
+            "framesPerSecond": "5",
+            "histogramBins": 100,
+            "reportType": "r-ar",
+            "startTime": 1490893613
+        },
+        "beamHistogramAnimation": {
+            "framesPerSecond": "5",
+            "histogramBins": 100,
+            "reportType": "r",
+            "startTime": 1490893613
+        },
+        "beamHistogramReport": {
+            "histogramBins": 100,
+            "reportType": "r"
+        },
+        "beamReport": {
+            "histogramBins": 100,
+            "reportType": "x-y"
+        },
+        "beamline": [
+            {
+                "id": 2,
+                "length": 10,
+                "meshPoints": 500,
+                "radius": 2.5,
+                "type": "driftElement"
+            }
+        ],
+        "ellipticalDistribution": {
+            "aX": 2,
+            "bY": 0.5,
+            "rmsDeviationFactor": 1,
+            "rotationAngle": 0
+        },
+        "energyPhaseDistribution": {
+            "distributionType": "uniform",
+            "energyDeviation": 0.25,
+            "energySpread": 0.001,
+            "meanEnergy": 1,
+            "meanPhase": 0,
+            "phaseDeviation": 20,
+            "phaseLength": 180
+        },
+        "panelState": {
+            "hidden": []
+        },
+        "simulation": {
+            "folder": "/",
+            "isExample": true,
+            "name": "Drift Tube",
+            "outOfSessionSimulationId": "",
+            "simulationId": "kc2EEDr4",
+            "simulationSerial": 1490894013614259
+        },
+        "simulationSettings": {
+            "allowBackwardWaves": "0",
+            "meshPoints": 20,
+            "smoothing": 0.95,
+            "splineInterpolation": "0"
+        },
+        "solenoid": {
+            "fieldStrength": 1000,
+            "fringeRegion": 1,
+            "length": 20,
+            "sourceDefinition": "none",
+            "z0": 0
+        },
+        "sphericalDistribution": {
+            "curvature": "flat",
+            "curvatureFactor": 0,
+            "radialLimit": 5,
+            "thermalEmittance": 10
+        },
+        "twissDistribution": {
+            "horizontalAlpha": 0.14,
+            "horizontalBeta": 2,
+            "horizontalEmittance": 0.0005,
+            "verticalAlpha": 0.28,
+            "verticalBeta": 4,
+            "verticalEmittance": 0.0015
+        }
+    },
+    "simulationType": "rshellweg"
+}

--- a/sirepo/package_data/template/rshellweg/examples/emittance-conservation.json
+++ b/sirepo/package_data/template/rshellweg/examples/emittance-conservation.json
@@ -1,0 +1,109 @@
+{
+    "models": {
+        "beam": {
+            "current": 0,
+            "longitudinalDistribution": "norm2d",
+            "numberOfParticles": 1000,
+            "spaceCharge": "none",
+            "spaceChargeCore": 3,
+            "transversalDistribution": "sph2d"
+        },
+        "beamAnimation": {
+            "framesPerSecond": "5",
+            "histogramBins": 100,
+            "reportType": "x-y",
+            "startTime": 1490895219
+        },
+        "beamHistogramAnimation": {
+            "framesPerSecond": "5",
+            "histogramBins": 100,
+            "reportType": "r",
+            "startTime": 1490895219
+        },
+        "beamHistogramReport": {
+            "histogramBins": 100,
+            "reportType": "r"
+        },
+        "beamReport": {
+            "histogramBins": 100,
+            "reportType": "x-y"
+        },
+        "beamline": [
+            {
+                "frequency": 2856,
+                "id": 2,
+                "inputPower": 5,
+                "phaseShift": 0,
+                "type": "powerElement"
+            },
+            {
+                "acceleratingInvariant": 500,
+                "aperture": 0,
+                "attenuation": 0,
+                "id": 3,
+                "phaseAdvance": 120,
+                "phaseVelocity": 0.999,
+                "repeat": 6,
+                "type": "cellsElement"
+            },
+            {
+                "id": 4,
+                "length": 5,
+                "meshPoints": 100,
+                "radius": 10,
+                "type": "driftElement"
+            }
+        ],
+        "ellipticalDistribution": {
+            "aX": 2,
+            "bY": 0.5,
+            "rmsDeviationFactor": 1,
+            "rotationAngle": 0
+        },
+        "energyPhaseDistribution": {
+            "distributionType": "uniform",
+            "energyDeviation": 0.25,
+            "energySpread": 0.001,
+            "meanEnergy": 0.3,
+            "meanPhase": 0,
+            "phaseDeviation": 20,
+            "phaseLength": 1
+        },
+        "simulation": {
+            "folder": "/",
+            "isExample": true,
+            "name": "Emittance Conservation",
+            "outOfSessionSimulationId": "",
+            "simulationId": "FIhkFoFj",
+            "simulationSerial": 1490895275688315
+        },
+        "simulationSettings": {
+            "allowBackwardWaves": "0",
+            "meshPoints": 20,
+            "smoothing": 0.95,
+            "splineInterpolation": "0"
+        },
+        "solenoid": {
+            "fieldStrength": 1000,
+            "fringeRegion": 1,
+            "length": 20,
+            "sourceDefinition": "none",
+            "z0": 0
+        },
+        "sphericalDistribution": {
+            "curvature": "flat",
+            "curvatureFactor": 0,
+            "radialLimit": 0.564,
+            "thermalEmittance": 0.5
+        },
+        "twissDistribution": {
+            "horizontalAlpha": 0.14,
+            "horizontalBeta": 2,
+            "horizontalEmittance": 0.0005,
+            "verticalAlpha": 0.28,
+            "verticalBeta": 4,
+            "verticalEmittance": 0.0015
+        }
+    },
+    "simulationType": "rshellweg"
+}

--- a/sirepo/package_data/template/rshellweg/examples/rf-fields.json
+++ b/sirepo/package_data/template/rshellweg/examples/rf-fields.json
@@ -1,0 +1,103 @@
+{
+    "models": {
+        "beam": {
+            "current": 0,
+            "longitudinalDistribution": "norm2d",
+            "numberOfParticles": 1000,
+            "spaceCharge": "none",
+            "spaceChargeCore": 3,
+            "transversalDistribution": "sph2d"
+        },
+        "beamAnimation": {
+            "framesPerSecond": "5",
+            "histogramBins": 100,
+            "reportType": "x-y",
+            "startTime": 1490895426,
+            "plotRangeType": "none"
+        },
+        "beamHistogramAnimation": {
+            "framesPerSecond": "5",
+            "histogramBins": 100,
+            "reportType": "r",
+            "startTime": 1490895426
+        },
+        "beamHistogramReport": {
+            "histogramBins": 100,
+            "reportType": "r"
+        },
+        "beamReport": {
+            "histogramBins": 100,
+            "reportType": "x-y"
+        },
+        "beamline": [
+            {
+                "frequency": 2856,
+                "id": 2,
+                "inputPower": 1,
+                "phaseShift": 0,
+                "type": "powerElement"
+            },
+            {
+                "acceleratingInvariant": 50,
+                "aperture": 0.1,
+                "attenuation": 0,
+                "id": 3,
+                "phaseAdvance": 120,
+                "phaseVelocity": 0.3,
+                "repeat": 24,
+                "type": "cellsElement"
+            }
+        ],
+        "ellipticalDistribution": {
+            "aX": 2,
+            "bY": 0.5,
+            "rmsDeviationFactor": 1,
+            "rotationAngle": 0
+        },
+        "energyPhaseDistribution": {
+            "distributionType": "uniform",
+            "energyDeviation": 0.25,
+            "energySpread": 1e-05,
+            "meanEnergy": 0.025,
+            "meanPhase": 90,
+            "phaseDeviation": 20,
+            "phaseLength": 180
+        },
+        "simulation": {
+            "folder": "/",
+            "isExample": true,
+            "name": "RF Fields",
+            "outOfSessionSimulationId": "",
+            "simulationId": "gfqdzAqI",
+            "simulationSerial": 1490895481759865
+        },
+        "simulationSettings": {
+            "allowBackwardWaves": "0",
+            "meshPoints": 20,
+            "smoothing": 0.95,
+            "splineInterpolation": "0"
+        },
+        "solenoid": {
+            "fieldStrength": 1000,
+            "fringeRegion": 1,
+            "length": 20,
+            "sourceDefinition": "none",
+            "z0": 0
+        },
+        "sphericalDistribution": {
+            "curvature": "flat",
+            "curvatureFactor": 0,
+            "radialLimit": 0.001,
+            "thermalEmittance": 0
+        },
+        "twissDistribution": {
+            "horizontalAlpha": 0.14,
+            "horizontalBeta": 2,
+            "horizontalEmittance": 0.0005,
+            "verticalAlpha": 0.28,
+            "verticalBeta": 4,
+            "verticalEmittance": 0.0015
+        }
+    },
+    "simulationType": "rshellweg"
+}

--- a/sirepo/package_data/template/rshellweg/examples/solenoid.json
+++ b/sirepo/package_data/template/rshellweg/examples/solenoid.json
@@ -1,0 +1,92 @@
+{
+    "models": {
+        "beam": {
+            "current": 0,
+            "longitudinalDistribution": "norm2d",
+            "numberOfParticles": 1000,
+            "spaceCharge": "none",
+            "spaceChargeCore": 3,
+            "transversalDistribution": "sph2d"
+        },
+        "beamAnimation": {
+            "framesPerSecond": "5",
+            "histogramBins": 100,
+            "reportType": "x-y",
+            "startTime": 1490894383
+        },
+        "beamHistogramAnimation": {
+            "framesPerSecond": "5",
+            "histogramBins": 100,
+            "reportType": "r",
+            "startTime": 1490894383
+        },
+        "beamHistogramReport": {
+            "histogramBins": 100,
+            "reportType": "r"
+        },
+        "beamReport": {
+            "histogramBins": 100,
+            "reportType": "x-y"
+        },
+        "beamline": [
+            {
+                "id": 2,
+                "length": 25,
+                "meshPoints": 500,
+                "radius": 1,
+                "type": "driftElement"
+            }
+        ],
+        "ellipticalDistribution": {
+            "aX": 2,
+            "bY": 0.5,
+            "rmsDeviationFactor": 1,
+            "rotationAngle": 0
+        },
+        "energyPhaseDistribution": {
+            "distributionType": "uniform",
+            "energyDeviation": 0.25,
+            "energySpread": 1e-05,
+            "meanEnergy": 0.03,
+            "meanPhase": 0,
+            "phaseDeviation": 20,
+            "phaseLength": 180
+        },
+        "simulation": {
+            "folder": "/",
+            "isExample": true,
+            "name": "Solenoid",
+            "outOfSessionSimulationId": "",
+            "simulationId": "LUV9dLw2",
+            "simulationSerial": 1490894709088191
+        },
+        "simulationSettings": {
+            "allowBackwardWaves": "0",
+            "meshPoints": 20,
+            "smoothing": 0.95,
+            "splineInterpolation": "0"
+        },
+        "solenoid": {
+            "fieldStrength": 500,
+            "fringeRegion": 1,
+            "length": 25,
+            "sourceDefinition": "values",
+            "z0": 1
+        },
+        "sphericalDistribution": {
+            "curvature": "flat",
+            "curvatureFactor": 0,
+            "radialLimit": 0.5,
+            "thermalEmittance": 0
+        },
+        "twissDistribution": {
+            "horizontalAlpha": 0.14,
+            "horizontalBeta": 2,
+            "horizontalEmittance": 0.0005,
+            "verticalAlpha": 0.28,
+            "verticalBeta": 4,
+            "verticalEmittance": 0.0015
+        }
+    },
+    "simulationType": "rshellweg"
+}

--- a/sirepo/package_data/template/rshellweg/examples/space-charge.json
+++ b/sirepo/package_data/template/rshellweg/examples/space-charge.json
@@ -1,0 +1,93 @@
+{
+    "models": {
+        "beam": {
+            "current": 1,
+            "longitudinalDistribution": "norm2d",
+            "numberOfParticles": 1000,
+            "spaceCharge": "elliptic",
+            "spaceChargeCore": 3,
+            "transversalDistribution": "twiss4d"
+        },
+        "beamAnimation": {
+            "framesPerSecond": "5",
+            "histogramBins": 100,
+            "reportType": "r-ar",
+            "startTime": 1490893953,
+            "plotRangeType": "none"
+        },
+        "beamHistogramAnimation": {
+            "framesPerSecond": "5",
+            "histogramBins": 100,
+            "reportType": "r",
+            "startTime": 1490893953
+        },
+        "beamHistogramReport": {
+            "histogramBins": 100,
+            "reportType": "r"
+        },
+        "beamReport": {
+            "histogramBins": 100,
+            "reportType": "x-y"
+        },
+        "beamline": [
+            {
+                "id": 2,
+                "length": 30,
+                "meshPoints": 500,
+                "radius": 10,
+                "type": "driftElement"
+            }
+        ],
+        "ellipticalDistribution": {
+            "aX": 2,
+            "bY": 0.5,
+            "rmsDeviationFactor": 1,
+            "rotationAngle": 0
+        },
+        "energyPhaseDistribution": {
+            "distributionType": "uniform",
+            "energyDeviation": 0.25,
+            "energySpread": 0.001,
+            "meanEnergy": 0.1,
+            "meanPhase": 90,
+            "phaseDeviation": 20,
+            "phaseLength": 10
+        },
+        "simulation": {
+            "folder": "/",
+            "isExample": true,
+            "name": "Space Charge",
+            "outOfSessionSimulationId": "",
+            "simulationId": "Wc0Nn2js",
+            "simulationSerial": 1490894235883413
+        },
+        "simulationSettings": {
+            "allowBackwardWaves": "0",
+            "meshPoints": 20,
+            "smoothing": 0.95,
+            "splineInterpolation": "0"
+        },
+        "solenoid": {
+            "fieldStrength": 1000,
+            "fringeRegion": 1,
+            "length": 20,
+            "sourceDefinition": "none",
+            "z0": 0
+        },
+        "sphericalDistribution": {
+            "curvature": "flat",
+            "curvatureFactor": 1,
+            "radialLimit": 0.564,
+            "thermalEmittance": 0
+        },
+        "twissDistribution": {
+            "horizontalAlpha": 0,
+            "horizontalBeta": 3,
+            "horizontalEmittance": 0.004,
+            "verticalAlpha": 0,
+            "verticalBeta": 4,
+            "verticalEmittance": 0.004
+        }
+    },
+    "simulationType": "rshellweg"
+}

--- a/sirepo/package_data/template/rshellweg/parameters.py.jinja
+++ b/sirepo/package_data/template/rshellweg/parameters.py.jinja
@@ -1,0 +1,18 @@
+# {{simulation_name}}
+
+ini_file = """
+[NUMERIC]
+Number of Mesh Points = {{simulationSettings_meshPoints}}
+Spline Interpolation = {{simulationSettings_splineInterpolation}}
+Smoothing = {{simulationSettings_smoothing}}
+"""
+
+input_file = """
+{{ optionsCommand }}
+{{ solenoidCommand }}
+{{ chargeCommand }}
+{{ beamCommand }}
+{{ currentCommand }}
+{{ latticeCommands }}
+END
+"""

--- a/sirepo/pkcli/rshellweg.py
+++ b/sirepo/pkcli/rshellweg.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Wrapper to run Hellweg from the command line.
+
+:copyright: Copyright (c) 2023 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from __future__ import absolute_import, division, print_function
+from pykern import pkio
+from pykern.pkdebug import pkdp, pkdc
+from rshellweg import solver
+from sirepo import simulation_db
+from sirepo.template import template_common
+import copy
+import py.path
+import sirepo.template.rshellweg as template
+
+
+def run(cfg_dir):
+    """Run Hellweg in ``cfg_dir``
+
+    Args:
+        cfg_dir (str): directory to run hellweg in
+    """
+    _run_hellweg(cfg_dir)
+    sim_in = simulation_db.read_json(template_common.INPUT_BASE_NAME)
+    r = sim_in.report
+    template_common.write_sequential_result(
+        template_common.sim_frame_dispatch(
+            copy.deepcopy(sim_in.models[r]).pkupdate(
+                # TODO(e-carlin): Is this right? What should frameIndex be?
+                frameIndex=0,
+                frameReport=r.replace("Report", "Animation"),
+                run_dir=pkio.py_path(cfg_dir),
+                sim_in=sim_in,
+                simulationType="rshellweg",
+            ),
+        ),
+    )
+
+
+def run_background(cfg_dir):
+    _run_hellweg(cfg_dir)
+
+
+def _run_hellweg(cfg_dir):
+    r = template_common.exec_parameters()
+    pkio.write_text(template.HELLWEG_INPUT_FILE, r.input_file)
+    pkio.write_text(template.HELLWEG_INI_FILE, r.ini_file)
+    s = solver.BeamSolver(template.HELLWEG_INI_FILE, template.HELLWEG_INPUT_FILE)
+    s.solve()
+    s.save_output(template.HELLWEG_SUMMARY_FILE)
+    s.dump_bin(template.HELLWEG_DUMP_FILE)

--- a/sirepo/sim_data/rshellweg.py
+++ b/sirepo/sim_data/rshellweg.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""simulation data operations
+
+:copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from __future__ import absolute_import, division, print_function
+from pykern.pkdebug import pkdp
+import sirepo.sim_data
+
+
+class SimData(sirepo.sim_data.SimDataBase):
+
+    ANALYSIS_ONLY_FIELDS = frozenset(("colorMap", "notes"))
+
+    @classmethod
+    def fixup_old_data(cls, data, **kwargs):
+        dm = data.models
+        cls._init_models(
+            dm,
+            (
+                "beamAnimation",
+                "beamHistogramAnimation",
+                "parameterAnimation",
+                "particleAnimation",
+            ),
+        )
+        dm.solenoid.setdefault("solenoidFile", "")
+        # TODO(robnagler) setdefaults?
+        if "beamDefinition" not in dm.beam:
+            dm.beam.update(
+                beamDefinition="transverse_longitude",
+                cstCompress="0",
+                transversalFile2d="",
+                transversalFile4d="",
+                longitudinalFile1d="",
+                longitudinalFile2d="",
+                cstFile="",
+            )
+        cls._organize_example(data)
+
+    @classmethod
+    def _compute_job_fields(cls, data, r, compute_model):
+        return cls._non_analysis_fields(data, r) + [
+            "beam",
+            "ellipticalDistribution",
+            "energyPhaseDistribution",
+            "solenoid",
+            "sphericalDistribution",
+            "twissDistribution",
+        ]
+
+    @classmethod
+    def _compute_model(cls, analysis_model, *args, **kwargs):
+        if "bunchReport" in analysis_model:
+            return "bunchReport"
+        return super()._compute_model(analysis_model, *args, **kwargs)
+
+    @classmethod
+    def _lib_file_basenames(cls, data):
+        res = []
+        s = data.models.solenoid
+        if s.sourceDefinition == "file" and s.solenoidFile:
+            res.append(
+                cls.lib_file_name_with_model_field(
+                    "solenoid", "solenoidFile", s.solenoidFile
+                )
+            )
+        beam = data.models.beam
+        if beam.beamDefinition == "cst_pit" or beam.beamDefinition == "cst_pid":
+            res.append(
+                cls.lib_file_name_with_model_field("beam", "cstFile", beam.cstFile)
+            )
+        if beam.beamDefinition == "transverse_longitude":
+            if beam.transversalDistribution == "file2d":
+                res.append(
+                    cls.lib_file_name_with_model_field(
+                        "beam", "transversalFile2d", beam.transversalFile2d
+                    )
+                )
+            elif beam.transversalDistribution == "file4d":
+                res.append(
+                    cls.lib_file_name_with_model_field(
+                        "beam", "transversalFile4d", beam.transversalFile4d
+                    )
+                )
+            if beam.longitudinalDistribution == "file1d":
+                res.append(
+                    cls.lib_file_name_with_model_field(
+                        "beam", "longitudinalFile1d", beam.longitudinalFile1d
+                    )
+                )
+            if beam.longitudinalDistribution == "file2d":
+                res.append(
+                    cls.lib_file_name_with_model_field(
+                        "beam", "longitudinalFile2d", beam.longitudinalFile2d
+                    )
+                )
+        return res

--- a/sirepo/template/rshellweg.py
+++ b/sirepo/template/rshellweg.py
@@ -37,6 +37,14 @@ _DEFAULT_DRIFT_ELEMENT = "DRIFT 1e-16 1e+16 2" + "\n"
 _HELLWEG_PARSED_FILE = "PARSED.TXT"
 
 
+def analysis_job_compute_particle_ranges(data, run_dir, **kwargs):
+    return template_common.compute_field_range(
+        data,
+        _compute_range_across_files,
+        run_dir,
+    )
+
+
 def background_percent_complete(report, run_dir, is_running):
     if is_running:
         return PKDict(
@@ -59,13 +67,7 @@ def background_percent_complete(report, run_dir, is_running):
     )
 
 
-def get_application_data(data, **kwargs):
-    if data["method"] == "compute_particle_ranges":
-        return template_common.compute_field_range(data, _compute_range_across_files)
-    assert False, "unknown application data method: {}".format(data["method"])
-
-
-def python_source_for_model(data, model):
+def python_source_for_model(data, model, qcall, **kwargs):
     return """
 from rshellweg import solver
 
@@ -206,7 +208,7 @@ def write_parameters(data, run_dir, is_parallel):
     )
 
 
-def _compute_range_across_files(run_dir, data):
+def _compute_range_across_files(run_dir, **kwargs):
     res = {}
     for v in SCHEMA.enum.BeamReportType:
         x, y = v[0].split("-")

--- a/sirepo/template/rshellweg.py
+++ b/sirepo/template/rshellweg.py
@@ -1,0 +1,475 @@
+# -*- coding: utf-8 -*-
+"""Hellweg execution template.
+
+:copyright: Copyright (c) 2017 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+
+from __future__ import absolute_import, division, print_function
+from pykern import pkio
+from pykern.pkcollections import PKDict
+from pykern.pkdebug import pkdc, pkdp
+from rshellweg import solver
+from sirepo import simulation_db
+from sirepo.template import template_common, rshellweg_dump_reader
+import math
+import numpy as np
+import os.path
+import py.path
+import re
+import sirepo.sim_data
+
+_SIM_DATA, SIM_TYPE, SCHEMA = sirepo.sim_data.template_globals()
+
+HELLWEG_DUMP_FILE = "all-data.bin"
+
+HELLWEG_SUMMARY_FILE = "output.txt"
+
+HELLWEG_INI_FILE = "defaults.ini"
+
+HELLWEG_INPUT_FILE = "input.txt"
+
+WANT_BROWSER_FRAME_CACHE = True
+
+# lattice element is required so make it very short and wide drift
+_DEFAULT_DRIFT_ELEMENT = "DRIFT 1e-16 1e+16 2" + "\n"
+
+_HELLWEG_PARSED_FILE = "PARSED.TXT"
+
+
+def background_percent_complete(report, run_dir, is_running):
+    if is_running:
+        return PKDict(
+            percentComplete=0,
+            frameCount=0,
+        )
+    dump_file = _dump_file(run_dir)
+    if os.path.exists(dump_file):
+        beam_header = rshellweg_dump_reader.beam_header(dump_file)
+        last_update_time = int(os.path.getmtime(dump_file))
+        frame_count = beam_header.NPoints
+        return PKDict(
+            lastUpdateTime=last_update_time,
+            percentComplete=100,
+            frameCount=frame_count,
+            summaryData=_summary_text(run_dir),
+        )
+    return PKDict(
+        percentComplete=100, frameCount=0, error=_parse_error_message(run_dir)
+    )
+
+
+def get_application_data(data, **kwargs):
+    if data["method"] == "compute_particle_ranges":
+        return template_common.compute_field_range(data, _compute_range_across_files)
+    assert False, "unknown application data method: {}".format(data["method"])
+
+
+def python_source_for_model(data, model):
+    return """
+from rshellweg import solver
+
+{}
+
+with open('input.txt', 'w') as f:
+    f.write(input_file)
+
+with open('defaults.ini', 'w') as f:
+    f.write(ini_file)
+
+s = solver.BeamSolver('defaults.ini', 'input.txt')
+s.solve()
+s.save_output('output.txt')
+    """.format(
+        _generate_parameters_file(data, is_parallel=len(data.models.beamline))
+    )
+
+
+def remove_last_frame(run_dir):
+    pass
+
+
+def sim_frame_beamAnimation(frame_args):
+    data = simulation_db.read_json(
+        frame_args.run_dir.join(template_common.INPUT_BASE_NAME)
+    )
+    model = data.models.beamAnimation
+    model.update(frame_args)
+    beam_info = rshellweg_dump_reader.beam_info(
+        _dump_file(frame_args.run_dir), frame_args.frameIndex
+    )
+    x, y = frame_args.reportType.split("-")
+    values = [
+        rshellweg_dump_reader.get_points(beam_info, x),
+        rshellweg_dump_reader.get_points(beam_info, y),
+    ]
+    model["x"] = x
+    model["y"] = y
+    # see issue #872
+    if not np.any(values):
+        values = [[], []]
+    return template_common.heatmap(
+        values,
+        model,
+        {
+            "x_label": rshellweg_dump_reader.get_label(x),
+            "y_label": rshellweg_dump_reader.get_label(y),
+            "title": _report_title(frame_args.reportType, "BeamReportType", beam_info),
+            "z_label": "Number of Particles",
+            "summaryData": _summary_text(frame_args.run_dir),
+        },
+    )
+
+
+def sim_frame_beamHistogramAnimation(frame_args):
+    beam_info = rshellweg_dump_reader.beam_info(
+        _dump_file(frame_args.run_dir), frame_args.frameIndex
+    )
+    points = rshellweg_dump_reader.get_points(beam_info, frame_args.reportType)
+    hist, edges = np.histogram(
+        points, template_common.histogram_bins(frame_args.histogramBins)
+    )
+    return {
+        "title": _report_title(
+            frame_args.reportType, "BeamHistogramReportType", beam_info
+        ),
+        "x_range": [edges[0], edges[-1]],
+        "y_label": "Number of Particles",
+        "x_label": rshellweg_dump_reader.get_label(frame_args.reportType),
+        "points": hist.T.tolist(),
+    }
+
+
+def sim_frame_parameterAnimation(frame_args):
+    s = solver.BeamSolver(
+        os.path.join(str(frame_args.run_dir), HELLWEG_INI_FILE),
+        os.path.join(str(frame_args.run_dir), HELLWEG_INPUT_FILE),
+    )
+    s.load_bin(os.path.join(str(frame_args.run_dir), HELLWEG_DUMP_FILE))
+    y1_var, y2_var = frame_args.reportType.split("-")
+    x_field = "z"
+    x = s.get_structure_parameters(_parameter_index(x_field))
+    y1 = s.get_structure_parameters(_parameter_index(y1_var))
+    y1_extent = [np.min(y1), np.max(y1)]
+    y2 = s.get_structure_parameters(_parameter_index(y2_var))
+    y2_extent = [np.min(y2), np.max(y2)]
+    return {
+        "title": _enum_text("ParameterReportType", frame_args.reportType),
+        "x_range": [x[0], x[-1]],
+        "y_label": rshellweg_dump_reader.get_parameter_label(y1_var),
+        "x_label": rshellweg_dump_reader.get_parameter_label(x_field),
+        "x_points": x,
+        "points": [
+            y1,
+            y2,
+        ],
+        "y_range": [min(y1_extent[0], y2_extent[0]), max(y1_extent[1], y2_extent[1])],
+        "y1_title": rshellweg_dump_reader.get_parameter_title(y1_var),
+        "y2_title": rshellweg_dump_reader.get_parameter_title(y2_var),
+    }
+
+
+def sim_frame_particleAnimation(frame_args):
+    x_field = "z0"
+    particle_info = rshellweg_dump_reader.particle_info(
+        _dump_file(frame_args.run_dir),
+        frame_args.reportType,
+        int(frame_args.renderCount),
+    )
+    x = particle_info["z_values"]
+    return {
+        "title": _enum_text("ParticleReportType", frame_args.reportType),
+        "x_range": [np.min(x), np.max(x)],
+        "y_label": rshellweg_dump_reader.get_label(frame_args.reportType),
+        "x_label": rshellweg_dump_reader.get_label(x_field),
+        "x_points": x,
+        "points": particle_info["y_values"],
+        "y_range": particle_info["y_range"],
+    }
+
+
+def write_parameters(data, run_dir, is_parallel):
+    """Write the parameters file
+
+    Args:
+        data (dict): input
+        run_dir (py.path): where to write
+        is_parallel (bool): run in background?
+    """
+    pkio.write_text(
+        run_dir.join(template_common.PARAMETERS_PYTHON_FILE),
+        _generate_parameters_file(
+            data,
+            run_dir,
+            is_parallel,
+        ),
+    )
+
+
+def _compute_range_across_files(run_dir, data):
+    res = {}
+    for v in SCHEMA.enum.BeamReportType:
+        x, y = v[0].split("-")
+        res[x] = []
+        res[y] = []
+    dump_file = _dump_file(run_dir)
+    if not os.path.exists(dump_file):
+        return res
+    beam_header = rshellweg_dump_reader.beam_header(dump_file)
+    for frame in range(beam_header.NPoints):
+        beam_info = rshellweg_dump_reader.beam_info(dump_file, frame)
+        for field in res:
+            values = rshellweg_dump_reader.get_points(beam_info, field)
+            if not values:
+                pass
+            elif res[field]:
+                res[field][0] = min(min(values), res[field][0])
+                res[field][1] = max(max(values), res[field][1])
+            else:
+                res[field] = [min(values), max(values)]
+    return res
+
+
+def _dump_file(run_dir):
+    return os.path.join(str(run_dir), HELLWEG_DUMP_FILE)
+
+
+def _enum_text(enum_name, v):
+    enum_values = SCHEMA["enum"][enum_name]
+    for e in enum_values:
+        if e[0] == v:
+            return e[1]
+    raise RuntimeError("invalid enum value: {}, {}".format(enum_values, v))
+
+
+def _generate_beam(models):
+    # BEAM SPH2D 0.564 -15 5 NORM2D 0.30 0.0000001 90 180
+    beam_def = models.beam.beamDefinition
+    if beam_def == "transverse_longitude":
+        return "BEAM {} {}".format(
+            _generate_transverse_dist(models), _generate_longitude_dist(models)
+        )
+    if beam_def == "cst_pit":
+        return "BEAM CST_PIT {} {}".format(
+            _SIM_DATA.lib_file_name_with_model_field(
+                "beam", "cstFile", models.beam.cstFile
+            ),
+            "COMPRESS" if models.beam.cstCompress else "",
+        )
+    if beam_def == "cst_pid":
+        return "BEAM CST_PID {} {}".format(
+            _SIM_DATA.lib_file_name_with_model_field(
+                "beam", "cstFile", models.beam.cstFile
+            ),
+            _generate_energy_phase_distribution(models.energyPhaseDistribution),
+        )
+    raise RuntimeError("invalid beam def: {}".format(beam_def))
+
+
+def _generate_cell_params(el):
+    # TODO(pjm): add an option field to select auto-calculate
+    if el.attenuation == 0 and el.aperture == 0:
+        return "{} {} {}".format(
+            el.phaseAdvance, el.phaseVelocity, el.acceleratingInvariant
+        )
+    return "{} {} {} {} {}".format(
+        el.phaseAdvance,
+        el.phaseVelocity,
+        el.acceleratingInvariant,
+        el.attenuation,
+        el.aperture,
+    )
+
+
+def _generate_charge(models):
+    if models.beam.spaceCharge == "none":
+        return ""
+    return "SPCHARGE {} {}".format(
+        models.beam.spaceCharge.upper(), models.beam.spaceChargeCore
+    )
+
+
+def _generate_current(models):
+    return "CURRENT {} {}".format(models.beam.current, models.beam.numberOfParticles)
+
+
+def _generate_energy_phase_distribution(dist):
+    return "{} {} {}".format(
+        dist.meanPhase,
+        dist.phaseLength,
+        dist.phaseDeviation if dist.distributionType == "gaussian" else "",
+    )
+
+
+def _generate_lattice(models):
+    res = ""
+    for el in models.beamline:
+        if el.type == "powerElement":
+            res += "POWER {} {} {}".format(el.inputPower, el.frequency, el.phaseShift)
+        elif el.type == "cellElement":
+            res += "CELL {}".format(_generate_cell_params(el))
+            has_cell_or_drift = True
+        elif el.type == "cellsElement":
+            res += "CELLS {} {}".format(el.repeat, _generate_cell_params(el))
+            has_cell_or_drift = True
+        elif el.type == "driftElement":
+            res += "DRIFT {} {} {}".format(el.length, el.radius, el.meshPoints)
+            has_cell_or_drift = True
+        elif el.type == "saveElement":
+            # TODO(pjm): implement this
+            pass
+        else:
+            raise RuntimeError("unknown element type: {}".format(el.type))
+        res += "\n"
+    return res
+
+
+def _generate_longitude_dist(models):
+    dist_type = models.beam.longitudinalDistribution
+    if dist_type == "norm2d":
+        dist = models.energyPhaseDistribution
+        if dist.distributionType == "uniform":
+            return "NORM2D {} {} {} {}".format(
+                dist.meanEnergy, dist.energySpread, dist.meanPhase, dist.phaseLength
+            )
+        if dist.distributionType == "gaussian":
+            return "NORM2D {} {} {} {} {} {}".format(
+                dist.meanEnergy,
+                dist.energySpread,
+                dist.energyDeviation,
+                dist.meanPhase,
+                dist.phaseLength,
+                dist.phaseDeviation,
+            )
+        raise RuntimeError(
+            "unknown longitudinal distribution type: {}".format(
+                models.longitudinalDistribution.distributionType
+            )
+        )
+    if dist_type == "file1d":
+        return "FILE1D {} {}".format(
+            _SIM_DATA.lib_file_name_with_model_field(
+                "beam", "longitudinalFile1d", models.beam.longitudinalFile1d
+            ),
+            _generate_energy_phase_distribution(models.energyPhaseDistribution),
+        )
+    if dist_type == "file2d":
+        return "FILE2D {}".format(
+            _SIM_DATA.lib_file_name_with_model_field(
+                "beam", "transversalFile2d", beam.transversalFile2d
+            )
+        )
+
+    raise RuntimeError(
+        "unknown longitudinal distribution: {}".format(
+            models.beam.longitudinalDistribution
+        )
+    )
+
+
+def _generate_options(models):
+    if models.simulationSettings.allowBackwardWaves == "1":
+        return "OPTIONS REVERSE"
+    return ""
+
+
+def _generate_parameters_file(data, run_dir=None, is_parallel=False):
+    template_common.validate_models(data, SCHEMA)
+    v = template_common.flatten_data(data["models"], {})
+    v["optionsCommand"] = _generate_options(data["models"])
+    v["solenoidCommand"] = _generate_solenoid(data["models"])
+    v["beamCommand"] = _generate_beam(data["models"])
+    v["currentCommand"] = _generate_current(data["models"])
+    v["chargeCommand"] = _generate_charge(data["models"])
+    if is_parallel:
+        v["latticeCommands"] = _generate_lattice(data["models"])
+    else:
+        v["latticeCommands"] = _DEFAULT_DRIFT_ELEMENT
+    return template_common.render_jinja(SIM_TYPE, v)
+
+
+def _generate_solenoid(models):
+    solenoid = models.solenoid
+    if solenoid.sourceDefinition == "none":
+        return ""
+    if solenoid.sourceDefinition == "values":
+        # TODO(pjm): latest version also has solenoid.fringeRegion
+        return "SOLENOID {} {} {}".format(
+            solenoid.fieldStrength, solenoid.length, solenoid.z0
+        )
+    if solenoid.sourceDefinition == "file":
+        return "SOLENOID {}".format(
+            _SIM_DATA.lib_file_name_with_model_field(
+                "solenoid", "solenoidFile", solenoid.solenoidFile
+            )
+        )
+    raise RuntimeError(
+        "unknown solenoidDefinition: {}".format(solenoid.sourceDefinition)
+    )
+
+
+def _generate_transverse_dist(models):
+    dist_type = models.beam.transversalDistribution
+    if dist_type == "twiss4d":
+        dist = models.twissDistribution
+        return "TWISS4D {} {} {} {} {} {}".format(
+            dist.horizontalAlpha,
+            dist.horizontalBeta,
+            dist.horizontalEmittance,
+            dist.verticalAlpha,
+            dist.verticalBeta,
+            dist.verticalEmittance,
+        )
+    if dist_type == "sph2d":
+        dist = models.sphericalDistribution
+        if dist.curvature == "flat":
+            dist.curvatureFactor = 0
+        return "SPH2D {} {} {}".format(
+            dist.radialLimit, dist.curvatureFactor, dist.thermalEmittance
+        )
+    if dist_type == "ell2d":
+        dist = models.ellipticalDistribution
+        return "ELL2D {} {} {} {}".format(
+            dist.aX, dist.bY, dist.rotationAngle, dist.rmsDeviationFactor
+        )
+    beam = models.beam
+    if dist_type == "file2d":
+        return "FILE2D {}".format(
+            _SIM_DATA.lib_file_name_with_model_field(
+                "beam", "transversalFile2d", beam.transversalFile2d
+            )
+        )
+    if dist_type == "file4d":
+        return "FILE4D {}".format(
+            _SIM_DATA.lib_file_name_with_model_field(
+                "beam", "transversalFile4d", beam.transversalFile4d
+            )
+        )
+    raise RuntimeError("unknown transverse distribution: {}".format(dist_type))
+
+
+def _parameter_index(name):
+    return rshellweg_dump_reader.parameter_index(name)
+
+
+def _parse_error_message(run_dir):
+    path = os.path.join(str(run_dir), _HELLWEG_PARSED_FILE)
+    if not os.path.exists(path):
+        return "No elements generated"
+    text = pkio.read_text(str(path))
+    for line in text.split("\n"):
+        match = re.search(r"^ERROR:\s(.*)$", line)
+        if match:
+            return match.group(1)
+    return "No output generated"
+
+
+def _report_title(report_type, enum_name, beam_info):
+    return "{}, z={:.4f} cm".format(
+        _enum_text(enum_name, report_type),
+        100 * rshellweg_dump_reader.get_parameter(beam_info, "z"),
+    )
+
+
+def _summary_text(run_dir):
+    return pkio.read_text(os.path.join(str(run_dir), HELLWEG_SUMMARY_FILE))

--- a/sirepo/template/rshellweg_dump_reader.py
+++ b/sirepo/template/rshellweg_dump_reader.py
@@ -1,0 +1,357 @@
+# -*- coding: utf-8 -*-
+"""Hellweg dump parser.
+
+:copyright: Copyright (c) 2017 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from __future__ import absolute_import, division, print_function
+
+import ctypes
+import math
+
+_LIVE_PARTICLE = 0
+_LOSS_VALUES = [
+    "live",
+    "radius_lost",
+    "phase_lost",
+    "bz_lost",
+    "br_lost",
+    "bth_lost",
+    "beta_lost",
+    "step_lost",
+]
+_STRUCTURE_VALUES = [
+    "ksi",
+    "z",
+    "a",
+    "rp",
+    "alpha",
+    "sbeta",
+    "ra",
+    "rb",
+    "b_ext",
+    "num",
+    "e0",
+    "ereal",
+    "prf",
+    "pbeam",
+    "bbeta",
+    "wav",
+    "wmax",
+    "xb",
+    "yb",
+    "er",
+    "ex",
+    "ey",
+    "enr",
+    "enx",
+    "eny",
+    "e4d",
+    "e4dn",
+    "et",
+    "ent",
+]
+_We0 = 0.5110034e6
+
+_BEAM_PARAMETER = {
+    "r": lambda p, lmb: abs(p.r * lmb),
+    "th": lambda p, lmb: p.Th * 180.0 / math.pi,
+    "x": lambda p, lmb: p.r * math.cos(p.Th) * lmb,
+    "y": lambda p, lmb: p.r * math.sin(p.Th) * lmb,
+    "br": lambda p, lmb: math.copysign(p.beta.r, p.r),
+    "bth": lambda p, lmb: p.beta.th,
+    "bx": lambda p, lmb: p.beta.r * math.cos(p.Th) - p.beta.th * math.sin(p.Th) * lmb,
+    "by": lambda p, lmb: p.beta.r * math.sin(p.Th) + p.beta.th * math.cos(p.Th) * lmb,
+    "bz": lambda p, lmb: p.beta.z,
+    "ar": lambda p, lmb: math.atan2(p.beta.r, p.beta0),
+    "ath": lambda p, lmb: math.atan2(p.beta.th, p.beta0),
+    "ax": lambda p, lmb: math.atan2(
+        p.beta.r * math.cos(p.Th) - p.beta.th * math.sin(p.Th) * lmb, p.beta.z
+    ),
+    "ay": lambda p, lmb: math.atan2(
+        p.beta.r * math.sin(p.Th) + p.beta.th * math.cos(p.Th) * lmb, p.beta.z
+    ),
+    "az": lambda p, lmb: 0,
+    "phi": lambda p, lmb: p.phi * 180.0 / math.pi,
+    "zrel": lambda p, lmb: lmb * p.phi / (2 * math.pi),
+    "z0": lambda p, lmb: p.z,
+    "beta": lambda p, lmb: p.beta0,
+    "w": lambda p, lmb: _velocity_to_mev(p.beta0),
+}
+
+_STRUCTURE_PARAMETER = {
+    "z": lambda s: s.ksi * s.lmb,
+}
+
+_STRUCTURE_TITLE = {
+    "wav": "Average Energy",
+    "wmax": "Maximum Energy",
+    "bbeta": "Beam Velocity",
+    "sbeta": "Phase Velocity",
+    "ra": "Aperture",
+    "rb": "Beam Radius (rms)",
+    "pbeam": "Beam Power",
+    "prf": "RF Power",
+    "e0": "With Beam Load",
+    "ereal": "Without Beam Load",
+    "er": "Actual (rms)",
+    "enr": "Normalized (rms)",
+    "ex": "Actual (rms)",
+    "enx": "Normalized (rms)",
+    "ey": "Actual (rms)",
+    "eny": "Normalized (rms)",
+    "e4d": "Actual (rms)",
+    "e4dn": "Normalized (rms)",
+    "et": "Actual (rms)",
+    "ent": "Normalized (rms)",
+}
+
+_STRUCTURE_LABEL = {
+    "wav": "W [eV]",
+    "sbeta": "Beta",
+    "rb": "r [m]",
+    "prf": "P [W]",
+    "e0": "E, (MV/m)",
+    "er": "er [m]",
+    "ex": "ex [m]",
+    "ey": "ey [m]",
+    "e4d": "e4D [m]",
+    "et": "eth [m]",
+    "z": "z [m]",
+}
+
+_PARTICLE_LABEL = {
+    "r": "r [m]",
+    "th": "theta [deg]",
+    "x": "x [m]",
+    "y": "y [m]",
+    # 'br': '',
+    # 'bth': '',
+    # 'bx': '',
+    # 'by': '',
+    # 'bz': '',
+    "ar": "r' [rad]",
+    "ath": "theta' [rad]",
+    "ax": "x' [rad]",
+    "ay": "y' [rad]",
+    # 'az': '',
+    "phi": "phi [deg]",
+    # 'zrel': '',
+    "z0": "z [m]",
+    # 'beta': '',
+    "w": "W [eV]",
+}
+
+# TDimension, TPivot and TFieldMap2D are used in future versions
+# pointer fields are typed as c_int for TPivot and TFieldMap2D
+class TDimension(ctypes.Structure):
+    _fields_ = [("Nx", ctypes.c_int), ("Ny", ctypes.c_int), ("Nz", ctypes.c_int)]
+
+
+class TPivot(ctypes.Structure):
+    _fields_ = [("X", ctypes.c_int), ("Y", ctypes.c_int), ("Z", ctypes.c_int)]
+
+
+class TFieldMap2D(ctypes.Structure):
+    _fields_ = [("Dim", TDimension), ("Piv", TPivot), ("Field", ctypes.c_int)]
+
+
+class THeader(ctypes.Structure):
+    _fields_ = [("NPoints", ctypes.c_int), ("NParticles", ctypes.c_int)]
+
+
+class TField(ctypes.Structure):
+    _fields_ = [("r", ctypes.c_double), ("th", ctypes.c_double), ("z", ctypes.c_double)]
+
+
+class TStructure(ctypes.Structure):
+    _fields_ = [
+        ("ksi", ctypes.c_double),
+        ("lmb", ctypes.c_double),
+        ("P", ctypes.c_double),
+        ("dF", ctypes.c_double),
+        ("E", ctypes.c_double),
+        ("AF", ctypes.c_double),
+        ("Rp", ctypes.c_double),
+        ("B", ctypes.c_double),
+        ("alpha", ctypes.c_double),
+        ("betta", ctypes.c_double),
+        ("Ra", ctypes.c_double),
+        ("Hext", TField),
+        # Bmap replaces Hext in future versions
+        # ('Bmap', TFieldMap2D),
+        ("jump", ctypes.c_bool),
+        ("drift", ctypes.c_bool),
+        ("CellNumber", ctypes.c_int),
+    ]
+
+
+class TBeamHeader(ctypes.Structure):
+    _fields_ = [
+        ("beam_lmb", ctypes.c_double),
+        ("beam_h", ctypes.c_double),
+        ("beam_current", ctypes.c_double),
+        ("input_current", ctypes.c_double),
+    ]
+
+
+class TParticle(ctypes.Structure):
+    _fields_ = [
+        ("r", ctypes.c_double),
+        ("Th", ctypes.c_double),
+        ("beta", TField),
+        ("phi", ctypes.c_double),
+        ("z", ctypes.c_double),
+        ("beta0", ctypes.c_double),
+        ("lost", ctypes.c_int),
+    ]
+
+
+def beam_header(filename):
+    with open(filename, "rb") as f:
+        header = THeader()
+        assert f.readinto(header) == ctypes.sizeof(header)
+        return header
+
+
+def beam_info(filename, idx):
+    info = {}
+    with open(filename, "rb") as f:
+        header = THeader()
+        assert f.readinto(header) == ctypes.sizeof(header)
+        info["Header"] = header
+        structure = TStructure()
+        size = ctypes.sizeof(structure)
+        if idx > 0:
+            f.seek(idx * size, 1)
+        assert f.readinto(structure) == size
+        info["Structure"] = structure
+        if idx < header.NPoints - 1:
+            f.seek((header.NPoints - idx - 1) * size, 1)
+        beam_header = TBeamHeader()
+        size = (
+            ctypes.sizeof(beam_header) + ctypes.sizeof(TParticle()) * header.NParticles
+        )
+        if idx > 0:
+            f.seek(idx * size, 1)
+        assert f.readinto(beam_header) == ctypes.sizeof(beam_header)
+        info["BeamHeader"] = beam_header
+        particles = []
+        for _ in range(header.NParticles):
+            p = TParticle()
+            assert f.readinto(p) == ctypes.sizeof(p)
+            particles.append(p)
+        info["Particles"] = particles
+        # ensure the expected bytes are present
+        if idx < header.NPoints - 1:
+            f.seek(
+                (header.NPoints - idx - 1)
+                * (ctypes.sizeof(beam_header) + ctypes.sizeof(p) * header.NParticles),
+                1,
+            )
+        # TODO(e-carlin): is this safe?
+        # assert f.readinto(header) == 0
+    return info
+
+
+def get_label(field):
+    return _PARTICLE_LABEL[field]
+
+
+def get_parameter(info, field):
+    fn = _STRUCTURE_PARAMETER[field]
+    return fn(info["Structure"])
+
+
+def get_parameter_label(field):
+    return _STRUCTURE_LABEL[field]
+
+
+def get_parameter_title(field):
+    return _STRUCTURE_TITLE[field]
+
+
+def get_points(info, field):
+    res = []
+    fn = _BEAM_PARAMETER[field]
+    lmb = info["BeamHeader"].beam_lmb
+
+    for p in info["Particles"]:
+        if p.lost == _LIVE_PARTICLE:
+            res.append(fn(p, lmb))
+    return res
+
+
+def parameter_index(name):
+    return _STRUCTURE_VALUES.index(name)
+
+
+def particle_info(filename, field, count):
+    info = {}
+    with open(filename, "rb") as f:
+        header = THeader()
+        assert f.readinto(header) == ctypes.sizeof(header)
+        info["Header"] = header
+        if count > header.NPoints:
+            count = header.NPoints
+        z_values = []
+        yfn = _BEAM_PARAMETER[field]
+        zfn = _STRUCTURE_PARAMETER["z"]
+        for _ in range(header.NPoints):
+            structure = TStructure()
+            assert f.readinto(structure) == ctypes.sizeof(structure)
+            z_values.append(zfn(structure))
+        info["z_values"] = z_values
+        beam_header_size = ctypes.sizeof(TBeamHeader())
+        particle_size = ctypes.sizeof(TParticle())
+        y_map = {}
+        indices = []
+        for i in range(count):
+            idx = int(round((i * header.NParticles) / count))
+            y_map[idx] = []
+            indices.append(idx)
+        y_range = None
+
+        for _ in range(header.NPoints):
+            beam_header = TBeamHeader()
+            assert f.readinto(beam_header) == beam_header_size
+            lmb = beam_header.beam_lmb
+            pi = 0
+            for idx in indices:
+                assert idx >= pi
+                if idx > pi:
+                    f.seek((idx - pi) * particle_size, 1)
+                p = TParticle()
+                assert f.readinto(p) == particle_size
+                if p.lost == _LIVE_PARTICLE:
+                    v = yfn(p, lmb)
+                    y_map[idx].append(v)
+                    if y_range:
+                        if v < y_range[0]:
+                            y_range[0] = v
+                        elif v > y_range[1]:
+                            y_range[1] = v
+                    else:
+                        y_range = [v, v]
+                pi = idx + 1
+            if pi < header.NParticles:
+                f.seek((header.NParticles - pi) * particle_size, 1)
+        assert f.readinto(header) == 0
+        y_values = []
+        for idx in sorted(y_map.keys()):
+            y_values.append(y_map[idx])
+        info["y_values"] = y_values
+        info["y_range"] = y_range
+    return info
+
+
+def _gamma_to_mev(g):
+    return _We0 * (g - 1) * 1e-6
+
+
+def _velocity_to_energy(b):
+    return 1 / math.sqrt(1 - b**2)
+
+
+def _velocity_to_mev(b):
+    return _gamma_to_mev(_velocity_to_energy(b))


### PR DESCRIPTION
@moellep I think I've resurrected the backend portions of the hellweg app. 

I tested using the [attached script](https://github.com/radiasoft/sirepo/files/10887010/hellweg_test.py.txt). It runs a test for all of animations and reports in all of the hellweg examples. You can run it with the below commands:
```bash
cd ~/src/radiasoft
gcl rshellweg
cd rshellweg
CFLAGS=-I/home/vagrant/.local/include/ pip install .
cd ~/src/radiasoft/sirepo
# copy in attached hellweg_test.py
 SIREPO_FEATURE_CONFIG_SIM_TYPES='rshellweg:myapp' pykern test hellweg_test.py
```

Almost no code changes were needed. I've called out a couple places where I made some guesses on code changes but wasn't very sure.

Let me know how it looks.