### PR TITLE
Fix #5515: open as shadow for all tabs

### DIFF
--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -1733,7 +1733,6 @@ SIREPO.app.directive('appHeader', function(appState, panelState, srwService) {
 
             $scope.showOpenShadow = function() {
                 return SIREPO.APP_SCHEMA.feature_config.show_open_shadow
-                    && $scope.nav.isActive('beamline')
                     && (srwService.isGaussianBeam() || srwService.isIdealizedUndulator() || srwService.isMultipole());
             };
 


### PR DESCRIPTION
now the open as shadow options is available on source, beamline and machine learning tabs