### PR TITLE
WIP radiasoft/raydata#83: Have raydata.scan_monitor send file to supervisor

### DIFF
--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -174,11 +174,6 @@ def _init():
             "codes that contain proprietary information and authorization to use is granted through oauth",
         ),
         raydata=dict(
-            file_reply_tmp_dir=(
-                "raydata_file_reply_tmp_dir",
-                _tmp_dir,
-                "directory to share analysis pdfs between scan monitor and supervisor",
-            ),
             scan_monitor_url=(
                 "http://127.0.0.1:9001/scan-monitor",
                 str,
@@ -250,17 +245,3 @@ def _check_packages(packages):
 
     for p in packages:
         importlib.import_module(p)
-
-
-def _tmp_dir(dir):
-    from pykern import pkconfig
-    from pykern import pkio
-    import os.path
-
-    if pkconfig.channel_in("dev"):
-        assert not os.path.isabs(dir), f"must use a relative path in dev dir={dir}"
-        import sirepo.srdb
-
-        return pkio.mkdir_parent(sirepo.srdb.root().join(dir))
-    assert os.path.isabs(dir), f"must use an absolute path outside of dev dir={dir}"
-    return pkio.py_path(dir)

--- a/sirepo/job.py
+++ b/sirepo/job.py
@@ -287,7 +287,9 @@ def init_module():
 
 
 def is_ok_reply(value):
-    return isinstance(value, PKDict) and value == _OK_REPLY
+    if not isinstance(value, PKDict):
+        return False
+    return value == _OK_REPLY or value.get("state") == COMPLETED
 
 
 def join_jid(uid, sid, compute_model):

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -275,7 +275,9 @@ class API(sirepo.quest.API):
                     f"expected json content-type={r.headers['content-type']}"
                 )
             j = pkjson.load_any(r.body)
-            if d and sirepo.job.is_ok_reply(j):
+            if d and (
+                sirepo.job.is_ok_reply(j) or j.get("state") == sirepo.job.COMPLETED
+            ):
                 return self._reply_with_file(d)
             return j
 

--- a/sirepo/pkcli/job_cmd.py
+++ b/sirepo/pkcli/job_cmd.py
@@ -82,7 +82,9 @@ def _dispatch_compute(msg, template):
     def _op(expect_file):
         if "dataFileUri" in msg:
             msg.data.dataFileUri = msg.dataFileUri
-        r = getattr(template_common, f"{msg.jobCmd}_dispatch")(msg.data)
+        r = getattr(template_common, f"{msg.jobCmd}_dispatch")(
+            msg.data, data_file_uri=msg.get("dataFileUri")
+        )
         if not isinstance(r, template_common.JobCmdFile):
             # ok to not return JobCmdFile if there was an error
             return r

--- a/sirepo/pkcli/job_cmd.py
+++ b/sirepo/pkcli/job_cmd.py
@@ -80,6 +80,8 @@ def _background_percent_complete(msg, template, is_running):
 
 def _dispatch_compute(msg, template):
     def _op(expect_file):
+        if "dataFileUri" in msg:
+            msg.data.dataFileUri = msg.dataFileUri
         r = getattr(template_common, f"{msg.jobCmd}_dispatch")(msg.data)
         if not isinstance(r, template_common.JobCmdFile):
             # ok to not return JobCmdFile if there was an error
@@ -104,14 +106,6 @@ def _dispatch_compute(msg, template):
             template.SIM_TYPE,
         ).does_api_reply_with_file(msg.api, msg.data.method)
         if x:
-            if sirepo.feature_config.for_sim_type(template.SIM_TYPE).file_reply_tmp_dir:
-                with tempfile.TemporaryDirectory(
-                    dir=sirepo.feature_config.for_sim_type(
-                        template.SIM_TYPE
-                    ).file_reply_tmp_dir
-                ) as t:
-                    msg.data.temp_dir = t
-                    return _op(expect_file=x)
             with simulation_db.tmp_dir(chdir=True) as d:
                 return _op(expect_file=x)
         else:

