### PR TITLE
Fix #5582 async api calls

### DIFF
--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -22,7 +22,6 @@ import sirepo.job
 import sirepo.quest
 import sirepo.reply
 import sirepo.request
-import sirepo.spa_session
 import sirepo.template
 import sirepo.uri
 import sirepo.util
@@ -102,7 +101,6 @@ def init_quest(qcall, internal_req=None):
         sirepo.cookie.init_quest(qcall)
         # TODO(robnagler) auth_db
         o._set_log_user()
-        sirepo.spa_session.init_quest(qcall)
 
 
 def init_module(**imports):

--- a/sirepo/auth/bluesky.py
+++ b/sirepo/auth/bluesky.py
@@ -38,7 +38,7 @@ _AUTH_NONCE_SEPARATOR = "-"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("allow_cookieless_set_user", sid="SimId")
-    def api_authBlueskyLogin(self):
+    await def api_authBlueskyLogin(self):
         req = self.parse_post(id=True)
         auth_hash(req.req_data, verify=True)
         path = simulation_db.find_global_simulation(
@@ -59,7 +59,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_cookieless_set_user")
-    def api_blueskyAuth(self):
+    await def api_blueskyAuth(self):
         """Deprecated use `api_authBlueskyLogin`"""
         return self.api_authBlueskyLogin()
 

--- a/sirepo/auth/bluesky.py
+++ b/sirepo/auth/bluesky.py
@@ -38,7 +38,7 @@ _AUTH_NONCE_SEPARATOR = "-"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("allow_cookieless_set_user", sid="SimId")
-    await def api_authBlueskyLogin(self):
+    async def api_authBlueskyLogin(self):
         req = self.parse_post(id=True)
         auth_hash(req.req_data, verify=True)
         path = simulation_db.find_global_simulation(
@@ -59,7 +59,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_cookieless_set_user")
-    await def api_blueskyAuth(self):
+    async def api_blueskyAuth(self):
         """Deprecated use `api_authBlueskyLogin`"""
         return self.api_authBlueskyLogin()
 

--- a/sirepo/auth/email.py
+++ b/sirepo/auth/email.py
@@ -36,7 +36,7 @@ this_module = pkinspect.this_module()
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("allow_cookieless_set_user", token="EmailAuthToken")
-    def api_authEmailAuthorized(self, simulation_type, token):
+    await def api_authEmailAuthorized(self, simulation_type, token):
         """Clicked by user in an email
 
         Token must exist in db and not be expired.
@@ -79,7 +79,7 @@ class API(sirepo.quest.API):
             self.auth.login_fail_redirect(req.type, this_module, "email-token")
 
     @sirepo.quest.Spec("require_cookie_sentinel", email="Email")
-    def api_authEmailLogin(self):
+    await def api_authEmailLogin(self):
         """Start the login process for the user.
 
         User has sent an email, which needs to be verified.

--- a/sirepo/auth/email.py
+++ b/sirepo/auth/email.py
@@ -36,7 +36,7 @@ this_module = pkinspect.this_module()
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("allow_cookieless_set_user", token="EmailAuthToken")
-    await def api_authEmailAuthorized(self, simulation_type, token):
+    async def api_authEmailAuthorized(self, simulation_type, token):
         """Clicked by user in an email
 
         Token must exist in db and not be expired.
@@ -79,7 +79,7 @@ class API(sirepo.quest.API):
             self.auth.login_fail_redirect(req.type, this_module, "email-token")
 
     @sirepo.quest.Spec("require_cookie_sentinel", email="Email")
-    await def api_authEmailLogin(self):
+    async def api_authEmailLogin(self):
         """Start the login process for the user.
 
         User has sent an email, which needs to be verified.

--- a/sirepo/auth/github.py
+++ b/sirepo/auth/github.py
@@ -27,7 +27,7 @@ UserModel = "AuthGithubUser"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("allow_cookieless_set_user")
-    await def api_authGithubAuthorized(self):
+    async def api_authGithubAuthorized(self):
         """Handle a callback from a successful OAUTH request.
 
         Tracks oauth users in a database.
@@ -48,7 +48,7 @@ class API(sirepo.quest.API):
             raise AssertionError("auth.login returned unexpectedly")
 
     @sirepo.quest.Spec("require_cookie_sentinel")
-    await def api_authGithubLogin(self, simulation_type):
+    async def api_authGithubLogin(self, simulation_type):
         """Redirects to Github"""
         sirepo.oauth.raise_authorize_redirect(
             self,
@@ -57,7 +57,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_cookieless_set_user")
-    await def api_oauthAuthorized(self, oauth_type):
+    async def api_oauthAuthorized(self, oauth_type):
         """Deprecated use `api_authGithubAuthorized`"""
         return self.api_authGithubAuthorized()
 

--- a/sirepo/auth/github.py
+++ b/sirepo/auth/github.py
@@ -27,7 +27,7 @@ UserModel = "AuthGithubUser"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("allow_cookieless_set_user")
-    def api_authGithubAuthorized(self):
+    await def api_authGithubAuthorized(self):
         """Handle a callback from a successful OAUTH request.
 
         Tracks oauth users in a database.
@@ -48,7 +48,7 @@ class API(sirepo.quest.API):
             raise AssertionError("auth.login returned unexpectedly")
 
     @sirepo.quest.Spec("require_cookie_sentinel")
-    def api_authGithubLogin(self, simulation_type):
+    await def api_authGithubLogin(self, simulation_type):
         """Redirects to Github"""
         sirepo.oauth.raise_authorize_redirect(
             self,
@@ -57,7 +57,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_cookieless_set_user")
-    def api_oauthAuthorized(self, oauth_type):
+    await def api_oauthAuthorized(self, oauth_type):
         """Deprecated use `api_authGithubAuthorized`"""
         return self.api_authGithubAuthorized()
 

--- a/sirepo/auth/guest.py
+++ b/sirepo/auth/guest.py
@@ -31,7 +31,7 @@ _ONE_DAY = datetime.timedelta(days=1)
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_cookie_sentinel")
-    await def api_authGuestLogin(self, simulation_type):
+    async def api_authGuestLogin(self, simulation_type):
         """You have to be an anonymous or logged in user at this point"""
         req = self.parse_params(type=simulation_type)
         # if already logged in as guest, just redirect

--- a/sirepo/auth/guest.py
+++ b/sirepo/auth/guest.py
@@ -31,7 +31,7 @@ _ONE_DAY = datetime.timedelta(days=1)
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_cookie_sentinel")
-    def api_authGuestLogin(self, simulation_type):
+    await def api_authGuestLogin(self, simulation_type):
         """You have to be an anonymous or logged in user at this point"""
         req = self.parse_params(type=simulation_type)
         # if already logged in as guest, just redirect

--- a/sirepo/auth/ldap.py
+++ b/sirepo/auth/ldap.py
@@ -35,7 +35,7 @@ user_model = "AuthEmailUser"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_cookie_sentinel")
-    await def api_authLdapLogin(self):
+    async def api_authLdapLogin(self):
         def _bind(creds):
             try:
                 ldap.initialize(_cfg.server).simple_bind_s(creds.dn, creds.password)

--- a/sirepo/auth/ldap.py
+++ b/sirepo/auth/ldap.py
@@ -35,7 +35,7 @@ user_model = "AuthEmailUser"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_cookie_sentinel")
-    def api_authLdapLogin(self):
+    await def api_authLdapLogin(self):
         def _bind(creds):
             try:
                 ldap.initialize(_cfg.server).simple_bind_s(creds.dn, creds.password)

--- a/sirepo/auth_api.py
+++ b/sirepo/auth_api.py
@@ -13,7 +13,7 @@ import sirepo.util
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_cookie_sentinel", display_name="UserDisplayName")
-    await def api_authCompleteRegistration(self):
+    async def api_authCompleteRegistration(self):
         # Needs to be explicit, because we would need a special permission
         # for just this API.
         if not self.auth.is_logged_in():
@@ -24,7 +24,7 @@ class API(sirepo.quest.API):
         return self.reply_ok()
 
     @sirepo.quest.Spec("allow_visitor")
-    await def api_authState(self):
+    async def api_authState(self):
         return self.reply_static_jinja(
             "auth-state",
             "js",
@@ -32,7 +32,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_visitor")
-    await def api_authState2(self):
+    async def api_authState2(self):
         """is alternative to auth_state that returns the JSON struct instead of static JS"""
         a = self.auth.only_for_api_auth_state()
         # only one method is valid, replace visibleMethods array with single value including guest
@@ -43,7 +43,7 @@ class API(sirepo.quest.API):
         return a
 
     @sirepo.quest.Spec("allow_visitor")
-    await def api_authLogout(self, simulation_type=None):
+    async def api_authLogout(self, simulation_type=None):
         """Set the current user as logged out.
 
         Redirects to root simulation page.

--- a/sirepo/auth_api.py
+++ b/sirepo/auth_api.py
@@ -13,7 +13,7 @@ import sirepo.util
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_cookie_sentinel", display_name="UserDisplayName")
-    def api_authCompleteRegistration(self):
+    await def api_authCompleteRegistration(self):
         # Needs to be explicit, because we would need a special permission
         # for just this API.
         if not self.auth.is_logged_in():
@@ -24,7 +24,7 @@ class API(sirepo.quest.API):
         return self.reply_ok()
 
     @sirepo.quest.Spec("allow_visitor")
-    def api_authState(self):
+    await def api_authState(self):
         return self.reply_static_jinja(
             "auth-state",
             "js",
@@ -32,7 +32,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_visitor")
-    def api_authState2(self):
+    await def api_authState2(self):
         """is alternative to auth_state that returns the JSON struct instead of static JS"""
         a = self.auth.only_for_api_auth_state()
         # only one method is valid, replace visibleMethods array with single value including guest
@@ -43,7 +43,7 @@ class API(sirepo.quest.API):
         return a
 
     @sirepo.quest.Spec("allow_visitor")
-    def api_authLogout(self, simulation_type=None):
+    await def api_authLogout(self, simulation_type=None):
         """Set the current user as logged out.
 
         Redirects to root simulation page.

--- a/sirepo/auth_db/user.py
+++ b/sirepo/auth_db/user.py
@@ -85,17 +85,25 @@ class UserRole(sirepo.auth_db.UserDbBase):
         return r.expiration < sirepo.srtime.utc_now()
 
     def uids_of_paid_users(self):
+        import sqlalchemy.exc
+
         cls = self.__class__
-        return [
-            x[0]
-            for x in self.query()
-            .with_entities(cls.uid)
-            .filter(
-                cls.role.in_(sirepo.auth_role.PAID_USER_ROLES),
-            )
-            .distinct()
-            .all()
-        ]
+        for _ in range(5):
+            try:
+                return [
+                    x[0]
+                    for x in self.query()
+                    .with_entities(cls.uid)
+                    .filter(
+                        cls.role.in_(sirepo.auth_role.PAID_USER_ROLES),
+                    )
+                    .distinct()
+                    .all()
+                ]
+            except sqlalchemy.exc.OperationalError:
+                time.sleep(0.5)
+        else:
+            raise AssertionError("x")
 
 
 class UserRoleInvite(sirepo.auth_db.UserDbBase):

--- a/sirepo/auth_role_moderation.py
+++ b/sirepo/auth_role_moderation.py
@@ -33,7 +33,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_adm", token="AuthModerationToken", status="AuthModerationStatus"
     )
-    await def api_admModerate(self):
+    async def api_admModerate(self):
         def _send_moderation_status_email(info):
             sirepo.smtp.send(
                 recipient=info.user_name,
@@ -90,7 +90,7 @@ class API(sirepo.quest.API):
         return self.reply_ok()
 
     @sirepo.quest.Spec("require_adm")
-    await def api_admModerateRedirect(self):
+    async def api_admModerateRedirect(self):
         def _type():
             x = sirepo.feature_config.auth_controlled_sim_types()
             res = sorted(sirepo.feature_config.cfg().sim_types - x)
@@ -103,7 +103,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_adm")
-    await def api_getModerationRequestRows(self):
+    async def api_getModerationRequestRows(self):
         return self.reply_json(
             PKDict(
                 rows=self.auth_db.model("UserRoleInvite").get_moderation_request_rows(),
@@ -113,7 +113,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "allow_sim_typeless_require_email_user", reason="AuthModerationReason"
     )
-    await def api_saveModerationReason(self):
+    async def api_saveModerationReason(self):
         def _send_request_email(info):
             sirepo.smtp.send(
                 recipient=_cfg.moderator_email,

--- a/sirepo/auth_role_moderation.py
+++ b/sirepo/auth_role_moderation.py
@@ -33,7 +33,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_adm", token="AuthModerationToken", status="AuthModerationStatus"
     )
-    def api_admModerate(self):
+    await def api_admModerate(self):
         def _send_moderation_status_email(info):
             sirepo.smtp.send(
                 recipient=info.user_name,
@@ -90,7 +90,7 @@ class API(sirepo.quest.API):
         return self.reply_ok()
 
     @sirepo.quest.Spec("require_adm")
-    def api_admModerateRedirect(self):
+    await def api_admModerateRedirect(self):
         def _type():
             x = sirepo.feature_config.auth_controlled_sim_types()
             res = sorted(sirepo.feature_config.cfg().sim_types - x)
@@ -103,7 +103,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_adm")
-    def api_getModerationRequestRows(self):
+    await def api_getModerationRequestRows(self):
         return self.reply_json(
             PKDict(
                 rows=self.auth_db.model("UserRoleInvite").get_moderation_request_rows(),
@@ -113,7 +113,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "allow_sim_typeless_require_email_user", reason="AuthModerationReason"
     )
-    def api_saveModerationReason(self):
+    await def api_saveModerationReason(self):
         def _send_request_email(info):
             sirepo.smtp.send(
                 recipient=_cfg.moderator_email,

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -32,7 +32,7 @@ _JSON_TYPE = re.compile(r"^application/json")
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("internal_test", days="TimeDeltaDays")
-    def api_adjustSupervisorSrtime(self, days):
+    await def api_adjustSupervisorSrtime(self, days):
         return self._request_api(
             api_name="not used",
             _request_content=PKDict(days=days),
@@ -40,18 +40,18 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_adm")
-    def api_admJobs(self):
+    await def api_admJobs(self):
         return self._request_api(
             _request_content=PKDict(**self._parse_post_just_data()),
         )
 
     @sirepo.quest.Spec("require_user")
-    def api_analysisJob(self):
+    await def api_analysisJob(self):
         # TODO(robnagler): computeJobHash has to be checked
         return self._request_api()
 
     @sirepo.quest.Spec("require_user")
-    def api_beginSession(self):
+    await def api_beginSession(self):
         u = self.auth.logged_in_user()
         return self._request_api(
             _request_content=PKDict(
@@ -67,7 +67,7 @@ class API(sirepo.quest.API):
         frame="DataFileIndex",
         suffix="FileSuffix optional",
     )
-    def api_downloadDataFile(
+    await def api_downloadDataFile(
         self, simulation_type, simulation_id, model, frame, suffix=None
     ):
         # TODO(robnagler) validate suffix and frame
@@ -108,7 +108,7 @@ class API(sirepo.quest.API):
             )
 
     @sirepo.quest.Spec("allow_visitor")
-    def api_jobSupervisorPing(self):
+    await def api_jobSupervisorPing(self):
         import requests.exceptions
 
         e = None
@@ -136,7 +136,7 @@ class API(sirepo.quest.API):
         return PKDict(state="error", error=e)
 
     @sirepo.quest.Spec("require_user")
-    def api_ownJobs(self):
+    await def api_ownJobs(self):
         return self._request_api(
             _request_content=self._parse_post_just_data().pkupdate(
                 uid=self.auth.logged_in_user(),
@@ -144,7 +144,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_user")
-    def api_runCancel(self):
+    await def api_runCancel(self):
         try:
             return self._request_api()
         except Exception as e:
@@ -153,7 +153,7 @@ class API(sirepo.quest.API):
         return self.reply_json({"state": "canceled"})
 
     @sirepo.quest.Spec("require_user", data="RunMultiSpec")
-    def api_runMulti(self):
+    await def api_runMulti(self):
         def _api(api):
             # SECURITY: Make sure we have permission to call API
             sirepo.uri_router.assert_api_name_and_auth(
@@ -175,18 +175,18 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_user")
-    def api_runSimulation(self):
+    await def api_runSimulation(self):
         r = self._request_content(PKDict(fixup_old_data=True))
         if r.isParallel:
             r.isPremiumUser = self.auth.is_premium_user()
         return self._request_api(_request_content=r)
 
     @sirepo.quest.Spec("require_user")
-    def api_runStatus(self):
+    await def api_runStatus(self):
         return self._request_api()
 
     @sirepo.quest.Spec("require_user")
-    def api_sbatchLogin(self):
+    await def api_sbatchLogin(self):
         r = self._request_content(
             PKDict(computeJobHash="unused", jobRunMode=sirepo.job.SBATCH),
         )
@@ -194,7 +194,7 @@ class API(sirepo.quest.API):
         return self._request_api(_request_content=r)
 
     @sirepo.quest.Spec("require_user", frame_id="SimFrameId")
-    def api_simulationFrame(self, frame_id):
+    await def api_simulationFrame(self, frame_id):
         return template_common.sim_frame(
             frame_id,
             lambda a: self._request_api(
@@ -208,11 +208,11 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_user")
-    def api_statefulCompute(self):
+    await def api_statefulCompute(self):
         return self._request_compute()
 
     @sirepo.quest.Spec("require_user")
-    def api_statelessCompute(self):
+    await def api_statelessCompute(self):
         return self._request_compute()
 
     def _parse_post_just_data(self):

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -32,7 +32,7 @@ _JSON_TYPE = re.compile(r"^application/json")
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("internal_test", days="TimeDeltaDays")
-    await def api_adjustSupervisorSrtime(self, days):
+    async def api_adjustSupervisorSrtime(self, days):
         return self._request_api(
             api_name="not used",
             _request_content=PKDict(days=days),
@@ -40,18 +40,18 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_adm")
-    await def api_admJobs(self):
+    async def api_admJobs(self):
         return self._request_api(
             _request_content=PKDict(**self._parse_post_just_data()),
         )
 
     @sirepo.quest.Spec("require_user")
-    await def api_analysisJob(self):
+    async def api_analysisJob(self):
         # TODO(robnagler): computeJobHash has to be checked
         return self._request_api()
 
     @sirepo.quest.Spec("require_user")
-    await def api_beginSession(self):
+    async def api_beginSession(self):
         u = self.auth.logged_in_user()
         return self._request_api(
             _request_content=PKDict(
@@ -67,7 +67,7 @@ class API(sirepo.quest.API):
         frame="DataFileIndex",
         suffix="FileSuffix optional",
     )
-    await def api_downloadDataFile(
+    async def api_downloadDataFile(
         self, simulation_type, simulation_id, model, frame, suffix=None
     ):
         # TODO(robnagler) validate suffix and frame
@@ -108,7 +108,7 @@ class API(sirepo.quest.API):
             )
 
     @sirepo.quest.Spec("allow_visitor")
-    await def api_jobSupervisorPing(self):
+    async def api_jobSupervisorPing(self):
         import requests.exceptions
 
         e = None
@@ -136,7 +136,7 @@ class API(sirepo.quest.API):
         return PKDict(state="error", error=e)
 
     @sirepo.quest.Spec("require_user")
-    await def api_ownJobs(self):
+    async def api_ownJobs(self):
         return self._request_api(
             _request_content=self._parse_post_just_data().pkupdate(
                 uid=self.auth.logged_in_user(),
@@ -144,7 +144,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_user")
-    await def api_runCancel(self):
+    async def api_runCancel(self):
         try:
             return self._request_api()
         except Exception as e:
@@ -153,7 +153,7 @@ class API(sirepo.quest.API):
         return self.reply_json({"state": "canceled"})
 
     @sirepo.quest.Spec("require_user", data="RunMultiSpec")
-    await def api_runMulti(self):
+    async def api_runMulti(self):
         def _api(api):
             # SECURITY: Make sure we have permission to call API
             sirepo.uri_router.assert_api_name_and_auth(
@@ -167,7 +167,7 @@ class API(sirepo.quest.API):
         r = []
         for m in self.parse_json():
             c = self._request_content(PKDict(req_data=m))
-            c.data.pkupdate(api=_api(c.data.api), awaitReply=m.awaitReply)
+            c.data.pkupdate(api=_api(c.data.api), asyncReply=m.awaitReply)
             r.append(c)
         return self._request_api(
             _request_content=PKDict(data=r),
@@ -175,18 +175,18 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_user")
-    await def api_runSimulation(self):
+    async def api_runSimulation(self):
         r = self._request_content(PKDict(fixup_old_data=True))
         if r.isParallel:
             r.isPremiumUser = self.auth.is_premium_user()
         return self._request_api(_request_content=r)
 
     @sirepo.quest.Spec("require_user")
-    await def api_runStatus(self):
+    async def api_runStatus(self):
         return self._request_api()
 
     @sirepo.quest.Spec("require_user")
-    await def api_sbatchLogin(self):
+    async def api_sbatchLogin(self):
         r = self._request_content(
             PKDict(computeJobHash="unused", jobRunMode=sirepo.job.SBATCH),
         )
@@ -194,7 +194,7 @@ class API(sirepo.quest.API):
         return self._request_api(_request_content=r)
 
     @sirepo.quest.Spec("require_user", frame_id="SimFrameId")
-    await def api_simulationFrame(self, frame_id):
+    async def api_simulationFrame(self, frame_id):
         return template_common.sim_frame(
             frame_id,
             lambda a: self._request_api(
@@ -208,11 +208,11 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_user")
-    await def api_statefulCompute(self):
+    async def api_statefulCompute(self):
         return self._request_compute()
 
     @sirepo.quest.Spec("require_user")
-    await def api_statelessCompute(self):
+    async def api_statelessCompute(self):
         return self._request_compute()
 
     def _parse_post_just_data(self):

--- a/sirepo/pkcli/job_supervisor.py
+++ b/sirepo/pkcli/job_supervisor.py
@@ -155,11 +155,11 @@ class _ServerReq(_JsonPostRequestHandler):
 
 
 class _ServerSrtime(_JsonPostRequestHandler):
-    def post(self):
+    async def post(self):
         assert (
             pkconfig.channel_in_internal_test()
         ), "You can only adjust time in internal test"
-        sirepo.srtime.adjust_time(pkjson.load_any(self.request.body).days)
+        await sirepo.srtime.adjust_time(pkjson.load_any(self.request.body).days)
         self.write(PKDict())
 
 

--- a/sirepo/pkcli/job_supervisor.py
+++ b/sirepo/pkcli/job_supervisor.py
@@ -159,7 +159,7 @@ class _ServerSrtime(_JsonPostRequestHandler):
         assert (
             pkconfig.channel_in_internal_test()
         ), "You can only adjust time in internal test"
-        await sirepo.srtime.adjust_time(pkjson.load_any(self.request.body).days)
+        sirepo.srtime.adjust_time(pkjson.load_any(self.request.body).days)
         self.write(PKDict())
 
 

--- a/sirepo/quest.py
+++ b/sirepo/quest.py
@@ -87,6 +87,15 @@ class API(pykern.quest.API):
         """
         return await uri_router.call_api(self, name, kwargs=kwargs, data=data)
 
+    def call_api_sync(self, *args, **kwargs):
+        """Synchronous call_api
+
+        Only use in tests.
+        """
+        import asyncio
+
+        return asyncio.run(self.call_api(*args, **kwargs))
+
     def destroy(self, commit=False):
         for k, v in reversed(list(self.items())):
             if hasattr(v, "destroy") and not getattr(v, "quest_no_destroy", False):

--- a/sirepo/quest.py
+++ b/sirepo/quest.py
@@ -75,7 +75,7 @@ class API(pykern.quest.API):
     def bucket_unchecked_get(self, name):
         return self._bucket.get(name)
 
-    def call_api(self, name, kwargs=None, data=None):
+    async def call_api(self, name, kwargs=None, data=None):
         """Calls uri_router.call_api, which calls the API with permission checks.
 
         Args:
@@ -85,7 +85,7 @@ class API(pykern.quest.API):
         Returns:
             Reply: result
         """
-        return uri_router.call_api(self, name, kwargs=kwargs, data=data)
+        return await uri_router.call_api(self, name, kwargs=kwargs, data=data)
 
     def destroy(self, commit=False):
         for k, v in reversed(list(self.items())):

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -53,7 +53,7 @@ _REACT_SERVER_BUILD = "build"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_user", sid="SimId")
-    def api_copyNonSessionSimulation(self):
+    await def api_copyNonSessionSimulation(self):
         req = self.parse_post(id=True, template=True)
         src = pkio.py_path(
             simulation_db.find_global_simulation(
@@ -89,7 +89,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", sid="SimId", folder="SimFolderName", name="SimName"
     )
-    def api_copySimulation(self):
+    await def api_copySimulation(self):
         """Takes the specified simulation and returns a newly named copy with the suffix ( X)"""
         req = self.parse_post(id=True, folder=True, name=True, template=True)
         d = simulation_db.read_simulation_json(req.type, sid=req.id, qcall=self)
@@ -102,7 +102,7 @@ class API(sirepo.quest.API):
         return self._save_new_and_reply(req, d)
 
     @sirepo.quest.Spec("require_user", filename="SimFileName", file_type="SimFileType")
-    def api_deleteFile(self):
+    await def api_deleteFile(self):
         req = self.parse_post(filename=True, file_type=True)
         e = _simulations_using_file(req)
         if len(e):
@@ -119,7 +119,7 @@ class API(sirepo.quest.API):
         return self.reply_ok()
 
     @sirepo.quest.Spec("require_user", sid="SimId")
-    def api_deleteSimulation(self):
+    await def api_deleteSimulation(self):
         req = self.parse_post(id=True)
         simulation_db.delete_simulation(req.type, req.id, qcall=self)
         return self.reply_ok()
@@ -127,7 +127,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", sid="SimId optional", filename="SimFileName", sim_data="SimData"
     )
-    def api_downloadFile(self, simulation_type, simulation_id, filename):
+    await def api_downloadFile(self, simulation_type, simulation_id, filename):
         # TODO(pjm): simulation_id is an unused argument
         req = self.parse_params(type=simulation_type, filename=filename)
         n = req.sim_data.lib_file_name_without_type(req.filename)
@@ -140,7 +140,7 @@ class API(sirepo.quest.API):
             raise
 
     @sirepo.quest.Spec("allow_visitor", spec="ErrorLoggingSpec")
-    def api_errorLogging(self):
+    await def api_errorLogging(self):
         ip = self.sreq.remote_addr
         try:
             pkdlog(
@@ -159,7 +159,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", simulation_id="SimId", filename="SimExportFileName"
     )
-    def api_exportArchive(self, simulation_type, simulation_id, filename):
+    await def api_exportArchive(self, simulation_type, simulation_id, filename):
         req = self.parse_params(
             template=True,
             filename=filename,
@@ -171,7 +171,7 @@ class API(sirepo.quest.API):
         return exporter.create_archive(req, self)
 
     @sirepo.quest.Spec("allow_visitor")
-    def api_favicon(self):
+    await def api_favicon(self):
         """Routes to favicon.ico file."""
         # SECURITY: We control the path of the file so using send_file is ok.
         return self.reply_file(
@@ -180,7 +180,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_visitor")
-    def api_forbidden(self):
+    await def api_forbidden(self):
         raise sirepo.util.Forbidden("app forced forbidden")
 
     @sirepo.quest.Spec(
@@ -189,7 +189,7 @@ class API(sirepo.quest.API):
         file_type="LibFileType",
         sim_data="SimData",
     )
-    def api_listFiles(self, simulation_type, simulation_id, file_type):
+    await def api_listFiles(self, simulation_type, simulation_id, file_type):
         # TODO(pjm): simulation_id is an unused argument
         req = self.parse_params(type=simulation_type, file_type=file_type)
         return self.reply_json(
@@ -199,7 +199,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "allow_visitor", application_mode="AppMode", simulation_name="SimName"
     )
-    def api_findByName(self, simulation_type, application_mode, simulation_name):
+    await def api_findByName(self, simulation_type, application_mode, simulation_name):
         req = self.parse_params(type=simulation_type)
         return self.reply_redirect_for_local_route(
             req.type,
@@ -213,7 +213,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", application_mode="AppMode", simulation_name="SimName"
     )
-    def api_findByNameWithAuth(
+    await def api_findByNameWithAuth(
         self, simulation_type, application_mode, simulation_name
     ):
         req = self.parse_params(type=simulation_type)
@@ -264,7 +264,7 @@ class API(sirepo.quest.API):
         sid="SimId",
         arguments="ImportArgs optional",
     )
-    def api_importFile(self, simulation_type):
+    await def api_importFile(self, simulation_type):
         """
         Args:
             simulation_type (str): which simulation type
@@ -338,7 +338,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_visitor", path_info="PathInfo optional")
-    def api_homePage(self, path_info=None):
+    await def api_homePage(self, path_info=None):
         return self.call_api(
             "staticFile", kwargs=PKDict(path_info="en/" + (path_info or "landing.html"))
         )
@@ -349,7 +349,7 @@ class API(sirepo.quest.API):
         model="Model optional",
         title="DownloadNamePostfix optional",
     )
-    def api_exportJupyterNotebook(
+    await def api_exportJupyterNotebook(
         self, simulation_type, simulation_id, model=None, title=None
     ):
         def _filename(req):
@@ -380,7 +380,7 @@ class API(sirepo.quest.API):
         model="Model optional",
         title="DownloadNamePostfix optional",
     )
-    def api_exportJupyterNotebook2(self, simulation_type):
+    await def api_exportJupyterNotebook2(self, simulation_type):
         def _filename(req):
             res = d.models.simulation.name
             if req.title:
@@ -410,7 +410,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_user", folder="FolderName", name="SimName")
-    def api_newSimulation(self):
+    await def api_newSimulation(self):
         req = self.parse_post(template=True, folder=True, name=True)
         d = simulation_db.default_data(req.type)
         d.models.simulation.pkupdate(
@@ -425,7 +425,7 @@ class API(sirepo.quest.API):
         return self._save_new_and_reply(req, d)
 
     @sirepo.quest.Spec("allow_visitor")
-    def api_notFound(self):
+    await def api_notFound(self):
         raise sirepo.util.NotFound("app forced not found (uri parsing error)")
 
     @sirepo.quest.Spec(
@@ -434,7 +434,7 @@ class API(sirepo.quest.API):
         model="ComputeModelName optional",
         title="DownloadNamePostfix optional",
     )
-    def api_pythonSource(self, simulation_type, simulation_id, model=None, title=None):
+    await def api_pythonSource(self, simulation_type, simulation_id, model=None, title=None):
         req = self.parse_params(type=simulation_type, id=simulation_id, template=True)
         m = model and req.sim_data.parse_model(model)
         d = simulation_db.read_simulation_json(req.type, sid=req.id, qcall=self)
@@ -455,7 +455,7 @@ class API(sirepo.quest.API):
         model="ComputeModelName optional",
         title="DownloadNamePostfix optional",
     )
-    def api_pythonSource2(self, simulation_type):
+    await def api_pythonSource2(self, simulation_type):
         req = self.parse_post(
             type=simulation_type,
             id=True,
@@ -475,7 +475,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_visitor")
-    def api_robotsTxt(self):
+    await def api_robotsTxt(self):
         """Disallow the app (dev, prod) or / (alpha, beta)"""
         global _ROBOTS_TXT
         if not _ROBOTS_TXT:
@@ -493,7 +493,7 @@ class API(sirepo.quest.API):
         return self.reply(content=_ROBOTS_TXT, content_type="text/plain")
 
     @sirepo.quest.Spec("allow_visitor", path_info="PathInfo")
-    def api_root(self, path_info=None):
+    await def api_root(self, path_info=None):
         from sirepo import template
 
         self._proxy_react(path_info)
@@ -507,7 +507,7 @@ class API(sirepo.quest.API):
         raise sirepo.util.NotFound(f"unknown path={path_info}")
 
     @sirepo.quest.Spec("require_user", sid="SimId", data="SimData all_input")
-    def api_saveSimulationData(self):
+    await def api_saveSimulationData(self):
         # do not fixup_old_data yet
         req = self.parse_post(id=True, template=True)
         d = req.req_data
@@ -522,7 +522,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", simulation_id="SimId", pretty="Bool optional", section="Section"
     )
-    def api_simulationData(
+    await def api_simulationData(
         self, simulation_type, simulation_id, pretty=False, section=None
     ):
         """First entry point for a simulation
@@ -562,7 +562,7 @@ class API(sirepo.quest.API):
             return _not_found(req)
 
     @sirepo.quest.Spec("require_user", search="SearchSpec")
-    def api_listSimulations(self):
+    await def api_listSimulations(self):
         req = self.parse_post()
         return self.reply_json(
             sorted(
@@ -577,7 +577,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_user")
-    def api_simulationRedirect(self, simulation_type, local_route, simulation_id):
+    await def api_simulationRedirect(self, simulation_type, local_route, simulation_id):
         return self.reply_redirect_for_local_route(
             sim_type=simulation_type,
             route=local_route,
@@ -586,7 +586,7 @@ class API(sirepo.quest.API):
 
     # visitor rather than user because error pages are rendered by the application
     @sirepo.quest.Spec("allow_visitor")
-    def api_simulationSchema(self):
+    await def api_simulationSchema(self):
         return self.reply_json(
             simulation_db.get_schema(
                 self.parse_params(
@@ -596,11 +596,11 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_visitor")
-    def api_srwLight(self):
+    await def api_srwLight(self):
         return self._render_root_page("light", PKDict())
 
     @sirepo.quest.Spec("allow_visitor", path_info="FilePath")
-    def api_staticFile(self, path_info=None):
+    await def api_staticFile(self, path_info=None):
         """Send file from static folder.
 
         Args:
@@ -627,7 +627,7 @@ class API(sirepo.quest.API):
         return self.reply_file(p)
 
     @sirepo.quest.Spec("require_user", oldName="SimFolderPath", newName="SimFolderPath")
-    def api_updateFolder(self):
+    await def api_updateFolder(self):
         # TODO(robnagler) Folder should have a serial, or should it be on data
         req = self.parse_post()
         o = sirepo.srschema.parse_folder(req.req_data["oldName"])
@@ -667,7 +667,7 @@ class API(sirepo.quest.API):
         simulation_id="SimId",
         confirm="Bool optional",
     )
-    def api_uploadFile(self, simulation_type, simulation_id, file_type):
+    await def api_uploadFile(self, simulation_type, simulation_id, file_type):
         f = self.sreq.form_file_get()
         req = self.parse_params(
             file_type=file_type,

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -53,7 +53,7 @@ _REACT_SERVER_BUILD = "build"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_user", sid="SimId")
-    await def api_copyNonSessionSimulation(self):
+    async def api_copyNonSessionSimulation(self):
         req = self.parse_post(id=True, template=True)
         src = pkio.py_path(
             simulation_db.find_global_simulation(
@@ -89,7 +89,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", sid="SimId", folder="SimFolderName", name="SimName"
     )
-    await def api_copySimulation(self):
+    async def api_copySimulation(self):
         """Takes the specified simulation and returns a newly named copy with the suffix ( X)"""
         req = self.parse_post(id=True, folder=True, name=True, template=True)
         d = simulation_db.read_simulation_json(req.type, sid=req.id, qcall=self)
@@ -102,7 +102,7 @@ class API(sirepo.quest.API):
         return self._save_new_and_reply(req, d)
 
     @sirepo.quest.Spec("require_user", filename="SimFileName", file_type="SimFileType")
-    await def api_deleteFile(self):
+    async def api_deleteFile(self):
         req = self.parse_post(filename=True, file_type=True)
         e = _simulations_using_file(req)
         if len(e):
@@ -119,7 +119,7 @@ class API(sirepo.quest.API):
         return self.reply_ok()
 
     @sirepo.quest.Spec("require_user", sid="SimId")
-    await def api_deleteSimulation(self):
+    async def api_deleteSimulation(self):
         req = self.parse_post(id=True)
         simulation_db.delete_simulation(req.type, req.id, qcall=self)
         return self.reply_ok()
@@ -127,7 +127,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", sid="SimId optional", filename="SimFileName", sim_data="SimData"
     )
-    await def api_downloadFile(self, simulation_type, simulation_id, filename):
+    async def api_downloadFile(self, simulation_type, simulation_id, filename):
         # TODO(pjm): simulation_id is an unused argument
         req = self.parse_params(type=simulation_type, filename=filename)
         n = req.sim_data.lib_file_name_without_type(req.filename)
@@ -140,7 +140,7 @@ class API(sirepo.quest.API):
             raise
 
     @sirepo.quest.Spec("allow_visitor", spec="ErrorLoggingSpec")
-    await def api_errorLogging(self):
+    async def api_errorLogging(self):
         ip = self.sreq.remote_addr
         try:
             pkdlog(
@@ -159,7 +159,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", simulation_id="SimId", filename="SimExportFileName"
     )
-    await def api_exportArchive(self, simulation_type, simulation_id, filename):
+    async def api_exportArchive(self, simulation_type, simulation_id, filename):
         req = self.parse_params(
             template=True,
             filename=filename,
@@ -171,7 +171,7 @@ class API(sirepo.quest.API):
         return exporter.create_archive(req, self)
 
     @sirepo.quest.Spec("allow_visitor")
-    await def api_favicon(self):
+    async def api_favicon(self):
         """Routes to favicon.ico file."""
         # SECURITY: We control the path of the file so using send_file is ok.
         return self.reply_file(
@@ -180,7 +180,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_visitor")
-    await def api_forbidden(self):
+    async def api_forbidden(self):
         raise sirepo.util.Forbidden("app forced forbidden")
 
     @sirepo.quest.Spec(
@@ -189,7 +189,7 @@ class API(sirepo.quest.API):
         file_type="LibFileType",
         sim_data="SimData",
     )
-    await def api_listFiles(self, simulation_type, simulation_id, file_type):
+    async def api_listFiles(self, simulation_type, simulation_id, file_type):
         # TODO(pjm): simulation_id is an unused argument
         req = self.parse_params(type=simulation_type, file_type=file_type)
         return self.reply_json(
@@ -199,7 +199,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "allow_visitor", application_mode="AppMode", simulation_name="SimName"
     )
-    await def api_findByName(self, simulation_type, application_mode, simulation_name):
+    async def api_findByName(self, simulation_type, application_mode, simulation_name):
         req = self.parse_params(type=simulation_type)
         return self.reply_redirect_for_local_route(
             req.type,
@@ -213,7 +213,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", application_mode="AppMode", simulation_name="SimName"
     )
-    await def api_findByNameWithAuth(
+    async def api_findByNameWithAuth(
         self, simulation_type, application_mode, simulation_name
     ):
         req = self.parse_params(type=simulation_type)
@@ -264,7 +264,7 @@ class API(sirepo.quest.API):
         sid="SimId",
         arguments="ImportArgs optional",
     )
-    await def api_importFile(self, simulation_type):
+    async def api_importFile(self, simulation_type):
         """
         Args:
             simulation_type (str): which simulation type
@@ -310,7 +310,7 @@ class API(sirepo.quest.API):
                         req,
                     )
                 with simulation_db.tmp_dir(qcall=self) as d:
-                    data = req.template.import_file(
+                    data = await req.template.import_file(
                         req,
                         tmp_dir=d,
                         reply_op=s,
@@ -338,8 +338,8 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_visitor", path_info="PathInfo optional")
-    await def api_homePage(self, path_info=None):
-        return self.call_api(
+    async def api_homePage(self, path_info=None):
+        return await self.call_api(
             "staticFile", kwargs=PKDict(path_info="en/" + (path_info or "landing.html"))
         )
 
@@ -349,7 +349,7 @@ class API(sirepo.quest.API):
         model="Model optional",
         title="DownloadNamePostfix optional",
     )
-    await def api_exportJupyterNotebook(
+    async def api_exportJupyterNotebook(
         self, simulation_type, simulation_id, model=None, title=None
     ):
         def _filename(req):
@@ -380,7 +380,7 @@ class API(sirepo.quest.API):
         model="Model optional",
         title="DownloadNamePostfix optional",
     )
-    await def api_exportJupyterNotebook2(self, simulation_type):
+    async def api_exportJupyterNotebook2(self, simulation_type):
         def _filename(req):
             res = d.models.simulation.name
             if req.title:
@@ -410,7 +410,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_user", folder="FolderName", name="SimName")
-    await def api_newSimulation(self):
+    async def api_newSimulation(self):
         req = self.parse_post(template=True, folder=True, name=True)
         d = simulation_db.default_data(req.type)
         d.models.simulation.pkupdate(
@@ -425,7 +425,7 @@ class API(sirepo.quest.API):
         return self._save_new_and_reply(req, d)
 
     @sirepo.quest.Spec("allow_visitor")
-    await def api_notFound(self):
+    async def api_notFound(self):
         raise sirepo.util.NotFound("app forced not found (uri parsing error)")
 
     @sirepo.quest.Spec(
@@ -434,7 +434,7 @@ class API(sirepo.quest.API):
         model="ComputeModelName optional",
         title="DownloadNamePostfix optional",
     )
-    await def api_pythonSource(self, simulation_type, simulation_id, model=None, title=None):
+    async def api_pythonSource(self, simulation_type, simulation_id, model=None, title=None):
         req = self.parse_params(type=simulation_type, id=simulation_id, template=True)
         m = model and req.sim_data.parse_model(model)
         d = simulation_db.read_simulation_json(req.type, sid=req.id, qcall=self)
@@ -455,7 +455,7 @@ class API(sirepo.quest.API):
         model="ComputeModelName optional",
         title="DownloadNamePostfix optional",
     )
-    await def api_pythonSource2(self, simulation_type):
+    async def api_pythonSource2(self, simulation_type):
         req = self.parse_post(
             type=simulation_type,
             id=True,
@@ -475,7 +475,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_visitor")
-    await def api_robotsTxt(self):
+    async def api_robotsTxt(self):
         """Disallow the app (dev, prod) or / (alpha, beta)"""
         global _ROBOTS_TXT
         if not _ROBOTS_TXT:
@@ -493,7 +493,7 @@ class API(sirepo.quest.API):
         return self.reply(content=_ROBOTS_TXT, content_type="text/plain")
 
     @sirepo.quest.Spec("allow_visitor", path_info="PathInfo")
-    await def api_root(self, path_info=None):
+    async def api_root(self, path_info=None):
         from sirepo import template
 
         self._proxy_react(path_info)
@@ -507,7 +507,7 @@ class API(sirepo.quest.API):
         raise sirepo.util.NotFound(f"unknown path={path_info}")
 
     @sirepo.quest.Spec("require_user", sid="SimId", data="SimData all_input")
-    await def api_saveSimulationData(self):
+    async def api_saveSimulationData(self):
         # do not fixup_old_data yet
         req = self.parse_post(id=True, template=True)
         d = req.req_data
@@ -522,7 +522,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", simulation_id="SimId", pretty="Bool optional", section="Section"
     )
-    await def api_simulationData(
+    async def api_simulationData(
         self, simulation_type, simulation_id, pretty=False, section=None
     ):
         """First entry point for a simulation
@@ -562,7 +562,7 @@ class API(sirepo.quest.API):
             return _not_found(req)
 
     @sirepo.quest.Spec("require_user", search="SearchSpec")
-    await def api_listSimulations(self):
+    async def api_listSimulations(self):
         req = self.parse_post()
         return self.reply_json(
             sorted(
@@ -577,7 +577,7 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("require_user")
-    await def api_simulationRedirect(self, simulation_type, local_route, simulation_id):
+    async def api_simulationRedirect(self, simulation_type, local_route, simulation_id):
         return self.reply_redirect_for_local_route(
             sim_type=simulation_type,
             route=local_route,
@@ -586,7 +586,7 @@ class API(sirepo.quest.API):
 
     # visitor rather than user because error pages are rendered by the application
     @sirepo.quest.Spec("allow_visitor")
-    await def api_simulationSchema(self):
+    async def api_simulationSchema(self):
         return self.reply_json(
             simulation_db.get_schema(
                 self.parse_params(
@@ -596,11 +596,11 @@ class API(sirepo.quest.API):
         )
 
     @sirepo.quest.Spec("allow_visitor")
-    await def api_srwLight(self):
+    async def api_srwLight(self):
         return self._render_root_page("light", PKDict())
 
     @sirepo.quest.Spec("allow_visitor", path_info="FilePath")
-    await def api_staticFile(self, path_info=None):
+    async def api_staticFile(self, path_info=None):
         """Send file from static folder.
 
         Args:
@@ -627,7 +627,7 @@ class API(sirepo.quest.API):
         return self.reply_file(p)
 
     @sirepo.quest.Spec("require_user", oldName="SimFolderPath", newName="SimFolderPath")
-    await def api_updateFolder(self):
+    async def api_updateFolder(self):
         # TODO(robnagler) Folder should have a serial, or should it be on data
         req = self.parse_post()
         o = sirepo.srschema.parse_folder(req.req_data["oldName"])
@@ -667,7 +667,7 @@ class API(sirepo.quest.API):
         simulation_id="SimId",
         confirm="Bool optional",
     )
-    await def api_uploadFile(self, simulation_type, simulation_id, file_type):
+    async def api_uploadFile(self, simulation_type, simulation_id, file_type):
         f = self.sreq.form_file_get()
         req = self.parse_params(
             file_type=file_type,

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -28,7 +28,7 @@ _SIM_TYPE = "jupyterhublogin"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_user", sim_type=f"SimType const={_SIM_TYPE}")
-    await def api_checkAuthJupyterhub(self):
+    async def api_checkAuthJupyterhub(self):
         self.parse_params(type=_SIM_TYPE)
         u = _unchecked_jupyterhub_user_name(
             self,
@@ -41,7 +41,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", do_migration="Bool", sim_type=f"SimType const={_SIM_TYPE}"
     )
-    await def api_migrateJupyterhub(self):
+    async def api_migrateJupyterhub(self):
         self.parse_params(type=_SIM_TYPE)
         if not _cfg.rs_jupyter_migrate:
             raise sirepo.util.Forbidden("migrate not enabled")
@@ -52,7 +52,7 @@ class API(sirepo.quest.API):
         sirepo.oauth.raise_authorize_redirect(self, _SIM_TYPE, github_auth=True)
 
     @sirepo.quest.Spec("require_user", sim_type=f"SimType const={_SIM_TYPE}")
-    await def api_redirectJupyterHub(self):
+    async def api_redirectJupyterHub(self):
         self.parse_params(type=_SIM_TYPE)
         u = _unchecked_jupyterhub_user_name(self)
         if u:

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -28,7 +28,7 @@ _SIM_TYPE = "jupyterhublogin"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_user", sim_type=f"SimType const={_SIM_TYPE}")
-    def api_checkAuthJupyterhub(self):
+    await def api_checkAuthJupyterhub(self):
         self.parse_params(type=_SIM_TYPE)
         u = _unchecked_jupyterhub_user_name(
             self,
@@ -41,7 +41,7 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec(
         "require_user", do_migration="Bool", sim_type=f"SimType const={_SIM_TYPE}"
     )
-    def api_migrateJupyterhub(self):
+    await def api_migrateJupyterhub(self):
         self.parse_params(type=_SIM_TYPE)
         if not _cfg.rs_jupyter_migrate:
             raise sirepo.util.Forbidden("migrate not enabled")
@@ -52,7 +52,7 @@ class API(sirepo.quest.API):
         sirepo.oauth.raise_authorize_redirect(self, _SIM_TYPE, github_auth=True)
 
     @sirepo.quest.Spec("require_user", sim_type=f"SimType const={_SIM_TYPE}")
-    def api_redirectJupyterHub(self):
+    await def api_redirectJupyterHub(self):
         self.parse_params(type=_SIM_TYPE)
         u = _unchecked_jupyterhub_user_name(self)
         if u:

--- a/sirepo/sim_oauth/flash.py
+++ b/sirepo/sim_oauth/flash.py
@@ -21,7 +21,7 @@ _SIM_TYPE = "flash"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_user")
-    def api_simOauthFlashAuthorized(self):
+    await def api_simOauthFlashAuthorized(self):
         o, _ = sirepo.oauth.check_authorized_callback(self)
         i = PKDict(o.get(cfg.info_url).json())
         # TODO(robnagler) should this not raise forbidden?

--- a/sirepo/sim_oauth/flash.py
+++ b/sirepo/sim_oauth/flash.py
@@ -21,7 +21,7 @@ _SIM_TYPE = "flash"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_user")
-    await def api_simOauthFlashAuthorized(self):
+    async def api_simOauthFlashAuthorized(self):
         o, _ = sirepo.oauth.check_authorized_callback(self)
         i = PKDict(o.get(cfg.info_url).json())
         # TODO(robnagler) should this not raise forbidden?

--- a/sirepo/spa_session.py
+++ b/sirepo/spa_session.py
@@ -8,12 +8,9 @@ from pykern.pkdebug import pkdp, pkdlog, pkdexc
 from pykern.pkcollections import PKDict
 import contextlib
 import datetime
-import pykern.pkconfig
-import sirepo.events
 import sirepo.quest
 import sirepo.srtime
 import sirepo.util
-import sqlalchemy
 
 _REFRESH_SESSION = datetime.timedelta(seconds=5 * 60)
 
@@ -29,10 +26,10 @@ def init_module():
     _initialized = True
 
 
-def init_quest(qcall):
-    def _begin():
+async def init_quest(qcall):
+    async def _begin():
         try:
-            qcall.call_api("beginSession").destroy()
+            (await qcall.call_api("beginSession")).destroy()
         except Exception as e:
             pkdlog("error={} trying api_beginSession stack={}", e, pkdexc())
 
@@ -52,4 +49,4 @@ def init_quest(qcall):
         return True
 
     if qcall.sreq.method_is_post() and qcall.auth.is_logged_in() and _check():
-        _begin()
+        await _begin()

--- a/sirepo/srtime.py
+++ b/sirepo/srtime.py
@@ -47,7 +47,7 @@ def adjust_time(days, qcall=None):
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("internal_test", days="TimeDeltaDays optional")
-    def api_adjustTime(self, days=None):
+    await def api_adjustTime(self, days=None):
         """Shift the system time by days and get the adjusted time
 
         Args:

--- a/sirepo/status.py
+++ b/sirepo/status.py
@@ -101,7 +101,7 @@ class API(sirepo.quest.API):
                 pass
 
     async def _validate_auth_state(self):
-        r = await self.call_api("authState").content_as_str()
+        r = (await self.call_api("authState")).content_as_str()
         m = re.search(r"SIREPO.authState\s*=\s*(.*?);", r)
         assert m, pkdformat("no authState in response={}", r)
         assert pkjson.load_any(m.group(1)).isLoggedIn, pkdformat(

--- a/sirepo/status.py
+++ b/sirepo/status.py
@@ -21,25 +21,25 @@ _SLEEP = 1
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_auth_basic")
-    await def api_serverStatus(self):
+    async def api_serverStatus(self):
         """Allow for remote monitoring of the web server status.
 
         The user must be an existing sirepo uid.  The status checks
         that a simple simulation can complete successfully within a
         short period of time.
         """
-        self._run_tests()
+        await self._run_tests()
         return self.reply_ok(
             {
                 "datetime": datetime.datetime.utcnow().isoformat(),
             }
         )
 
-    def _run_tests(self):
+    async def _run_tests(self):
         """Runs the SRW "Undulator Radiation" simulation's initialIntensityReport"""
-        self._validate_auth_state()
+        await self._validate_auth_state()
         simulation_type = _cfg.sim_type
-        res = self.call_api(
+        res = await self.call_api(
             "findByNameWithAuth",
             dict(
                 simulation_type=simulation_type,
@@ -70,7 +70,7 @@ class API(sirepo.quest.API):
         r = None
         resp = None
         try:
-            resp = self.call_api("runSimulation", data=d)
+            resp = await self.call_api("runSimulation", data=d)
             for _ in range(_cfg.max_calls):
                 r = simulation_db.json_load(resp.content_as_str())
                 resp.destroy()
@@ -85,7 +85,7 @@ class API(sirepo.quest.API):
                             raise RuntimeError("received bad report output: resp={}", r)
                     return
                 d = r.nextRequest
-                resp = self.call_api("runStatus", data=d)
+                resp = await self.call_api("runStatus", data=d)
                 time.sleep(_SLEEP)
             raise RuntimeError(
                 "simulation timed out: seconds={} resp=".format(
@@ -96,12 +96,12 @@ class API(sirepo.quest.API):
             if resp:
                 resp.destroy()
             try:
-                self.call_api("runCancel", data=d)
+                await self.call_api("runCancel", data=d)
             except Exception:
                 pass
 
-    def _validate_auth_state(self):
-        r = self.call_api("authState").content_as_str()
+    async def _validate_auth_state(self):
+        r = await self.call_api("authState").content_as_str()
         m = re.search(r"SIREPO.authState\s*=\s*(.*?);", r)
         assert m, pkdformat("no authState in response={}", r)
         assert pkjson.load_any(m.group(1)).isLoggedIn, pkdformat(

--- a/sirepo/status.py
+++ b/sirepo/status.py
@@ -21,7 +21,7 @@ _SLEEP = 1
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_auth_basic")
-    def api_serverStatus(self):
+    await def api_serverStatus(self):
         """Allow for remote monitoring of the web server status.
 
         The user must be an existing sirepo uid.  The status checks

--- a/sirepo/template/elegant.py
+++ b/sirepo/template/elegant.py
@@ -703,7 +703,7 @@ def get_data_file(run_dir, model, frame, options):
     return _sdds(_report_output_filename("bunchReport"))
 
 
-def import_file(req, test_data=None, **kwargs):
+async def import_file(req, test_data=None, **kwargs):
     # input_data is passed by test cases only
     d = test_data
     if "id" in req:

--- a/sirepo/template/genesis.py
+++ b/sirepo/template/genesis.py
@@ -119,7 +119,7 @@ def get_data_file(run_dir, model, frame, options):
     raise AssertionError("unknown model={}".format(model))
 
 
-def import_file(req, **kwargs):
+async def import_file(req, **kwargs):
     text = req.form_file.as_str()
     if not bool(re.search(r"\.in$", req.filename, re.IGNORECASE)):
         raise AssertionError("invalid file extension, expecting .in")

--- a/sirepo/template/madx.py
+++ b/sirepo/template/madx.py
@@ -353,7 +353,7 @@ def get_data_file(run_dir, model, frame, options):
     assert False, f"no data file for model: {model}"
 
 
-def import_file(req, **kwargs):
+async def import_file(req, **kwargs):
     text = req.form_file.as_str()
     if not bool(re.search(r"\.madx$|\.seq$", req.filename, re.IGNORECASE)):
         raise AssertionError("invalid file extension, expecting .madx or .seq")

--- a/sirepo/template/opal.py
+++ b/sirepo/template/opal.py
@@ -468,7 +468,7 @@ def get_data_file(run_dir, model, frame, options):
     raise AssertionError("unknown model={}".format(model))
 
 
-def import_file(req, unit_test_mode=False, **kwargs):
+async def import_file(req, unit_test_mode=False, **kwargs):
     from sirepo.template import opal_parser
 
     text = req.form_file.as_str()

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -271,7 +271,7 @@ def get_data_file(run_dir, model, frame, options):
         return f
 
 
-def import_file(req, tmp_dir=None, **kwargs):
+async def import_file(req, tmp_dir=None, **kwargs):
     data = simulation_db.default_data(req.type)
     data.models.simulation.pkupdate(
         {k: v for k, v in req.req_data.items() if k in data.models.simulation}

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -593,7 +593,7 @@ async def import_file(req, tmp_dir, qcall, **kwargs):
                     x,
                 )
             time.sleep(x.nextRequestSeconds)
-            r = await qcall.call_api_sync("runStatus", data=x.nextRequest)
+            r = await qcall.call_api("runStatus", data=x.nextRequest)
         else:
             raise sirepo.util.UserAlert(
                 "error parsing python",

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -532,7 +532,7 @@ def sim_frame(frame_args):
     return extract_report_data(frame_args.sim_in)
 
 
-def import_file(req, tmp_dir, qcall, **kwargs):
+async def import_file(req, tmp_dir, qcall, **kwargs):
     import sirepo.server
 
     i = None
@@ -558,7 +558,7 @@ def import_file(req, tmp_dir, qcall, **kwargs):
             forceRun=True,
             simulationId=i,
         )
-        r = qcall.call_api("runSimulation", data=d)
+        r = await qcall.call_api("runSimulation", data=d)
         for _ in range(_IMPORT_PYTHON_POLLS):
             if r.status_as_int() != 200:
                 raise sirepo.util.UserAlert(
@@ -593,7 +593,7 @@ def import_file(req, tmp_dir, qcall, **kwargs):
                     x,
                 )
             time.sleep(x.nextRequestSeconds)
-            r = qcall.call_api("runStatus", data=x.nextRequest)
+            r = await qcall.call_api_sync("runStatus", data=x.nextRequest)
         else:
             raise sirepo.util.UserAlert(
                 "error parsing python",
@@ -619,7 +619,7 @@ def import_file(req, tmp_dir, qcall, **kwargs):
             r.destroy()
             r = None
     raise sirepo.util.SReplyExc(
-        qcall.call_api(
+        await qcall.call_api(
             "simulationData",
             kwargs=PKDict(simulation_type=x.simulationType, simulation_id=i),
         ),

--- a/sirepo/template/synergia.py
+++ b/sirepo/template/synergia.py
@@ -136,7 +136,7 @@ def format_float(v):
     return float(format(v, ".10f"))
 
 
-def import_file(req, tmp_dir=None, **kwargs):
+async def import_file(req, tmp_dir=None, **kwargs):
     f = req.form_file.as_str()
     if re.search(r".madx$", req.filename, re.IGNORECASE):
         data = _import_madx_file(f)

--- a/sirepo/template/zgoubi.py
+++ b/sirepo/template/zgoubi.py
@@ -463,7 +463,7 @@ def stateful_compute_tosca_info(data):
     return zgoubi_importer.tosca_info(data.args.tosca)
 
 
-def import_file(req, unit_test_mode=False, **kwargs):
+async def import_file(req, unit_test_mode=False, **kwargs):
     return zgoubi_importer.import_file(
         req.form_file.as_str(),
         unit_test_mode=unit_test_mode,

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -310,7 +310,7 @@ async def _call_api(parent, route, kwargs, data=None, internal_req=None, reply_o
                 kwargs = PKDict()
             _check_route(qcall, qcall.uri_route)
             r = qcall.sreply.from_api(
-                getattr(qcall, qcall.uri_route.func_name)(**kwargs),
+                await getattr(qcall, qcall.uri_route.func_name)(**kwargs)
             )
             c = True
         except Exception as e:

--- a/tests/auth/ldap_test.py
+++ b/tests/auth/ldap_test.py
@@ -37,13 +37,14 @@ def test_incorrect_creds():
 def _call_login(email, password):
     from pykern import pkinspect
     from sirepo import srunit
+    from pykern.pkdebug import pkdp
     import sys
 
     sys.modules["ldap"] = pkinspect.this_module()
     with srunit.quest_start(cfg={"SIREPO_AUTH_METHODS": "ldap"}) as qcall:
         from pykern.pkcollections import PKDict
 
-        r = qcall.call_api(
+        r = qcall.call_api_sync(
             "authLdapLogin",
             data=PKDict(
                 simulationType="myapp",

--- a/tests/auth1_test.py
+++ b/tests/auth1_test.py
@@ -19,7 +19,7 @@ def test_login():
         from sirepo import util
         from sirepo.auth import guest
 
-        r = qcall.call_api("authState")
+        r = qcall.call_api_sync("authState")
         pkre('LoggedIn": false.*Registration": false', r.content_as_str())
         r.destroy()
         r = None

--- a/tests/template/elegant_import_test.py
+++ b/tests/template/elegant_import_test.py
@@ -14,6 +14,7 @@ import pytest
 def test_importer(import_req):
     from pykern.pkcollections import PKDict
     from sirepo.template import elegant
+    import asyncio
     import sirepo.lib
 
     for fn in pkio.sorted_glob(pkunit.data_dir().join("*")):
@@ -25,13 +26,13 @@ def test_importer(import_req):
         pkdlog("file={}", fn)
         if fn.basename.startswith("deviance-"):
             try:
-                data = elegant.import_file(import_req(fn))
+                data = asyncio.run(elegant.import_file(import_req(fn)))
             except Exception as e:
                 k.actual = f"{e}\n"
             else:
                 k.actual = "did not raise exception"
         elif fn.ext == ".lte":
-            data = elegant.import_file(import_req(fn))
+            data = asyncio.run(elegant.import_file(import_req(fn)))
             data["models"]["commands"] = []
             g = elegant._Generate(data)
             g.sim()

--- a/tests/template/madx_converter_test.py
+++ b/tests/template/madx_converter_test.py
@@ -43,10 +43,15 @@ def test_import_elegant_export_madx(import_req):
     from sirepo import srunit
     from sirepo.template import elegant
     from sirepo.template.elegant import ElegantMadxConverter
+    import asyncio
 
-    data = elegant.import_file(import_req(pkunit.data_dir().join("test1.ele")))
-    data = elegant.import_file(
-        import_req(pkunit.data_dir().join("test1.lte")), test_data=data
+    data = asyncio.run(
+        elegant.import_file(import_req(pkunit.data_dir().join("test1.ele")))
+    )
+    data = asyncio.run(
+        elegant.import_file(
+            import_req(pkunit.data_dir().join("test1.lte")), test_data=data
+        )
     )
     # this is updated from javascript unfortunately
     data.models.bunch.longitudinalMethod = "3"
@@ -105,11 +110,16 @@ def _opal_to_madx(import_req, basename):
     from sirepo import srunit
     from sirepo.template import opal
     from sirepo.template.opal import OpalMadxConverter
+    import asyncio
 
     with srunit.quest_start() as qcall:
         file_eq(
             f"{basename}.madx",
             actual=OpalMadxConverter(qcall=qcall).to_madx_text(
-                opal.import_file(import_req(pkunit.data_dir().join(f"{basename}.in")))
+                asyncio.run(
+                    opal.import_file(
+                        import_req(pkunit.data_dir().join(f"{basename}.in"))
+                    )
+                )
             ),
         )

--- a/tests/template/zgoubi_import_test.py
+++ b/tests/template/zgoubi_import_test.py
@@ -17,13 +17,14 @@ def test_importer(import_req):
     from sirepo import srunit
     from sirepo.template import zgoubi
     from sirepo import sim_data
+    import asyncio
 
     with pkunit.save_chdir_work() as w:
         for fn in pkio.sorted_glob(pkunit.data_dir().join("*.dat")):
             error = None
             req = import_req(fn)
             try:
-                data = zgoubi.import_file(req, unit_test_mode=True)
+                data = asyncio.run(zgoubi.import_file(req, unit_test_mode=True))
                 sim_data.get_class("zgoubi").fixup_old_data(
                     data,
                     qcall=req.qcall,


### PR DESCRIPTION
Currently failing supervisor_purge_free_sims_test.py with db not created by the time the supervisor runs purge sims. It's a race condition on startup. Tried to switch order in conftest, but that runs into different bugs. Fails both in tornado and flask cases. Not sure why.
