### PR TITLE
Fix #5808 `#!/usr/bin/env python` instead of `/usr/bin/python`

### DIFF
--- a/sirepo/package_data/template/elegant/lib/SCRIPT-commandFile.combine.py
+++ b/sirepo/package_data/template/elegant/lib/SCRIPT-commandFile.combine.py
@@ -1,10 +1,11 @@
-#!/usr/bin/python
-
-import os
+#!/usr/bin/env python
+import subprocess
 import sys
 
-try:
-    (infile1, infile2, outfile) = sys.argv[1:]
-    os.system('sddscombine {} {} -merge {}'.format(infile1, infile2, outfile))
-except:
-    raise RuntimeError('usage: {} <infile> <infile> <outfile>'.format(sys.argv[0]))
+if len(sys.argv) != 4:
+    raise RuntimeError(
+        f"Expected 3 args, got {len(sys.argv) - 1}\nusage: {sys.argv[0]} <infile> <infile> <outfile>",
+    )
+subprocess.check_call(
+    ("sddscombine", sys.argv[1], sys.argv[2], "-merge", sys.argv[3]),
+)

--- a/sirepo/template/elegant.py
+++ b/sirepo/template/elegant.py
@@ -943,8 +943,14 @@ def write_parameters(data, run_dir, is_parallel):
         ),
     )
     for b in _SIM_DATA.lib_file_basenames(data):
-        if re.search(r"SCRIPT-commandFile", b):
-            os.chmod(str(run_dir.join(b)), stat.S_IRUSR | stat.S_IXUSR)
+        if not b.startswith("SCRIPT-commandFile"):
+            continue
+        f = run_dir.join(b)
+        if f.check(link=True):
+            x = f.read_binary()
+            f.remove()
+            f.write_binary(x)
+        f.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
 
 class _Generate(sirepo.lib.GenerateBase):


### PR DESCRIPTION
- Use subprocess.check_call so can pass tuple and not string for cmd
- Don't catch all errors (suppresses errors in sddscombine)
- Fix #5814 make a local copy if link and chmod u=rwx
