### PR TITLE
Fix #5612: Remove RequiredUnlessDev for raydata.file_reply_tmp_dir

### DIFF
--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -174,7 +174,7 @@ def _init():
             "codes that contain proprietary information and authorization to use is granted through oauth",
         ),
         raydata=dict(
-            file_reply_tmp_dir=pkconfig.RequiredUnlessDev(
+            file_reply_tmp_dir=(
                 "raydata_file_reply_tmp_dir",
                 _tmp_dir,
                 "directory to share analysis pdfs between scan monitor and supervisor",


### PR DESCRIPTION
On systems w/o raydata as a configured sim_type this parameter shouldn't be required.