### PR TITLE
Fix #5700 - removed last point for each shape type

### DIFF
--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -1012,7 +1012,6 @@ def _get_cee_points(o, stemmed_info):
             [p.ax2, sy2],
             [p.ax2, p.sy1],
             [p.sx1, p.sy1],
-            [p.ax1, p.ay1],
         ],
         stemmed_info.plane_ctr,
     )
@@ -1041,7 +1040,6 @@ def _get_ell_points(o, stemmed_info):
             [p.sx2, p.ay2],
             [p.sx2, p.sy1],
             [p.sx1, p.sy1],
-            [p.ax1, p.ay1],
         ],
         stemmed_info.plane_ctr,
     )
@@ -1098,7 +1096,6 @@ def _get_jay_points(o, stemmed_info):
             [p.sx2, p.ay2],
             [p.sx2, p.sy1],
             [p.sx1, p.sy1],
-            [p.ax1, p.ay1],
         ],
         stemmed_info.plane_ctr,
     )


### PR DESCRIPTION
Offending points have been excised from the `_get_<type>_points()` functions.
