### PR TITLE
Fix #5491 nersc account error

### DIFF
--- a/sirepo/nersc.py
+++ b/sirepo/nersc.py
@@ -30,4 +30,4 @@ def _hpssquota(project=None):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
-    )
+    ).stdout

--- a/sirepo/nersc.py
+++ b/sirepo/nersc.py
@@ -23,7 +23,7 @@ def sbatch_project_option(project):
 
 
 # Note: project is only used for unit tests
-def _hpssquota(project=None):
+def _hpssquota():
     # -N excludes home and scratch file systems; -J outputs json
     return subprocess.run(
         ("hpssquota", "-N", "-J"),

--- a/sirepo/nersc.py
+++ b/sirepo/nersc.py
@@ -23,7 +23,7 @@ def sbatch_project_option(project):
 
 
 # Note: project is only used for unit tests
-def _hpssquota():
+def _hpssquota(project=None):
     # -N excludes home and scratch file systems; -J outputs json
     return subprocess.run(
         ("hpssquota", "-N", "-J"),

--- a/tests/nersc_test.py
+++ b/tests/nersc_test.py
@@ -4,21 +4,11 @@
 :copyright: Copyright (c) 2023 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-import subprocess
 import sirepo.util
 from pykern.pkcollections import PKDict
 
 
 def test_nersc_project(monkeypatch):
-
-    def _hpssquota(p):
-        return subprocess.run(
-            ("echo", mock_output[p]),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        ).stdout
-
     from sirepo import nersc
     from pykern.pkunit import pkeq, pkok, pkre, pkfail, pkexcept
 
@@ -33,7 +23,7 @@ def test_nersc_project(monkeypatch):
     mock_output[_NO_SUCH_PROJECT] = "[]"
     mock_output[_ERROR] = "arbitrary hpssquota error"
 
-    monkeypatch.setattr(nersc, "_hpssquota", _hpssquota)
+    monkeypatch.setattr(nersc, "_hpssquota", lambda p: mock_output[p])
 
     with pkexcept(sirepo.util.UserAlert):
         nersc.sbatch_project_option(_ERROR)

--- a/tests/nersc_test.py
+++ b/tests/nersc_test.py
@@ -4,11 +4,21 @@
 :copyright: Copyright (c) 2023 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+import subprocess
 import sirepo.util
 from pykern.pkcollections import PKDict
 
 
 def test_nersc_project(monkeypatch):
+
+    def _hpssquota(p):
+        return subprocess.run(
+            ("echo", mock_output[p]),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        ).stdout
+
     from sirepo import nersc
     from pykern.pkunit import pkeq, pkok, pkre, pkfail, pkexcept
 
@@ -23,7 +33,7 @@ def test_nersc_project(monkeypatch):
     mock_output[_NO_SUCH_PROJECT] = "[]"
     mock_output[_ERROR] = "arbitrary hpssquota error"
 
-    monkeypatch.setattr(nersc, "_hpssquota", lambda p: mock_output[p])
+    monkeypatch.setattr(nersc, "_hpssquota", _hpssquota)
 
     with pkexcept(sirepo.util.UserAlert):
         nersc.sbatch_project_option(_ERROR)


### PR DESCRIPTION
Trying this again. We need to parse the "stdout" attribute of the subprocess, not the subprocess itself. I've tested this on NERSC itself so it should behave