### PR TITLE
Fix #6083: auth.login creates the uid

### DIFF
--- a/sirepo/auth/email.py
+++ b/sirepo/auth/email.py
@@ -86,7 +86,7 @@ class API(sirepo.quest.API):
             self.auth.login(
                 this_module,
                 sim_type=req.type,
-                model=m.unchecked_search_by(uid=i),
+                model=u,
                 display_name=n,
             )
             raise AssertionError("auth.login returned unexpectedly")

--- a/tests/auth/email1_test.py
+++ b/tests/auth/email1_test.py
@@ -201,6 +201,18 @@ def test_happy_path(auth_fc):
     )
 
 
+def test_multiple_unverified_users(auth_fc):
+    fc = auth_fc
+
+    for e in ("1@x.x", "2@x.x"):
+        r = fc.sr_post(
+            "authEmailLogin",
+            {"email": e, "simulationType": fc.sr_sim_type},
+        )
+    fc.sr_email_confirm(r)
+    fc.sr_auth_state(isLoggedIn=True)
+
+
 def test_token_expired(auth_fc):
     fc = auth_fc
 


### PR DESCRIPTION
In 791364f18d02e28307ffb0101e4ebab488a13e02 the api_authEmailAuthorized code was changed from passing the user model we acquired based on searching by the email token to one acquired by searching for the uid into auth.login.

Previous behavior: https://github.com/radiasoft/sirepo/commit/791364f18d02e28307ffb0101e4ebab488a13e02#diff-109de77eab3047455095be7e4c1f5f1d918083adaa02b87d5c862a8e513e8436L61
Behavior introduced in 791364f18d02e28307ffb0101e4ebab488a13e02: https://github.com/radiasoft/sirepo/commit/791364f18d02e28307ffb0101e4ebab488a13e02#diff-109de77eab3047455095be7e4c1f5f1d918083adaa02b87d5c862a8e513e8436R89

But, the uid isn't present on the model. auth.login creates the user and populates the uid. In the case where we have multiple records in auth_email_user_t without a uid the query would return all of the records even though we are looking for just one.

This reverts the behavior to what it was previously.