### PR TITLE
fix #6273 fix autoSave error cases

### DIFF
--- a/sirepo/simulation_db.py
+++ b/sirepo/simulation_db.py
@@ -585,7 +585,11 @@ def save_simulation_json(data, fixup, do_validate=True, qcall=None, modified=Fal
             PKDict(
                 error="invalidSerial",
                 sim_type=data.simulationType,
-                simulationData=data,
+                simulationData=read_simulation_json(
+                    data.simulationType,
+                    data.models.simulation.simulationId,
+                    qcall,
+                ),
             ),
             "{}: incoming serial {} than stored serial={} sid={}, resetting client",
             incoming,


### PR DESCRIPTION
 - remove uncalled errorCallback from autoSave()
 - fixed bug if resp.error is present in autoSave response, but error is not invalidSerial
 - update fileManager sim from server response when renaming
 - if an invalidSerial occurs on the server, return the on-disk simulation data to be refreshed on the client