### PR TITLE
fixed a minor bug in ux on forbidden requests to simulation schema

### DIFF
--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -138,7 +138,7 @@ angular.element(document).ready(function() {
         error: function(xhr, status, err) {
             if (! SIREPO.APP_SCHEMA) {
                 srlog("schema load failed: ", err);
-                if (err.match(/forbidden/i)) {
+                if (err.toString().match(/forbidden/i)) {
                     window.location.href = "/forbidden";
                     return;
                 }


### PR DESCRIPTION
Forwarding to /forbidden from loading screen would fail due to a bug in the regex matching of the Error object. I stumbled upon this while trying to host sirepo on a remote node.

Issue: match() is performed on a non-string Error object
Fix: Perform regex matching on a string representation of the Error object