--- a/sirepo/pkcli/job_cmd.py
+++ b/sirepo/pkcli/job_cmd.py
@@ -80,8 +80,6 @@ def _background_percent_complete(msg, template, is_running):
 
 def _dispatch_compute(msg, template):
     def _op(expect_file):
-        if "dataFileUri" in msg:
-            msg.data.dataFileUri = msg.dataFileUri
         r = getattr(template_common, f"{msg.jobCmd}_dispatch")(
             msg.data, data_file_uri=msg.get("dataFileUri")
         )

--- a/sirepo/template/activait.py
+++ b/sirepo/template/activait.py
@@ -209,7 +209,7 @@ def prepare_sequential_output_file(run_dir, data):
                 pass
 
 
-def stateless_compute_load_keras_model(data):
+def stateless_compute_load_keras_model(data, **kwargs):
     import keras.models
 
     l = _SIM_DATA.lib_file_abspath(
@@ -346,7 +346,7 @@ def sim_frame_logisticRegressionErrorRateAnimation(frame_args):
     )
 
 
-def stateful_compute_column_info(data):
+def stateful_compute_column_info(data, **kwargs):
     f = data.args.dataFile.file
     if pkio.has_file_extension(f, "csv"):
         return _compute_csv_info(f)
@@ -363,11 +363,11 @@ def analysis_job_dice_coefficient(data, run_dir, **kwargs):
     return _dice_coefficient_plot(data, run_dir)
 
 
-def stateful_compute_sample_images(data):
+def stateful_compute_sample_images(data, **kwargs):
     return _image_preview(data)
 
 
-def stateless_compute_get_remote_data(data):
+def stateless_compute_get_remote_data(data, **kwargs):
     return template_common.remote_file_to_simulation_lib(
         _SIM_DATA,
         data.args.url,
@@ -377,11 +377,11 @@ def stateless_compute_get_remote_data(data):
     )
 
 
-def stateless_compute_remote_data_bytes_loaded(data):
+def stateless_compute_remote_data_bytes_loaded(data, **kwargs):
     return _remote_data_bytes_loaded(data.args.filename)
 
 
-def stateless_compute_get_archive_file_list(data):
+def stateless_compute_get_archive_file_list(data, **kwargs):
     return _archive_file_list(data.args.filename, data.args.data_type)
 
 

--- a/sirepo/template/cloudmc.py
+++ b/sirepo/template/cloudmc.py
@@ -90,7 +90,7 @@ def python_source_for_model(data, model, qcall, **kwargs):
     return _generate_parameters_file(data)
 
 
-def stateful_compute_download_remote_lib_file(data):
+def stateful_compute_download_remote_lib_file(data, **kwargs):
     return template_common.remote_file_to_simulation_lib(
         _SIM_DATA,
         "{}/{}".format(
@@ -135,7 +135,7 @@ def sim_frame(frame_args):
     )
 
 
-def stateless_compute_validate_material_name(data):
+def stateless_compute_validate_material_name(data, **kwargs):
     import openmc
 
     res = PKDict()

--- a/sirepo/template/controls.py
+++ b/sirepo/template/controls.py
@@ -188,7 +188,7 @@ def sim_frame(frame_args):
     )
 
 
