### PR TITLE
Fix #5598 - set camera only after initial scene build

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -2208,7 +2208,6 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
                 updateLayout();
                 setAlpha();
                 setBgColor();
-                $scope.vtkScene.setCam();
                 enableWatchFields(true);
             }
 
@@ -2657,6 +2656,7 @@ SIREPO.app.directive('radiaViewer', function(appState, errorService, frameCache,
                 buildScene();
                 if (! initDone) {
                     initDone = true;
+                    $scope.vtkScene.setCam();
                 }
             }
 


### PR DESCRIPTION
The camera was being reset every time the scene was built - it's only really needed after the first time.