### PR TITLE
5914 shadow conversion

### DIFF
--- a/react/src/utility/compute.ts
+++ b/react/src/utility/compute.ts
@@ -85,14 +85,12 @@ export function pollRunReport(routeHelper: RouteHelper, { appName, models, simul
 
     doFetch().then(resp => {
         callback(resp);
-        pollRunStatus(routeHelper, {
-            callback,
-            simulationId,
-            models,
-            appName,
-            report,
-            forceRun
-        });
+        if (resp.nextRequest) {
+            pollRunStatus(routeHelper, {
+                callback: callback,
+                ...resp.nextRequest,
+            });
+        }
     });
 }
 
@@ -121,7 +119,7 @@ export function cancelReport(routeHelper: RouteHelper, { appName, models, simula
 
 export type RunStatusParams = {
     appName: string,
-    models: StoreState<ModelState>,
+    models?: StoreState<ModelState>,
     simulationId: string,
     report: string,
     forceRun: boolean
@@ -142,7 +140,7 @@ export function getRunStatusOnce(routeHelper: RouteHelper, { appName, ...otherPa
     return new Promise<ResponseHasState>((resolve, reject) => {
         doStatus().then(async lastResp => resolve(await lastResp.json()));
     })
-    
+
 }
 
 export type RunStatusPollParams = {

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -96,6 +96,10 @@ def for_sim_type(sim_type):
     )
 
 
+def is_react_sim_type(sim_type):
+    return sim_type in cfg().react_sim_types
+
+
 def proprietary_sim_types():
     """All sim types that have proprietary information and require granted access to use
 

--- a/sirepo/http_request.py
+++ b/sirepo/http_request.py
@@ -62,8 +62,11 @@ def parse_post(qcall, kwargs):
     r = kwargs.pkdel("req_data")
     if r is None:
         r = parse_json(qcall)
-    if kwargs.pkdel("fixup_old_data"):
-        r = simulation_db.fixup_old_data(r, qcall=qcall)[0]
+    assert not kwargs.get("fixup_old_data")
+    if kwargs.pkdel("is_sim_data"):
+        s = sirepo.sim_data.get_class(r)
+        if sirepo.feature_config.is_react_sim_type(s.sim_type()) and r.get("models"):
+            s.react_unformat_data(r)
     res.pkupdate(req_data=r)
     kwargs.pksetdefault(type=True)
 

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -15,6 +15,7 @@ import pykern.pkconfig
 import pykern.pkio
 import re
 import sirepo.auth
+import sirepo.feature_config
 import sirepo.flask
 import sirepo.job
 import sirepo.quest
@@ -324,6 +325,10 @@ class API(sirepo.quest.API):
                 check_sim_exists=True,
             ).req_data
         s = sirepo.sim_data.get_class(d)
+        if sirepo.feature_config.is_react_sim_type(s.sim_type()):
+            # TODO(pjm): need to know if this is the full sirepo data
+            if d.get("models"):
+                s.react_unformat_data(d)
         ##TODO(robnagler) this should be req_data
         b = PKDict(data=d, **kwargs)
         # TODO(e-carlin): some of these fields are only used for some type of reqs

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -183,14 +183,16 @@ class API(sirepo.quest.API):
 
     @sirepo.quest.Spec("require_user")
     async def api_runSimulation(self):
-        r = self._request_content(PKDict(fixup_old_data=True))
+        r = self._request_content(PKDict(is_sim_data=True))
         if r.isParallel:
             r.isPremiumUser = self.auth.is_premium_user()
         return await self._request_api(_request_content=r)
 
     @sirepo.quest.Spec("require_user")
     async def api_runStatus(self):
-        return await self._request_api()
+        # runStatus receives models when an animation status if first queried
+        r = self._request_content(PKDict(is_sim_data=True))
+        return await self._request_api(_request_content=r)
 
     @sirepo.quest.Spec("require_user")
     async def api_sbatchLogin(self):
@@ -319,16 +321,12 @@ class API(sirepo.quest.API):
             # of the used values are modified by parse_post. If we have files (e.g. file_type, filename),
             # we need to use those values from parse_post
             d = self.parse_post(
-                fixup_old_data=kwargs.pkdel("fixup_old_data", False),
+                is_sim_data=kwargs.pkdel("is_sim_data", False),
                 id=True,
                 model=True,
                 check_sim_exists=True,
             ).req_data
         s = sirepo.sim_data.get_class(d)
-        if sirepo.feature_config.is_react_sim_type(s.sim_type()):
-            # TODO(pjm): need to know if this is the full sirepo data
-            if d.get("models"):
-                s.react_unformat_data(d)
         ##TODO(robnagler) this should be req_data
         b = PKDict(data=d, **kwargs)
         # TODO(e-carlin): some of these fields are only used for some type of reqs

--- a/sirepo/package_data/static/react-json/shadow-schema.json
+++ b/sirepo/package_data/static/react-json/shadow-schema.json
@@ -4108,7 +4108,9 @@
                                                                 "electronBeam.*",
                                                                 "geometricSource.*",
                                                                 "rayFilter.*",
-                                                                "simulation.*",
+                                                                "simulation.sourceType",
+                                                                "simulation.npoint",
+                                                                "simulation.istar1",
                                                                 "sourceDivergence.*",
                                                                 "undulator.*",
                                                                 "undulatorBeam.*",
@@ -4153,7 +4155,9 @@
                                                                 "electronBeam.*",
                                                                 "geometricSource.*",
                                                                 "rayFilter.*",
-                                                                "simulation.*",
+                                                                "simulation.sourceType",
+                                                                "simulation.npoint",
+                                                                "simulation.istar1",
                                                                 "sourceDivergence.*",
                                                                 "undulator.*",
                                                                 "undulatorBeam.*",
@@ -5073,7 +5077,9 @@
                                                                             "electronBeam.*",
                                                                             "geometricSource.*",
                                                                             "rayFilter.*",
-                                                                            "simulation.*",
+                                                                            "simulation.sourceType",
+                                                                            "simulation.npoint",
+                                                                            "simulation.istar1",
                                                                             "sourceDivergence.*",
                                                                             "undulator.*",
                                                                             "undulatorBeam.*",
@@ -5177,7 +5183,9 @@
                                                                             "electronBeam.*",
                                                                             "geometricSource.*",
                                                                             "rayFilter.*",
-                                                                            "simulation.*",
+                                                                            "simulation.sourceType",
+                                                                            "simulation.npoint",
+                                                                            "simulation.istar1",
                                                                             "sourceDivergence.*",
                                                                             "undulator.*",
                                                                             "undulatorBeam.*",
@@ -5221,7 +5229,7 @@
                     }
                 ]
             }
-            
+
         }
     ]
 }

--- a/sirepo/pkcli/shadow.py
+++ b/sirepo/pkcli/shadow.py
@@ -10,13 +10,10 @@ from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp, pkdlog, pkdexc
 from sirepo import simulation_db
 from sirepo.template import template_common
-import sirepo.sim_data
 import numpy
 import py.path
 import re
 import sirepo.template.shadow as template
-
-_SIM_DATA, _, _ = sirepo.sim_data.template_globals()
 
 _MM_TO_CM = 0.1
 _CM_TO_M = 0.01
@@ -122,13 +119,7 @@ def _run_beam_statistics(cfg_dir, data):
 
 def _run_shadow(cfg_dir, data):
     beam = template_common.exec_parameters().beam
-    r = data["report"]
-    model = None
-    if _SIM_DATA.is_watchpoint(r):
-        i = _SIM_DATA.watchpoint_id(r)
-        model = data["models"]["watchpointReports"]["reports"][i].item
-    else:
-        model = data["models"][data["report"]]
+    model = data["models"][data["report"]]
     column_values = _SCHEMA["enum"]["ColumnValue"]
 
     if "y" in model:

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -524,6 +524,9 @@ class API(sirepo.quest.API):
         req = self.parse_post(id=True, template=True)
         d = req.req_data
         simulation_db.validate_serial(d, qcall=self)
+        # TODO(pjm): this should happen with the fixup below, but is not
+        if sirepo.feature_config.is_react_sim_type(req.type):
+            req.sim_data.react_unformat_data(d)
         return self._simulation_data_reply(
             req,
             simulation_db.save_simulation_json(

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -521,12 +521,9 @@ class API(sirepo.quest.API):
     @sirepo.quest.Spec("require_user", sid="SimId", data="SimData all_input")
     async def api_saveSimulationData(self):
         # do not fixup_old_data yet
-        req = self.parse_post(id=True, template=True)
+        req = self.parse_post(id=True, template=True, is_sim_data=True)
         d = req.req_data
         simulation_db.validate_serial(d, qcall=self)
-        # TODO(pjm): this should happen with the fixup below, but is not
-        if sirepo.feature_config.is_react_sim_type(req.type):
-            req.sim_data.react_unformat_data(d)
         return self._simulation_data_reply(
             req,
             simulation_db.save_simulation_json(
@@ -781,10 +778,6 @@ class API(sirepo.quest.API):
 
     def _simulation_data_reply(self, req, data):
         if hasattr(req.template, "prepare_for_client"):
-            # TODO(pjm): for some reason _simulation_data_reply() can be called twice in one request
-            # see madx FODO PTC example
-            if sirepo.feature_config.is_react_sim_type(req.type):
-                req.sim_data.react_unformat_data(data)
             d = req.template.prepare_for_client(data, qcall=self)
         if sirepo.feature_config.is_react_sim_type(req.type):
             req.sim_data.react_format_data(data)

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -779,6 +779,8 @@ class API(sirepo.quest.API):
     def _simulation_data_reply(self, req, data):
         if hasattr(req.template, "prepare_for_client"):
             d = req.template.prepare_for_client(data, qcall=self)
+        if sirepo.feature_config.is_react_sim_type(req.type):
+            req.sim_data.react_format_data(data)
         return self.headers_for_no_cache(self.reply_json(data))
 
 

--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -778,6 +778,10 @@ class API(sirepo.quest.API):
 
     def _simulation_data_reply(self, req, data):
         if hasattr(req.template, "prepare_for_client"):
+            # TODO(pjm): for some reason _simulation_data_reply() can be called twice in one request
+            # see madx FODO PTC example
+            if sirepo.feature_config.is_react_sim_type(req.type):
+                req.sim_data.react_unformat_data(data)
             d = req.template.prepare_for_client(data, qcall=self)
         if sirepo.feature_config.is_react_sim_type(req.type):
             req.sim_data.react_format_data(data)

--- a/sirepo/sim_data/__init__.py
+++ b/sirepo/sim_data/__init__.py
@@ -274,6 +274,14 @@ class SimDataBase(object):
         raise NotImplementedError()
 
     @classmethod
+    def react_format_data(cls, data):
+        pass
+
+    @classmethod
+    def react_unformat_data(cls, data):
+        pass
+
+    @classmethod
     def frame_id(cls, data, response, model, index):
         """Generate a frame_id from values (unit testing)
 

--- a/sirepo/sim_data/madx.py
+++ b/sirepo/sim_data/madx.py
@@ -25,18 +25,35 @@ class SimData(sirepo.sim_data.SimDataBase):
         )
         for container in ("commands", "elements"):
             for m in dm[container]:
-                if not isinstance(m, list):
-                    continue
                 cls.update_model_defaults(m, LatticeUtil.model_name_for_data(m))
-        if "beamlines" in dm and isinstance(dm.beamlines, list):
+
+    @classmethod
+    def react_format_data(cls, data):
+        pkdp("madx format data")
+        dm = data.models
+        if "beamlines" in dm:
+            assert isinstance(dm.beamlines, list)
             dm.lattice = PKDict(
-                beamlines=list(map(lambda i: PKDict(model="Beamline", item=i), dm.beamlines))
+                beamlines=list(
+                    map(lambda i: PKDict(model="Beamline", item=i), dm.beamlines)
+                )
             )
             del dm["beamlines"]
+        assert isinstance(dm.elements, list)
+        dm.elements = PKDict(
+            elements=list(map(lambda i: PKDict(model=i.type, item=i), dm.elements))
+        )
+
+    @classmethod
+    def react_unformat_data(cls, data):
+        pkdp("madx unformat data")
+        dm = data.models
         if isinstance(dm.elements, list):
-            dm.elements = PKDict(
-                elements=list(map(lambda i: PKDict(model=i.type, item=i), dm.elements))
-            )
+            return
+        if "lattice" in dm:
+            dm.beamlines = [i.item for i in dm.lattice.beamlines]
+            del dm["lattice"]
+        dm.elements = [i.item for i in dm.elements.elements]
 
     @classmethod
     def _compute_job_fields(cls, data, r, compute_model):
@@ -50,7 +67,7 @@ class SimData(sirepo.sim_data.SimDataBase):
             ]
         if r == "twissReport":
             res += [
-                "lattice",
+                "beamlines",
                 "elements",
                 "simulation.activeBeamlineId",
                 "rpnVariables",

--- a/sirepo/sim_data/madx.py
+++ b/sirepo/sim_data/madx.py
@@ -29,7 +29,6 @@ class SimData(sirepo.sim_data.SimDataBase):
 
     @classmethod
     def react_format_data(cls, data):
-        pkdp("madx format data")
         dm = data.models
         if "beamlines" in dm:
             assert isinstance(dm.beamlines, list)
@@ -46,7 +45,6 @@ class SimData(sirepo.sim_data.SimDataBase):
 
     @classmethod
     def react_unformat_data(cls, data):
-        pkdp("madx unformat data")
         dm = data.models
         if isinstance(dm.elements, list):
             return

--- a/sirepo/sim_data/shadow.py
+++ b/sirepo/sim_data/shadow.py
@@ -7,74 +7,18 @@
 from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdc, pkdlog, pkdp
-from pykern import pkconfig
-from pykern import pkjson
 import sirepo.sim_data
 import scipy.constants
-import hashlib
 
 
 class SimData(sirepo.sim_data.SimDataBase):
     ANALYSIS_ONLY_FIELDS = frozenset(("colorMap", "notes", "aspectRatio"))
 
     @classmethod
-    def compute_job_hash(cls, data, qcall):
-        """Hash fields related to data and set computeJobHash
-
-        Only needs to be unique relative to the report, not globally unique
-        so MD5 is adequate. Long and cryptographic hashes make the
-        cache checks slower.
-
-        Args:
-            data (dict): simulation data
-            changed (callable): called when value changed
-        Returns:
-            bytes: hash value
-        """
-        cls._assert_server_side()
-        c = cls.compute_model(data)
-        if data.get("forceRun") or cls.is_parallel(c):
-            return "HashIsUnused"
-        m = data["models"]
-        res = hashlib.md5()
-        fields = sirepo.sim_data.get_class(data.simulationType)._compute_job_fields(
-            data, data.report, c
-        )
-        # values may be string or PKDict
-        fields.sort(key=lambda x: str(x))
-        for f in fields:
-            # assert isinstance(f, pkconfig.STRING_TYPES), \
-            #     'value={} not a string_type'.format(f)
-            # TODO(pjm): work-around for now
-            if isinstance(f, pkconfig.STRING_TYPES):
-                x = f.split(".")
-                if cls.is_watchpoint(f) and f != "watchpointReports":
-                    i = cls.watchpoint_id(f)
-                    value = m.watchpointReports.reports[i].item
-                else:
-                    value = m[x[0]][x[1]] if len(x) > 1 else m[x[0]]
-            else:
-                value = f
-            res.update(
-                pkjson.dump_bytes(
-                    value,
-                    sort_keys=True,
-                    allow_nan=False,
-                )
-            )
-        res.update(
-            "".join(
-                (
-                    str(cls.lib_file_abspath(b, data=data, qcall=qcall).mtime())
-                    for b in sorted(cls.lib_file_basenames(data))
-                ),
-            ).encode()
-        )
-        return res.hexdigest()
-
-    @classmethod
     def fixup_old_data(cls, data, qcall, **kwargs):
         dm = data.models
+        if not isinstance(dm.beamline, list):
+            raise AssertionError("models.beamline is in the incorrect format")
         cls._init_models(
             dm,
             (
@@ -94,12 +38,22 @@ class SimData(sirepo.sim_data.SimDataBase):
                 * float(dm.electronBeam.bener)
                 / float(dm.bendingMagnet.r_magnet)
             )
-        if isinstance(dm.beamline, list):
-            dm.beamline = PKDict(
-                elements=list(map(lambda i: PKDict(model=i.type, item=i), dm.beamline))
-            )
-        if not "watchpointReports" in dm:
-            dm.watchpointReports = PKDict(reports=[])
+        for m in dm:
+            if cls.is_watchpoint(m):
+                cls.update_model_defaults(dm[m], "watchpointReport")
+        for m in dm.beamline:
+            cls.update_model_defaults(m, m.type)
+        cls._organize_example(data)
+
+    @classmethod
+    def react_format_data(cls, data):
+        dm = data.models
+        assert isinstance(dm.beamline, list)
+        dm.beamline = PKDict(
+            elements=list(map(lambda i: PKDict(model=i.type, item=i), dm.beamline))
+        )
+        assert not dm.get("watchpointReports")
+        dm.watchpointReports = PKDict(reports=[])
         n = []
         for m in dm:
             if cls.is_watchpoint(m) and m != "watchpointReports":
@@ -112,9 +66,24 @@ class SimData(sirepo.sim_data.SimDataBase):
                 n.append(m)
         for i in n:
             del dm[i]
-        for m in map(lambda i: i.item, dm.beamline.elements):
-            cls.update_model_defaults(m, m.type)
-        cls._organize_example(data)
+
+    @classmethod
+    def react_unformat_data(cls, data):
+        dm = data.models
+        # assert not isinstance(dm.beamline, list)
+        if isinstance(dm.beamline, list):
+            return
+        dm.beamline = [e.item for e in dm.beamline.elements]
+        assert "watchpointReports" in dm
+        names = []
+        for r in dm.watchpointReports.reports:
+            n = f"watchpointReport{r.item.id}"
+            assert not dm.get(n)
+            dm[n] = r.item
+            names.append(n)
+        del dm["watchpointReports"]
+        if data.get("report") and cls.is_watchpoint(data.report):
+            data.report = names[cls.watchpoint_id(data.report)]
 
     @classmethod
     def shadow_simulation_files(cls, data):
@@ -129,6 +98,7 @@ class SimData(sirepo.sim_data.SimDataBase):
 
     @classmethod
     def _compute_job_fields(cls, data, r, compute_model):
+        assert r in data.models
         res = cls._non_analysis_fields(data, r) + [
             "bendingMagnet",
             "electronBeam",
@@ -142,13 +112,8 @@ class SimData(sirepo.sim_data.SimDataBase):
             "undulatorBeam",
             "wiggler",
         ]
-        if (
-            r == "initialIntensityReport"
-            and data["models"]["beamline"]
-            and data["models"]["beamline"]["elements"]
-            and len(data["models"]["beamline"]["elements"]) > 0
-        ):
-            res.append([data["models"]["beamline"]["elements"][0]["item"]["position"]])
+        if r == "initialIntensityReport" and data["models"]["beamline"]:
+            res.append([data["models"]["beamline"][0]["position"]])
         # TODO(pjm): only include items up to the current watchpoint
         if cls.is_watchpoint(r) or r == "beamStatisticsReport":
             res.append("beamline")

--- a/sirepo/sim_data/shadow.py
+++ b/sirepo/sim_data/shadow.py
@@ -98,7 +98,7 @@ class SimData(sirepo.sim_data.SimDataBase):
 
     @classmethod
     def _compute_job_fields(cls, data, r, compute_model):
-        assert r in data.models
+        assert r in data.models, f"unknown report: {r}"
         res = cls._non_analysis_fields(data, r) + [
             "bendingMagnet",
             "electronBeam",

--- a/sirepo/simulation_db.py
+++ b/sirepo/simulation_db.py
@@ -249,7 +249,10 @@ def fixup_old_data(data, force=False, path=None, qcall=None):
             data.models.simulation.lastModified = _last_modified(data, path)
         from sirepo import sim_data
 
-        sim_data.get_class(data.simulationType).fixup_old_data(data, qcall=qcall)
+        s = sim_data.get_class(data.simulationType)
+        if sirepo.feature_config.is_react_sim_type(s.sim_type()):
+            s.react_unformat_data(data)
+        s.fixup_old_data(data, qcall=qcall)
         data.pkdel("fixup_old_version")
         return data, True
     except Exception as e:

--- a/sirepo/simulation_db.py
+++ b/sirepo/simulation_db.py
@@ -249,10 +249,7 @@ def fixup_old_data(data, force=False, path=None, qcall=None):
             data.models.simulation.lastModified = _last_modified(data, path)
         from sirepo import sim_data
 
-        s = sim_data.get_class(data.simulationType)
-        if sirepo.feature_config.is_react_sim_type(s.sim_type()):
-            s.react_unformat_data(data)
-        s.fixup_old_data(data, qcall=qcall)
+        sim_data.get_class(data.simulationType).fixup_old_data(data, qcall=qcall)
         data.pkdel("fixup_old_version")
         return data, True
     except Exception as e:

--- a/sirepo/template/code_variable.py
+++ b/sirepo/template/code_variable.py
@@ -281,7 +281,7 @@ class CodeVarIterator(lattice.ModelIterator):
         if not schema.get("model") or not schema.model.get("beamline"):
             return
         bs = schema.model.beamline
-        for bl in map(lambda i: i.item, data.models.lattice.beamlines):
+        for bl in data.models.beamlines:
             if "positions" not in bl:
                 continue
             for f in bs:

--- a/sirepo/template/madx_converter.py
+++ b/sirepo/template/madx_converter.py
@@ -108,15 +108,12 @@ class MadxConverter:
         return self.result
 
     def _copy_beamlines(self, data):
-        for bl in map(lambda i: i.item, data.models.lattice.beamlines):
+        for bl in data.models.beamlines:
             self.result.models.beamlines.append(
                 PKDict(
-                    item=PKDict(
-                        name=bl.name,
-                        items=bl["items"],
-                        id=bl.id,
-                    ),
-                    model="Beamline"
+                    name=bl.name,
+                    items=bl["items"],
+                    id=bl.id,
                 )
             )
         for f in ("name", "visualizationBeamlineId", "activeBeamlineId"):
@@ -140,7 +137,7 @@ class MadxConverter:
         self.result.models.rpnVariables = res
 
     def _copy_elements(self, data):
-        for el in map(lambda i: i.item, data.models.elements.elements):
+        for el in data.models.elements:
             if el.type not in self.field_map:
                 pkdlog("Unhandled element type: {}", el.type)
                 el.type = self.drift_type
@@ -161,10 +158,7 @@ class MadxConverter:
                 values[f1] = el[f2]
             self._fixup_element(el, values)
             self.to_class.update_model_defaults(values, values.type)
-            self.result.models.elements.elements.append(PKDict(
-                item=values,
-                model=values.type
-            ))
+            self.result.models.elements.append(values)
 
     def _find_var(self, data, name):
         name = self._var_name(name)

--- a/sirepo/template/madx_parser.py
+++ b/sirepo/template/madx_parser.py
@@ -91,8 +91,7 @@ class MadXParser(lattice.LatticeParser):
             # assert name not in name_to_id, 'duplicate name: {}'.format(name)
             name_to_id[name] = id
         for container in ("elements", "commands"):
-            dm = map(lambda i: i.item, self.data.models[container].elements) if container == "elements" else self.data.models[container]
-            for el in dm:
+            for el in self.data.models[container]:
                 model_schema = self.schema.model[
                     lattice.LatticeUtil.model_name_for_data(el)
                 ]
@@ -155,10 +154,7 @@ class MadXParser(lattice.LatticeParser):
                     if d:
                         beamline["items"].append(d)
                 beamline.id = self.parser.next_id()
-                data.models.lattice.beamlines.append(PKDict(
-                    item=beamline,
-                    model="Beamline"
-                ))
+                data.models.beamlines.append(beamline)
         del data.models["sequences"]
         util.sort_elements_and_beamlines()
 

--- a/sirepo/template/shadow.py
+++ b/sirepo/template/shadow.py
@@ -182,20 +182,14 @@ def post_execution_processing(success_exit, is_parallel, run_dir, **kwargs):
 def python_source_for_model(data, model, qcall, **kwargs):
     data.report = model
     if not model:
-        beamline = list(map(lambda i: i.item, data.models.beamline.elements))
+        beamline = data.models.beamline
         watch_id = None
         watch_index = None
         for b in beamline:
             if b.type == "watch":
                 watch_id = b.id
         if watch_id:
-            for i, w in enumerate(data.models.watchpointReports.reports):
-                if w.item.id == watch_id:
-                    watch_index = i
-            if watch_index:
-                data.report = "{}{}".format(_SIM_DATA.WATCHPOINT_REPORT, watch_index)
-            else:
-                data.report = "plotXYReport"
+            data.report = "{}{}".format(_SIM_DATA.WATCHPOINT_REPORT, watch_id)
         else:
             data.report = "plotXYReport"
     return """
@@ -295,7 +289,7 @@ def _generate_autotune_element(item):
 
 
 def _generate_beamline_optics(models, last_id=None, calc_beam_stats=False):
-    beamline = list(map(lambda i: i.item, models.beamline.elements))
+    beamline = models.beamline
     res = ""
     prev_position = source_position = 0
     last_element = False
@@ -730,9 +724,8 @@ def _generate_parameters_file(data, run_dir=None, is_parallel=False):
     _scale_units(data)
     v = template_common.flatten_data(data.models, PKDict())
     r = data.report
-
-    # report_model = data.models[r]
-    beamline = list(map(lambda i: i.item, data.models.beamline.elements))
+    report_model = data.models[r]
+    beamline = data.models.beamline
     v.shadowOutputFile = _SHADOW_OUTPUT_FILE
     if _has_zone_plate(beamline):
         v.zonePlateMethods = template_common.render_jinja(SIM_TYPE, v, "zone_plate.py")
@@ -781,11 +774,11 @@ def _generate_parameters_file(data, run_dir=None, is_parallel=False):
             v.photonEnergy = v.bendingMagnet_ph1
         return template_common.render_jinja(SIM_TYPE, v, "beam_statistics.py")
     elif _SIM_DATA.is_watchpoint(r):
-        di = _SIM_DATA.watchpoint_id(r)
-        rd = data.models.watchpointReports.reports[di]
-        v.beamlineOptics = _generate_beamline_optics(data.models, last_id=rd.item.id)
+        v.beamlineOptics = _generate_beamline_optics(
+            data.models, last_id=_SIM_DATA.watchpoint_id(r)
+        )
     else:
-        v.distanceFromSource = data.models[r].distanceFromSource
+        v.distanceFromSource = report_model.distanceFromSource
     return template_common.render_jinja(SIM_TYPE, v)
 
 
@@ -952,7 +945,6 @@ def _item_field(item, fields):
 def _parse_shadow_log(run_dir):
     if run_dir.join(template_common.RUN_LOG).exists():
         text = pkio.read_text(run_dir.join(template_common.RUN_LOG))
-        pkdp(text)
         for line in text.split("\n"):
             if re.search(r"invalid chemical formula", line):
                 return "A mirror contains an invalid reflectivity material"
@@ -978,7 +970,7 @@ def _scale_units(data):
     for name in _MODEL_UNITS.unit_def:
         if name in data.models:
             _MODEL_UNITS.scale_to_native(name, data.models[name])
-    for item in list(map(lambda i: i.item, data.models.beamline.elements)):
+    for item in data.models.beamline:
         if item.type in _MODEL_UNITS.unit_def:
             _MODEL_UNITS.scale_to_native(item.type, item)
 

--- a/sirepo/template/shadow.py
+++ b/sirepo/template/shadow.py
@@ -184,7 +184,6 @@ def python_source_for_model(data, model, qcall, **kwargs):
     if not model:
         beamline = data.models.beamline
         watch_id = None
-        watch_index = None
         for b in beamline:
             if b.type == "watch":
                 watch_id = b.id

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -825,9 +825,7 @@ def validate_models(model_data, model_schema):
                 enum_info,
             )
     if "beamline" in model_data["models"]:
-        for m in model_data["models"]["beamline"]["elements"]:
-            if isinstance(m, PKDict):
-                m = m.item
+        for m in model_data["models"]["beamline"]:
             validate_model(m, model_schema["model"][m["type"]], enum_info)
     return enum_info
 

--- a/tests/template/srw_shadow_data/to_shadow_crl.out/shadow.json
+++ b/tests/template/srw_shadow_data/to_shadow_crl.out/shadow.json
@@ -260,6 +260,7 @@
         "column": "6",
         "distanceFromSource": 0,
         "histogramBins": 100,
+        "notes": "",
         "weight": "22"
     },
     "initialIntensityReport": {

--- a/tests/template/srw_shadow_data/to_shadow_gauss.out/shadow.json
+++ b/tests/template/srw_shadow_data/to_shadow_gauss.out/shadow.json
@@ -109,6 +109,7 @@
         "column": "6",
         "distanceFromSource": 0,
         "histogramBins": 100,
+        "notes": "",
         "weight": "22"
     },
     "initialIntensityReport": {

--- a/tests/template/srw_shadow_data/to_shadow_grating.out/shadow.json
+++ b/tests/template/srw_shadow_data/to_shadow_grating.out/shadow.json
@@ -271,6 +271,7 @@
         "column": "6",
         "distanceFromSource": 0,
         "histogramBins": 100,
+        "notes": "",
         "weight": "22"
     },
     "initialIntensityReport": {


### PR DESCRIPTION
Revert shadow server side to old data format. Un/format react data as needed.

unformat react data hooks

- simulation_db.fixup_old_data()
- job_api._request_content()

format react data hook
 
- server.API._simulation_data_reply()

React data un/format code takes place in sim_data subclasses using the methods 
```python
def react_format_data(cls, data)
def react_unformat_data(cls, data)
```
