### PR TITLE
Fix #5602 radia incorrect bevel

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -14,6 +14,9 @@ SIREPO.app.config(function() {
     SIREPO.appDefaultSimulationValues.simulation.freehandType = 'freehand';
     SIREPO.SINGLE_FRAME_ANIMATION = ['solverAnimation'];
     SIREPO.appFieldEditors += `
+        <div data-ng-switch-when="BevelEdge" class="col-sm-12">
+          <div data-bevel-edge="" data-model="model" data-model-name="modelName" data-field="field"></div>
+        </div>
         <div data-ng-switch-when="Color" data-ng-class="fieldClass">
           <input type="color" data-ng-model="model[field]" class="sr-color-button">
         </div>
@@ -1003,6 +1006,31 @@ SIREPO.app.directive('appHeader', function(activeSection, appState, panelState, 
                 return SIREPO.APP_SCHEMA.constants.rawExamples.indexOf(name) >= 0;
             }
         }
+    };
+});
+
+SIREPO.app.directive('bevelEdge', function(appState, panelState, radiaService, utilities) {
+
+    return {
+        restrict: 'A',
+        scope: {
+            field: '=',
+            model: '=',
+            modelName: '=',
+        },
+        template: `
+          <select class="form-control" data-ng-model="model[field]" data-ng-options="item[0] as cornerLabel(item[0]) for item in enum[info[1]]"></select>
+        `,
+        controller: function($scope) {
+            $scope.enum = SIREPO.APP_SCHEMA.enum;
+            $scope.info = appState.modelInfo($scope.modelName)[$scope.field];
+
+            $scope.cornerLabel = index => {
+                const signs = [['-', '+'], ['+', '+'], ['+', '-'], ['-', '-']][parseInt(index)];
+                const axes = SIREPO.GEOMETRY.GeometryUtils.nextAxes($scope.model.cutAxis);
+                return `(${signs[0]}${axes[0]}, ${signs[1]}${axes[1]})`;
+            }
+        },
     };
 });
 

--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1029,7 +1029,7 @@ SIREPO.app.directive('bevelEdge', function(appState, panelState, radiaService, u
                 const signs = [['-', '+'], ['+', '+'], ['+', '-'], ['-', '-']][parseInt(index)];
                 const axes = SIREPO.GEOMETRY.GeometryUtils.nextAxes($scope.model.cutAxis);
                 return `(${signs[0]}${axes[0]}, ${signs[1]}${axes[1]})`;
-            }
+            };
         },
     };
 });

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -872,7 +872,7 @@
             "amountVert": ["Vertical Cut [mm]", "Float", 1.0],
             "amountHoriz": ["Horizontal Cut [mm]", "Float", 1.0],
             "cutDir": ["", "Array", [0, 0, 1]],
-            "edge": ["Bevel Edge", "BevelEdge", "0", "Edge of cross-section to bevel"],
+            "edge": ["Corner", "BevelEdge", "0", "Corner of cross-sectional footprint to cut"],
             "heightDir": ["", "Array", [0, 1, 0]],
             "type": ["_", "ObjectCutType", "objectBevel"],
             "widthDir": ["", "Array", [1, 0, 0]]

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -872,7 +872,7 @@
             "amountVert": ["Vertical Cut [mm]", "Float", 1.0],
             "amountHoriz": ["Horizontal Cut [mm]", "Float", 1.0],
             "cutDir": ["", "Array", [0, 0, 1]],
-            "edge": ["Bevel Edge", "BevelEdge", "0", "Index of base shape edge to bevel, relative to the view axis"],
+            "edge": ["Bevel Edge", "BevelEdge", "0", "Edge of cross-section to bevel"],
             "heightDir": ["", "Array", [0, 1, 0]],
             "type": ["_", "ObjectCutType", "objectBevel"],
             "widthDir": ["", "Array", [1, 0, 0]]
@@ -1407,15 +1407,15 @@
             "basic": [
                 "cutAxis",
                 "edge",
-                "amountVert",
                 "amountHoriz",
+                "amountVert",
                 "cutRemoval"
             ],
             "advanced": [
                 "cutAxis",
                 "edge",
-                "amountVert",
                 "amountHoriz",
+                "amountVert",
                 "cutRemoval"
             ]
         },

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -606,6 +606,120 @@
                 "color": "#0000ff",
                 "segments": [4, 4, 4],
                 "magnetization": [0.0, 0.0, 1.0],
+                "modifications": [
+                    {
+                        "amountHoriz": 8,
+                        "amountVert": 8,
+                        "cutAxis": "x",
+                        "cutDir": [
+                            0,
+                            0,
+                            1
+                        ],
+                        "cutPoint": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "cutRemoval": "1",
+                        "edge": "2",
+                        "heightDir": [
+                            0,
+                            1,
+                            0
+                        ],
+                        "type": "objectBevel",
+                        "widthDir": [
+                            1,
+                            0,
+                            0
+                        ]
+                    },
+                    {
+                        "amountHoriz": 8,
+                        "amountVert": 8,
+                        "cutAxis": "x",
+                        "cutDir": [
+                            0,
+                            0,
+                            1
+                        ],
+                        "cutPoint": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "cutRemoval": "1",
+                        "edge": "3",
+                        "heightDir": [
+                            0,
+                            1,
+                            0
+                        ],
+                        "type": "objectBevel",
+                        "widthDir": [
+                            1,
+                            0,
+                            0
+                        ]
+                    },
+                    {
+                        "amountHoriz": 8,
+                        "amountVert": 8,
+                        "cutAxis": "y",
+                        "cutDir": [
+                            0,
+                            0,
+                            1
+                        ],
+                        "cutPoint": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "cutRemoval": "1",
+                        "edge": "0",
+                        "heightDir": [
+                            0,
+                            1,
+                            0
+                        ],
+                        "type": "objectBevel",
+                        "widthDir": [
+                            1,
+                            0,
+                            0
+                        ]
+                    },
+                    {
+                        "amountHoriz": 8,
+                        "amountVert": 8,
+                        "cutAxis": "y",
+                        "cutDir": [
+                            0,
+                            0,
+                            1
+                        ],
+                        "cutPoint": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "cutRemoval": "1",
+                        "edge": "3",
+                        "heightDir": [
+                            0,
+                            1,
+                            0
+                        ],
+                        "type": "objectBevel",
+                        "widthDir": [
+                            1,
+                            0,
+                            0
+                        ]
+                    }
+                ],
                 "name": "pole",
                 "remanentMag": 1.0,
                 "material": "Xc06",

--- a/sirepo/package_data/static/json/radia-schema.json
+++ b/sirepo/package_data/static/json/radia-schema.json
@@ -512,96 +512,6 @@
                 "stemPosition": "1"
             }],
             "pole": ["Pole", "model.cuboid", {
-                "bevels": [
-                    {
-                        "amountHoriz": 8,
-                        "amountVert": 8,
-                        "cutAxis": "x",
-                        "cutDir": [
-                            1,
-                            0,
-                            0
-                        ],
-                        "cutRemoval": 1,
-                        "edge": "2",
-                        "heightDir": [
-                            0,
-                            0,
-                            1
-                        ],
-                        "widthDir": [
-                            0,
-                            1,
-                            0
-                        ]
-                    },
-                    {
-                        "amountHoriz": 8,
-                        "amountVert": 8,
-                        "cutAxis": "x",
-                        "cutDir": [
-                            1,
-                            0,
-                            0
-                        ],
-                        "cutRemoval": 1,
-                        "edge": "3",
-                        "heightDir": [
-                            0,
-                            0,
-                            1
-                        ],
-                        "widthDir": [
-                            0,
-                            1,
-                            0
-                        ]
-                    },
-                    {
-                        "amountHoriz": 8,
-                        "amountVert": 8,
-                        "cutAxis": "y",
-                        "cutDir": [
-                            0,
-                            1,
-                            0
-                        ],
-                        "cutRemoval": 1,
-                        "edge": "2",
-                        "heightDir": [
-                            0,
-                            0,
-                            1
-                        ],
-                        "widthDir": [
-                            1,
-                            0,
-                            0
-                        ]
-                    },
-                    {
-                        "amountHoriz": 8,
-                        "amountVert": 8,
-                        "cutAxis": "y",
-                        "cutDir": [
-                            0,
-                            1,
-                            0
-                        ],
-                        "cutRemoval": 1,
-                        "edge": "3",
-                        "heightDir": [
-                            0,
-                            0,
-                            1
-                        ],
-                        "widthDir": [
-                            1,
-                            0,
-                            0
-                        ]
-                    }
-                ],
                 "center": [0.0, 0.0, 30.0],
                 "color": "#0000ff",
                 "segments": [4, 4, 4],
@@ -772,34 +682,25 @@
                 "transforms": []
             }],
             "pole": ["Pole", "model.cuboid", {
-                "bevels": [
+                "center": [0.0, 2.5, 1.5],
+                "color": "#0066cd",
+                "magnetization": [0.0, 0.0, 1.0],
+                "material": "Xc06",
+                "modifications": [
                     {
                         "amountHoriz": 0.5,
                         "amountVert": 0.5,
                         "cutAxis": "x",
-                        "edge": "2",
                         "cutDir": [
                             1,
                             0,
                             0
                         ],
                         "cutRemoval": 1,
-                        "heightDir": [
-                            0,
-                            0,
-                            1
-                        ],
-                        "widthDir": [
-                            0,
-                            1,
-                            0
-                        ]
+                        "edge": "2",
+                        "type": "objectBevel"
                     }
                 ],
-                "center": [0.0, 2.5, 1.5],
-                "color": "#0066cd",
-                "magnetization": [0.0, 0.0, 1.0],
-                "material": "Xc06",
                 "name": "pole",
                 "remanentMag": 1.0,
                 "segments": [4, 4, 4],


### PR DESCRIPTION
Notes:
- Corrects the bevels for the default parameterized c-bend dipole and moves them to the "modifications" array
- Moves the bevel for the default parameterized h-bend dipole to the "modifications" array
- Changes the label and tooltip for the "bevel edge" to clarify the geometry
