### PR TITLE
Fix #6326 - set objectEquality true in watch

### DIFF
--- a/sirepo/package_data/static/js/sirepo-plotting-vtk.js
+++ b/sirepo/package_data/static/js/sirepo-plotting-vtk.js
@@ -3025,7 +3025,7 @@ SIREPO.app.directive('vtkAxes', function(appState, frameCache, panelState, reque
                     rebuildAxes();
                     refresh();
                 }
-            });
+            }, true);
 
             init();
         },


### PR DESCRIPTION
The objectEquality parameter to angular's $watch needed to be _true_ to trigger the refresh. Otherwise it just senses changes to the reference.
