### PR TITLE
Fix #6121 - use lower() on file types to validate

### DIFF
--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -357,14 +357,15 @@ def save_field_srw(gap, vectors, beam_axis, filename):
 
 
 def validate_file(file_type, path):
-    if path.ext not in (".csv", ".dat", ".stl", ".txt"):
+    p = path.ext.lower()
+    if p not in (".csv", ".dat", ".stl", ".txt"):
         return f"invalid file type: {path.ext}"
     if file_type == "extrudedPoints-pointsFile":
         try:
             _ = sirepo.csv.read_as_number_list(path)
         except RuntimeError as e:
             return e
-    if path.ext == ".stl":
+    if p == ".stl":
         mesh = _create_stl_trimesh(path)
         if trimesh.convex.is_convex(mesh) == False:
             return f"not convex model: {path.basename}"


### PR DESCRIPTION
We now accept file types regardless of case
