### PR TITLE
Fix #6184 radia stl position

### DIFF
--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -1721,7 +1721,9 @@ def _update_geom_obj(o, qcall=None, **kwargs):
             d.stlFaces.append(list(f))
         o.stlVertices = d.stlVertices
         o.stlFaces = d.stlFaces
-        o.stlBoundsCenter = list(mesh.bounding_box.bounds[0] + 0.5 * mesh.bounding_box.extents)
+        o.stlBoundsCenter = list(
+            mesh.bounding_box.bounds[0] + 0.5 * mesh.bounding_box.extents
+        )
         o.size = list(mesh.bounding_box.primitive.extents)
         o.stlCentroid = mesh.centroid.tolist()
 

--- a/sirepo/template/radia.py
+++ b/sirepo/template/radia.py
@@ -1721,6 +1721,7 @@ def _update_geom_obj(o, qcall=None, **kwargs):
             d.stlFaces.append(list(f))
         o.stlVertices = d.stlVertices
         o.stlFaces = d.stlFaces
+        o.stlBoundsCenter = list(mesh.bounding_box.bounds[0] + 0.5 * mesh.bounding_box.extents)
         o.size = list(mesh.bounding_box.primitive.extents)
         o.stlCentroid = mesh.centroid.tolist()
 

--- a/sirepo/template/radia_util.py
+++ b/sirepo/template/radia_util.py
@@ -271,7 +271,7 @@ def _build_stl(**kwargs):
     g_id = radia.ObjPolyhdr(
         d.stlVertices, (numpy.array(d.stlFaces) + 1).tolist(), d.magnetization
     )
-    center = [x - d.stlCentroid[i] for i, x in enumerate(d.center)]
+    center = [x - d.stlBoundsCenter[i] for i, x in enumerate(d.center)]
     radia.TrfOrnt(g_id, radia.TrfTrsl([center[0], center[1], center[2]]))
     return g_id
 


### PR DESCRIPTION
We now shift the stl vertices such that the bounding box center, and not the stl's centroid, is at the user-specified center. Note `stlCentroid` is still provided for possible future use.
