### PR TITLE
Fix #5570 Add feature_config trust_sh_env for non-RadiaSoft shell environments

### DIFF
--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -4,8 +4,6 @@
 :copyright: Copyright (c) 2016 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
-
 # defer all imports so *_CODES is available to testing functions
 
 
@@ -150,13 +148,13 @@ def _init():
         schema_common=dict(
             hide_guest_warning=b("Hide the guest warning in the UI", dev=True),
         ),
+        jspec=dict(
+            derbenevskrinsky_force_formula=b("Include Derbenev-Skrinsky force formula"),
+        ),
         moderated_sim_types=(
             frozenset(),
             set,
             "codes where all users must be authorized via moderation",
-        ),
-        jspec=dict(
-            derbenevskrinsky_force_formula=b("Include Derbenev-Skrinsky force formula"),
         ),
         package_path=(
             tuple(["sirepo"]),
@@ -208,6 +206,11 @@ def _init():
                 bool,
                 'Show "Export ML Script" menu item',
             ),
+        ),
+        trust_sh_env=(
+            False,
+            bool,
+            "Trust Bash env to run Python and agents",
         ),
         warpvnd=dict(
             allow_3d_mode=(True, bool, "Include 3D features in the Warp VND UI"),

--- a/sirepo/job.py
+++ b/sirepo/job.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 """Common functionality that is shared between the server, supervisor, and driver.
 
-:copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.
+:copyright: Copyright (c) 2019-2023 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 from pykern import pkconfig
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp, pkdc, pkdlog, pkdexc
 import pykern.pkdebug
 import sirepo.const
+import sirepo.feature_config
 import sirepo.srdb
 import sirepo.util
 import re
@@ -159,11 +159,13 @@ def agent_cmd_stdin_env(cmd, env, uid, cwd=".", source_bashrc=""):
         cwd (str): directory for the agent to run in (will be created if it doesn't exist)
 
     Returns:
-        tuple: new cmd (tuple), stdin (file), env (PKDict)
+        tuple: new cmd (tuple), stdin (file), env (PKDict or None)
     """
     import os
     import tempfile
 
+    if sirepo.feature_config.cfg().trust_sh_env:
+        source_bashrc = ""
     t = tempfile.TemporaryFile()
     c = "exec " + " ".join(("'{}'".format(x) for x in cmd))
     # POSIT: we control all these values
@@ -183,6 +185,9 @@ cd '{}'
         ).encode()
     )
     t.seek(0)
+    if sirepo.feature_config.cfg().trust_sh_env:
+        # Trust the local environment
+        return ("bash", t, None)
     # it's reasonable to hardwire this path, even though we don't
     # do that with others. We want to make sure the subprocess starts
     # with a clean environment (no $PATH). You have to pass HOME.
@@ -212,8 +217,6 @@ def agent_env(uid, env=None):
             **x,
         )
         .pksetdefault(
-            PYTHONPATH="",
-            PYTHONSTARTUP="",
             PYTHONUNBUFFERED="1",
             SIREPO_AUTH_LOGGED_IN_USER=uid,
             SIREPO_JOB_MAX_MESSAGE_BYTES=_cfg.max_message_bytes,
@@ -224,6 +227,11 @@ def agent_env(uid, env=None):
             SIREPO_SRDB_ROOT=lambda: sirepo.srdb.root(),
         )
     )
+    if not sirepo.feature_config.cfg().trust_sh_env:
+        env.pksetdefault(
+            PYTHONPATH="",
+            PYTHONSTARTUP="",
+        )
     for k in env.keys():
         assert not pykern.pkdebug.SECRETS_RE.search(
             k

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -17,6 +17,7 @@ import os
 import re
 import shutil
 import signal
+import sirepo.feature_config
 import sirepo.modules
 import sirepo.nersc
 import sirepo.tornado
@@ -472,6 +473,8 @@ class _Cmd(PKDict):
         )
 
     def job_cmd_source_bashrc(self):
+        if sirepo.feature_config.cfg().trust_sh_env:
+            return ""
         return "source $HOME/.bashrc"
 
     async def on_stderr_read(self, text):

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -3,10 +3,9 @@
 
 Also supports starting nginx proxy.
 
-:copyright: Copyright (c) 2015 RadiaSoft LLC.  All Rights Reserved.
+:copyright: Copyright (c) 2015-2023 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 from pykern import pkcli
 from pykern import pkcollections
 from pykern import pkconfig
@@ -114,7 +113,14 @@ def http():
         except (psutil.TimeoutExpired, subprocess.TimeoutExpired):
             proc.kill()
 
-    def _start(service, extra_environ, cwd=".", prefix=("pyenv", "exec", "sirepo")):
+    def _start(service, extra_environ, cwd=".", want_prefix=True):
+        if not want_prefix:
+            prefix = ()
+        else:
+            if sirepo.feature_config.cfg().trust_sh_env:
+                prefix = ("sirepo",)
+            else:
+                prefix = ("pyenv", "exec", "sirepo")
         processes.append(
             subprocess.Popen(
                 prefix + service,
@@ -140,7 +146,7 @@ def http():
                 _start(
                     ("npm", "start"),
                     cwd="../react",
-                    prefix=(),
+                    want_prefix=False,
                     extra_environ=PKDict(PORT=str(_cfg().react_port)),
                 )
                 e.SIREPO_SERVER_REACT_SERVER = f"http://127.0.0.1:{_cfg().react_port}/"


### PR DESCRIPTION
- trust_sh_env is false by default
- In non-RadiaSoft environments, will not source bashrc/profile and assume Python is correct (no pyenv)