### PR TITLE
Fix #6304 radia xform subgroup shapes

### DIFF
--- a/sirepo/package_data/static/js/radia.js
+++ b/sirepo/package_data/static/js/radia.js
@@ -732,17 +732,17 @@ SIREPO.app.controller('RadiaSourceController', function (appState, geometry, pan
 
     function addViewsForObject(o) {
 
-        function addSymmetryToGroup(g, r) {
+        function applyMatrixToGroup(g, m) {
             for (const m_id of g.members) {
-                let mv = self.getObjectView(m_id);
-                const m = self.getObject(m_id);
-                if (! mv) {
-                    mv = self.viewsForObject(m);
-                    self.views.push(mv);
+                let v = self.getObjectView(m_id);
+                const member = self.getObject(m_id);
+                if (! v) {
+                    v = self.viewsForObject(member);
+                    self.views.push(v);
                 }
-                mv.addCopyingTransform(r);
-                if (self.isGroup(m)) {
-                    addSymmetryToGroup(m, r);
+                v.addCopyingTransform(m);
+                if (self.isGroup(member)) {
+                    applyMatrixToGroup(member, m);
                 }
             }
         }
@@ -779,7 +779,7 @@ SIREPO.app.controller('RadiaSourceController', function (appState, geometry, pan
                 const r = new SIREPO.GEOMETRY.ReflectionMatrix(plane);
                 baseViews.addCopyingTransform(r);
                 if (self.isGroup(o)) {
-                    addSymmetryToGroup(o, r);
+                    applyMatrixToGroup(o, r);
                 }
                 continue;
             }

--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -2537,8 +2537,8 @@ SIREPO.app.directive('objectTable', function(appState, $rootScope) {
                         <img alt="{{ lockTitle(o) }}" title="{{ lockTitle(o) }}" data-ng-src="/static/svg/lock.svg" data-ng-show="locked[o.id]" data-ng-class="{'sr-disabled-image': ! unlockable[o.id]}" style="padding-left: 1px;"  data-ng-disabled="! unlockable[o.id]" data-ng-click="toggleLock(o)">
                         <img alt="{{ lockTitle(o) }}" title="{{ lockTitle(o) }}" data-ng-src="/static/svg/unlock.svg" data-ng-show="! locked[o.id]" style="padding-left: 1px;"  data-ng-disabled="! unlockable[o.id]" data-ng-click="toggleLock(o)">
                         <span style="font-size: large; color: {{o.color || '#cccccc'}}; padding-left: 1px;">■</span>
-                          <span data-ng-if="isGroup(o)" class="glyphicon" data-ng-class="{'glyphicon-chevron-down': expanded[o.id], 'glyphicon-chevron-up': ! expanded[o.id]}"  data-ng-click="toggleExpand(o)"></span>
-                            <span>{{ o.name }}</span>
+                        <span data-ng-if="isGroup(o)" class="glyphicon" data-ng-class="{'glyphicon-chevron-up': expanded[o.id], 'glyphicon-chevron-down': ! expanded[o.id]}"  data-ng-click="toggleExpand(o)"></span>
+                        <span>{{ o.name }}</span>
                       </td>
                         <td style="text-align: right">
                           <div class="sr-button-bar-parent">


### PR DESCRIPTION
This applies symmetries to groups recursively. Bonus flipping of expansion carets in the object list to conform to convention.
