### PR TITLE
Fix #5854 - update path on save, not change

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -1521,7 +1521,7 @@ SIREPO.app.directive('fieldLineoutAnimation', function(appState, persistentSimul
             $scope.showFieldLineoutPanel = () => $scope.hasPaths();
 
             $scope.$on('fieldLineoutAnimation.saved', runSimulation);
-            $scope.$on('fieldPaths.changed', updatePath);
+            $scope.$on('fieldPaths.saved', updatePath);
             $scope.$on('solve.complete', runSimulation);
 
             appState.watchModelFields($scope, [`${modelName}.fieldPath`],  () => {


### PR DESCRIPTION
The new path was being copied to the fieldLineoutAnimation model before all the parameters were set. Waiting for the save to complete ensures that they are.