-def stateful_compute_get_madx_sim_list(data):
+def stateful_compute_get_madx_sim_list(data, **kwargs):
     res = []
     for f in pkio.sorted_glob(
         _SIM_DATA.controls_madx_dir().join(
@@ -211,7 +211,7 @@ def stateful_compute_get_madx_sim_list(data):
     return PKDict(simList=res)
 
 
-def stateful_compute_get_external_lattice(data):
+def stateful_compute_get_external_lattice(data, **kwargs):
     madx = sirepo.simulation_db.read_json(
         _SIM_DATA.controls_madx_dir().join(
             data.args.simulationId,
@@ -238,7 +238,7 @@ def stateful_compute_get_external_lattice(data):
     )
 
 
-def stateful_compute_get_log_file_time_list(data):
+def stateful_compute_get_log_file_time_list(data, **kwargs):
     import h5py
 
     with h5py.File(_log_file_path(data.lib_file), "r") as f:
@@ -247,11 +247,11 @@ def stateful_compute_get_log_file_time_list(data):
         )
 
 
-def stateful_compute_get_log_file_values_at_index(data):
+def stateful_compute_get_log_file_values_at_index(data, **kwargs):
     return PKDict(values=_log_file_values(data.models, data.index, data.lib_file))
 
 
-def stateless_compute_current_to_kick(data):
+def stateless_compute_current_to_kick(data, **kwargs):
     return PKDict(
         kick=AmpConverter(
             data.args.command_beam, data.args.amp_table, data.args.default_factor
@@ -259,7 +259,7 @@ def stateless_compute_current_to_kick(data):
     )
 
 
-def stateless_compute_kick_to_current(data):
+def stateless_compute_kick_to_current(data, **kwargs):
     return PKDict(
         current=AmpConverter(
             data.args.command_beam, data.args.amp_table, data.args.default_factor

--- a/sirepo/template/elegant.py
+++ b/sirepo/template/elegant.py
@@ -841,7 +841,7 @@ def sim_frame(frame_args):
     )
 
 
-def stateful_compute_get_beam_input_type(data):
+def stateful_compute_get_beam_input_type(data, **kwargs):
     if data.args.input_file:
         data.input_type = _sdds_beam_type_from_file(
             _SIM_DATA.lib_file_abspath(data.args.input_file),

--- a/sirepo/template/flash.py
+++ b/sirepo/template/flash.py
@@ -341,7 +341,7 @@ def sort_problem_files(files):
     return sorted(files, key=lambda x: (_sort_suffix(x), x["name"]))
 
 
-def stateless_compute_delete_archive_file(data):
+def stateless_compute_delete_archive_file(data, **kwargs):
     # TODO(pjm): python may have ZipFile.remove() method eventually
     pksubprocess.check_call_with_signals(
         [
@@ -358,7 +358,7 @@ def stateless_compute_delete_archive_file(data):
     return PKDict()
 
 
-def stateless_compute_format_text_file(data):
+def stateless_compute_format_text_file(data, **kwargs):
     if data.args.filename == _SIM_DATA.FLASH_PAR_FILE and data.args.models.get(
         "flashSchema"
     ):
@@ -390,7 +390,7 @@ def stateless_compute_format_text_file(data):
     )
 
 
-def stateless_compute_get_archive_file(data):
+def stateless_compute_get_archive_file(data, **kwargs):
     if data.args.filename == _SIM_DATA.FLASH_PAR_FILE and data.args.models.get(
         "flashSchema"
     ):
@@ -407,7 +407,7 @@ def stateless_compute_get_archive_file(data):
     )
 
 
-def stateless_compute_update_lib_file(data):
+def stateless_compute_update_lib_file(data, **kwargs):
     p = _SIM_DATA.lib_file_write_path(
         _SIM_DATA.flash_app_lib_basename(data.args.simulationId),
     )
@@ -424,7 +424,7 @@ def stateless_compute_update_lib_file(data):
     )
 
 
-def stateless_compute_replace_file_in_zip(data):
+def stateless_compute_replace_file_in_zip(data, **kwargs):
     found = False
     for f in data.args.archiveFiles:
         if f.name == data.args.filename:
@@ -467,7 +467,7 @@ def stateless_compute_replace_file_in_zip(data):
     return res
 
 
-def stateless_compute_setup_command(data):
+def stateless_compute_setup_command(data, **kwargs):
     return PKDict(
         setupCommand=" ".join(
             _SIM_DATA.flash_setup_command(data.args.setupArguments),

--- a/sirepo/template/jspec.py
+++ b/sirepo/template/jspec.py
@@ -234,7 +234,7 @@ def sim_frame_particleAnimation(frame_args):
     )
 
 
-def stateful_compute_get_elegant_sim_list(data):
+def stateful_compute_get_elegant_sim_list(data, **kwargs):
     tp = _SIM_DATA.jspec_elegant_twiss_path()
     res = []
     for f in pkio.sorted_glob(

--- a/sirepo/template/madx.py
+++ b/sirepo/template/madx.py
@@ -412,7 +412,7 @@ def save_sequential_report_data(data, run_dir):
     )
 
 
-def stateless_compute_calculate_bunch_parameters(data):
+def stateless_compute_calculate_bunch_parameters(data, **kwargs):
     return _calc_bunch_parameters(
         data.args.bunch, data.args.command_beam, data.args.variables
     )

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -317,7 +317,7 @@ def sim_frame_fieldLineoutAnimation(frame_args):
     )
 
 
-def stateless_compute_build_shape_points(data):
+def stateless_compute_build_shape_points(data, **kwargs):
     o = data.args.object
     if not o.get("pointsFile"):
         return PKDict(
@@ -338,7 +338,7 @@ def stateless_compute_build_shape_points(data):
     return PKDict(points=pts)
 
 
-def stateless_compute_stl_size(data):
+def stateless_compute_stl_size(data, **kwargs):
     f = _SIM_DATA.lib_file_abspath(
         _SIM_DATA.lib_file_name_with_type(data.args.file, SCHEMA.constants.fileTypeSTL)
     )

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -50,13 +50,7 @@ def stateless_compute_catalog_names(_):
 
 
 def stateless_compute_download_analysis_pdfs(data):
-    return template_common.JobCmdFile(
-        path=pkio.py_path(
-            _request_scan_monitor(
-                PKDict(method="download_analysis_pdfs", data=data)
-            ).path
-        )
-    )
+    return _request_scan_monitor(PKDict(method="download_analysis_pdfs", data=data))
 
 
 def stateless_compute_run_analysis(data):

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -21,11 +21,11 @@ import sirepo.util
 _SIM_DATA, SIM_TYPE, SCHEMA = sirepo.sim_data.template_globals()
 
 
-def stateless_compute_analysis_output(data):
+def stateless_compute_analysis_output(data, **kwargs):
     return _request_scan_monitor(PKDict(method="analysis_output", uid=data.args.uid))
 
 
-def stateless_compute_analysis_run_log(data):
+def stateless_compute_analysis_run_log(data, **kwargs):
     def _log_to_html(log):
         return pygments.highlight(
             log,
@@ -41,7 +41,7 @@ def stateless_compute_analysis_run_log(data):
     return r
 
 
-def stateless_compute_begin_replay(data):
+def stateless_compute_begin_replay(data, **kwargs):
     return PKDict(data=_request_scan_monitor(PKDict(method="begin_replay", data=data)))
 
 
@@ -49,19 +49,19 @@ def stateless_compute_catalog_names(_):
     return _request_scan_monitor(PKDict(method="catalog_names"))
 
 
-def stateless_compute_download_analysis_pdfs(data):
+def stateless_compute_download_analysis_pdfs(data, **kwargs):
     return _request_scan_monitor(PKDict(method="download_analysis_pdfs", data=data))
 
 
-def stateless_compute_run_analysis(data):
+def stateless_compute_run_analysis(data, **kwargs):
     return _request_scan_monitor(PKDict(method="run_analysis", data=data))
 
 
-def stateless_compute_scans(data):
+def stateless_compute_scans(data, **kwargs):
     return _request_scan_monitor(PKDict(method="get_scans", data=data))
 
 
-def stateless_compute_scan_fields(data):
+def stateless_compute_scan_fields(data, **kwargs):
     return _request_scan_monitor(PKDict(method="scan_fields", data=data))
 
 

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -49,7 +49,9 @@ def stateless_compute_catalog_names(_):
     return _request_scan_monitor(PKDict(method="catalog_names"))
 
 
-def stateless_compute_download_analysis_pdfs(data, **kwargs):
+def stateless_compute_download_analysis_pdfs(data, data_file_uri=None, **kwargs):
+    assert data_file_uri, f"expected data_file_uri={data_file_uri}"
+    data.dataFileUri = data_file_uri
     return _request_scan_monitor(PKDict(method="download_analysis_pdfs", data=data))
 
 

--- a/sirepo/template/shadow.py
+++ b/sirepo/template/shadow.py
@@ -159,11 +159,11 @@ _LOWERCASE_FIELDS = set(["focal_x", "focal_z"])
 _WIGGLER_TRAJECTORY_FILENAME = "xshwig.sha"
 
 
-def stateless_compute_harmonic_photon_energy(data):
+def stateless_compute_harmonic_photon_energy(data, **kwargs):
     return _compute_harmonic_photon_energy(data.args)
 
 
-def stateful_compute_convert_to_srw(data):
+def stateful_compute_convert_to_srw(data, **kwargs):
     return sirepo.template.srw_shadow.Convert().to_srw(data)
 
 

--- a/sirepo/template/silas.py
+++ b/sirepo/template/silas.py
@@ -117,7 +117,7 @@ def sim_frame_plot2Animation(frame_args):
     return _crystal_plot(frame_args, "zv", "uz", "[m]", 1e-2)
 
 
-def stateful_compute_mesh_dimensions(data):
+def stateful_compute_mesh_dimensions(data, **kwargs):
     f = {
         k: _SIM_DATA.lib_file_abspath(
             _SIM_DATA.lib_file_name_with_model_field("laserPulse", k, data.args[k])

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -787,7 +787,7 @@ def run_epilogue():
     sirepo.mpi.restrict_op_to_first_rank(_op)
 
 
-def stateful_compute_sample_preview(data):
+def stateful_compute_sample_preview(data, **kwargs):
     """Process image and return
 
     Args:
@@ -867,17 +867,17 @@ def stateful_compute_sample_preview(data):
     return template_common.JobCmdFile(path=p)
 
 
-def stateful_compute_undulator_length(data):
+def stateful_compute_undulator_length(data, **kwargs):
     return compute_undulator_length(data.args["tabulated_undulator"])
 
 
-def stateful_compute_create_shadow_simulation(data):
+def stateful_compute_create_shadow_simulation(data, **kwargs):
     from sirepo.template.srw_shadow import Convert
 
     return Convert().to_shadow(data)
 
 
-def stateful_compute_delete_user_models(data):
+def stateful_compute_delete_user_models(data, **kwargs):
     """Remove the beam and undulator user model list files"""
     electron_beam = data.args.electron_beam
     tabulated_undulator = data.args.tabulated_undulator
@@ -894,7 +894,7 @@ def stateful_compute_delete_user_models(data):
     return PKDict()
 
 
-def stateful_compute_model_list(data):
+def stateful_compute_model_list(data, **kwargs):
     res = []
     model_name = data.args["model_name"]
     if model_name == "electronBeam":
@@ -906,11 +906,11 @@ def stateful_compute_model_list(data):
     return PKDict(modelList=res)
 
 
-def stateless_compute_PGM_value(data):
+def stateless_compute_PGM_value(data, **kwargs):
     return _compute_PGM_value(data.optical_element)
 
 
-def stateless_compute_crl_characteristics(data):
+def stateless_compute_crl_characteristics(data, **kwargs):
     return compute_crl_focus(
         _compute_material_characteristics(
             data.optical_element,
@@ -919,22 +919,22 @@ def stateless_compute_crl_characteristics(data):
     )
 
 
-def stateless_compute_crystal_init(data):
+def stateless_compute_crystal_init(data, **kwargs):
     return _compute_crystal_init(data.optical_element)
 
 
-def stateless_compute_crystal_orientation(data):
+def stateless_compute_crystal_orientation(data, **kwargs):
     return _compute_crystal_orientation(data.optical_element)
 
 
-def stateless_compute_delta_atten_characteristics(data):
+def stateless_compute_delta_atten_characteristics(data, **kwargs):
     return _compute_material_characteristics(
         data.optical_element,
         data.photon_energy,
     )
 
 
-def stateless_compute_dual_characteristics(data):
+def stateless_compute_dual_characteristics(data, **kwargs):
     return _compute_material_characteristics(
         _compute_material_characteristics(
             data.optical_element,
@@ -946,11 +946,11 @@ def stateless_compute_dual_characteristics(data):
     )
 
 
-def stateless_compute_compute_grazing_orientation(data):
+def stateless_compute_compute_grazing_orientation(data, **kwargs):
     return _compute_grazing_orientation(data.optical_element)
 
 
-def stateless_compute_process_beam_parameters(data):
+def stateless_compute_process_beam_parameters(data, **kwargs):
     data.ebeam = srw_common.process_beam_parameters(data.ebeam)
     data.ebeam.drift = calculate_beam_drift(
         data.ebeam_position,
@@ -962,7 +962,7 @@ def stateless_compute_process_beam_parameters(data):
     return data.ebeam
 
 
-def stateless_compute_process_undulator_definition(data):
+def stateless_compute_process_undulator_definition(data, **kwargs):
     return process_undulator_definition(data)
 
 

--- a/sirepo/template/synergia.py
+++ b/sirepo/template/synergia.py
@@ -385,7 +385,7 @@ def sim_frame_turnComparisonAnimation(frame_args):
         }
 
 
-def stateless_compute_calculate_bunch_parameters(data):
+def stateless_compute_calculate_bunch_parameters(data, **kwargs):
     return _calc_bunch_parameters(data.args.bunch)
 
 

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -725,7 +725,7 @@ def stateless_compute_dispatch(data, **kwargs):
     return getattr(
         t,
         f"stateless_compute_{_validate_method(t, data)}",
-    )(data)
+    )(data, **kwargs)
 
 
 def subprocess_output(cmd, env=None):

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -269,14 +269,14 @@ class ParticleEnergy:
         cls.__set_from_beta(particle, energy)
 
 
-def analysis_job_dispatch(data):
+def analysis_job_dispatch(data, **kwargs):
     from sirepo import simulation_db
 
     t = sirepo.template.import_module(data.simulationType)
     return getattr(
         t,
         f"analysis_job_{_validate_method(t, data)}",
-    )(data, simulation_db.simulation_run_dir(data))
+    )(data, simulation_db.simulation_run_dir(data), **kwargs)
 
 
 def compute_field_range(args, compute_range, run_dir):
@@ -709,7 +709,7 @@ def sim_frame_dispatch(frame_args):
     return res
 
 
-def stateful_compute_dispatch(data):
+def stateful_compute_dispatch(data, **kwargs):
     t = sirepo.template.import_module(data.simulationType)
     m = _validate_method(t, data)
     k = PKDict(data=data)
@@ -717,10 +717,10 @@ def stateful_compute_dispatch(data):
         k.schema = getattr(t, "SCHEMA")
         t = getattr(t, "code_var")(data.variables)
         k.ignore_array_values = getattr(t, "CODE_VAR_IGNORE_ARRAY_VALUES", True)
-    return getattr(t, f"stateful_compute_{m}")(**k)
+    return getattr(t, f"stateful_compute_{m}")(**k, **kwargs)
 
 
-def stateless_compute_dispatch(data):
+def stateless_compute_dispatch(data, **kwargs):
     t = sirepo.template.import_module(data.simulationType)
     return getattr(
         t,

--- a/sirepo/template/webcon.py
+++ b/sirepo/template/webcon.py
@@ -500,7 +500,7 @@ def run_epics_command(server_address, cmd):
     return template_common.subprocess_output(cmd, epics_env(server_address))
 
 
-def stateful_compute_column_info(data):
+def stateful_compute_column_info(data, **kwargs):
     data = PKDict(
         models=PKDict(
             analysisData=data.args["analysisData"],

--- a/sirepo/template/zgoubi.py
+++ b/sirepo/template/zgoubi.py
@@ -459,7 +459,7 @@ def sim_frame(frame_args):
     return None
 
 
-def stateful_compute_tosca_info(data):
+def stateful_compute_tosca_info(data, **kwargs):
     return zgoubi_importer.tosca_info(data.args.tosca)
 
 


### PR DESCRIPTION
Pass on the dataFileUri all the way to the scan_monitor and have it put the file. This eliminates the need for shared directories or any unnecessary marshalling/unmarshalling of the file on the way back.