### PR TITLE
Fix #5532 radia plot units

### DIFF
--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -409,8 +409,8 @@
         "axisPath": {
             "_super": ["_", "model", "linePath"],
             "axis": ["Axis", "BeamAxis", "z"],
-            "start": ["Start", "Float", -10.0, "Start point"],
-            "stop": ["End", "Float", 10.0, "End point"],
+            "start": ["Start [mm]", "Float", -10.0, "Start point"],
+            "stop": ["End [mm]", "Float", 10.0, "End point"],
             "type": ["_", "PathType", "axisPath"]
         },
         "cuboid": {
@@ -807,7 +807,7 @@
         },
         "kickMapReport": {
             "beamAxis": ["_", "BeamAxis", "z", ""],
-            "begin": ["Start", "FloatArray", [0, 0, 0], "Start point", ["x", "y", "z"]],
+            "begin": ["Start [mm]", "FloatArray", [0, 0, 0], "Start point", ["x", "y", "z"]],
             "colorMap": ["Color Map", "ColorMap", "viridis"],
             "component": ["Component", "KickMapComponent", "h"],
             "direction": ["Direction", "FloatArray", [0, 0, 1], "Beam direction", ["x", "y", "z"]],
@@ -829,8 +829,8 @@
         },
         "linePath": {
             "_super": ["_", "model", "fieldPath"],
-            "begin": ["Start", "FloatArray", [-10.0, 0, 0], "Start point", ["x", "y", "z"]],
-            "end": ["End", "FloatArray", [10.0, 0, 0], "End point", ["x", "y", "z"]],
+            "begin": ["Start [mm]", "FloatArray", [-10.0, 0, 0], "Start point", ["x", "y", "z"]],
+            "end": ["End [mm]", "FloatArray", [10.0, 0, 0], "End point", ["x", "y", "z"]],
             "numPoints": ["Num Points", "Integer", 10, "", 2],
             "type": ["_", "PathType", "linePath"]
         },

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -667,13 +667,13 @@ _FIELD_PT_BUILDERS = {
 def _electron_trajectory_plot(sim_id, **kwargs):
     d = PKDict(kwargs)
     t = _generate_electron_trajectory(sim_id, get_g_id(), **kwargs)
-    pts = (0.001 * t[radia_util.axes_index(d.beam_axis)]).tolist()
+    pts = (_MILLIS_TO_METERS * t[radia_util.axes_index(d.beam_axis)]).tolist()
     plots = []
     a = [d.width_axis, d.height_axis]
     for i in range(2):
         plots.append(
             PKDict(
-                points=(0.001 * t[radia_util.axes_index(a[i])]).tolist(),
+                points=(_MILLIS_TO_METERS * t[radia_util.axes_index(a[i])]).tolist(),
                 label=f"{a[i]}",
                 style="line",
             )
@@ -702,7 +702,7 @@ def _field_lineout_plot(sim_id, name, f_type, f_path, plot_axis, field_data=None
             .vectors
         )
     )
-    pts = numpy.array(v.vertices).reshape(-1, 3)
+    pts = _MILLIS_TO_METERS * numpy.array(v.vertices).reshape(-1, 3)
     plots = []
     f = numpy.array(v.directions).reshape(-1, 3)
     m = numpy.array(v.magnitudes)
@@ -722,7 +722,7 @@ def _field_lineout_plot(sim_id, name, f_type, f_path, plot_axis, field_data=None
         PKDict(
             title=f"{f_type} on {f_path.name}",
             y_label=f_type,
-            x_label=f"{plot_axis} [mm]",
+            x_label=f"{plot_axis} [m]",
             summaryData=PKDict(),
         ),
     )
@@ -1154,8 +1154,8 @@ def _kick_map_plot(model):
         title=f'{srschema.get_enums(SCHEMA, "KickMapComponent")[component]} (T2m2)',
         x_range=[km.x[0], km.x[-1], len(z)],
         y_range=[km.y[0], km.y[-1], len(z[0])],
-        x_label="x [mm]",
-        y_label="y [mm]",
+        x_label="x [m]",
+        y_label="y [m]",
         z_matrix=z,
     )
 


### PR DESCRIPTION
The auto-scaling of the axis units means the points have to be in "base" units, in this case meters not millimeters. That had not been done for the field lineouts (cf electron trajectory)

