### PR TITLE
fix #5577 translate to shadow

### DIFF
--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -1733,7 +1733,8 @@ SIREPO.app.directive('appHeader', function(appState, panelState, srwService) {
 
             $scope.showOpenShadow = function() {
                 return SIREPO.APP_SCHEMA.feature_config.show_open_shadow
-                    && (srwService.isGaussianBeam() || srwService.isIdealizedUndulator() || srwService.isMultipole());
+                    && (srwService.isGaussianBeam() || srwService.isIdealizedUndulator() || srwService.isMultipole()
+                     || (srwService.isTabulatedUndulator() && ! srwService.isTabulatedUndulatorWithMagenticFile()));
             };
 
             $scope.showRsOptML = function() {

--- a/sirepo/template/srw_shadow.py
+++ b/sirepo/template/srw_shadow.py
@@ -233,6 +233,7 @@ class Convert:
 
     _SOURCE_TYPE = PKDict(
         g="geometricSource",
+        t="undulator",
         u="undulator",
         m="bendingMagnet",
     )
@@ -262,6 +263,7 @@ class Convert:
         self.__sim_to_srw(data, res.models)
         PKDict(
             u=self.__undulator_to_srw,
+            t=self.__undulator_to_srw,
             g=self.__geometric_source_to_srw,
             m=self.__multipole_to_srw,
         )[res.models.simulation.sourceType](data, res.models)


### PR DESCRIPTION
Allow srw tabulated undulator simulations running in idealized mode to be exported as a shadow simulation.