### PR TITLE
Fix #6370 add requestSender.sendDownloadDataFile

### DIFF
--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -281,13 +281,13 @@ SIREPO.app.controller('VisualizationController', function(appState, cloudmcServi
         self.simState.saveAndRunSimulation('openmcAnimation');
     };
     self.simState.logFileURL = function() {
-        return requestSender.formatUrl('downloadDataFile', {
-            '<simulation_id>': appState.models.simulation.simulationId,
-            '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
-            '<model>': self.simState.model,
-            '<frame>': SIREPO.nonDataFileFrame,
-            '<suffix>': 'log',
-        });
+        return requestSender.downloadDataFileUrl(
+            appState,
+            {
+                model: self.simState.model,
+                suffix: 'log',
+            },
+        );
     };
     self.tallyTitle = () => {
         const a = appState.models.openmcAnimation;
@@ -387,26 +387,16 @@ SIREPO.app.factory('tallyService', function(appState, cloudmcService, requestSen
 
     self.loadOutlines = () => {
         self.outlines = {};
-        const url = requestSender.formatUrl(
-            'downloadDataFile',
+        requestSender.sendDownloadDataFile(
+            appState,
             {
-                '<simulation_id>': appState.models.simulation.simulationId,
-                '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
-                '<model>': 'openmcAnimation',
-                '<frame>': SIREPO.nonDataFileFrame,
-                '<suffix>': '.json',
-            }
-        );
-        requestSender.sendRequest(
-            url,
+                model: 'openmcAnimation',
+                suffix: 'json',
+            },
             data => {
                 self.outlines = data;
                 $rootScope.$broadcast('outlines.loaded');
             },
-            false,
-            res => {
-                throw new Error(res.error);
-            }
         );
     };
 
@@ -464,14 +454,13 @@ SIREPO.app.factory('volumeLoadingService', function(appState, requestSender, $ro
     }
 
     function volumeURL(volId) {
-        return requestSender.formatUrl(
-            'downloadDataFile',
+        return requestSender.downloadDataFileUrl(
+            appState,
             {
-                '<simulation_id>': appState.models.simulation.simulationId,
-                '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
-                '<model>': 'dagmcAnimation',
-                '<frame>': volId,
-            });
+                model: 'dagmcAnimation',
+                frame: volId,
+            }
+        );
     }
 
     self.loadVolumes = (volIds, initCallback, loadedCallback) => {

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -1030,9 +1030,9 @@ SIREPO.app.directive('fileField', function(errorService, panelState, requestSend
             $scope.downloadFileUrl = function() {
                 if ($scope.model) {
                     return requestSender.formatUrl('downloadFile', {
-                        '<simulation_id>': 'unused',
-                        '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
-                        '<filename>': SIREPO.APP_NAME == 'srw'
+                        simulation_id: 'unused',
+                        simulation_type: SIREPO.APP_SCHEMA.simulationType,
+                        filename: SIREPO.APP_NAME == 'srw'
                             ? $scope.model[$scope.fileField]
                             : $scope.fileType + '.' + $scope.model[$scope.fileField],
                     });
@@ -1275,9 +1275,9 @@ SIREPO.app.directive('fileUploadDialog', function(appState, fileUpload, panelSta
                     requestSender.formatUrl(
                         'uploadFile',
                         {
-                            '<simulation_id>': appState.models.simulation.simulationId,
-                            '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
-                            '<file_type>': $scope.fileType,
+                            simulation_id: appState.models.simulation.simulationId,
+                            simulation_type: SIREPO.APP_SCHEMA.simulationType,
+                            file_type: $scope.fileType,
                         }),
                     function(data) {
                         $scope.isUploading = false;
@@ -2192,16 +2192,16 @@ SIREPO.app.directive('panelHeading', function(appState, frameCache, panelState, 
             $scope.dataFileURL = function(suffix) {
                 if (appState.isLoaded()) {
                     var params = {
-                        '<simulation_id>': appState.models.simulation.simulationId,
-                        '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
-                        '<model>': $scope.modelKey,
-                        '<frame>': appState.isAnimationModelName($scope.modelKey)
+                        simulation_id: appState.models.simulation.simulationId,
+                        simulation_type: SIREPO.APP_SCHEMA.simulationType,
+                        model: $scope.modelKey,
+                        frame: appState.isAnimationModelName($scope.modelKey)
                             ? frameCache.getCurrentFrame($scope.modelKey)
                             // any value is fine (ignored)
                             : -1,
                     };
                     if (suffix) {
-                        params['<suffix>'] = suffix;
+                        params.suffix = suffix;
                     }
                     return requestSender.formatUrl('downloadDataFile', params);
                 }
@@ -2736,9 +2736,9 @@ SIREPO.app.directive('importOptions', function(fileUpload, requestSender) {
                             'uploadFile',
                             {
                                 // dummy id because no simulation id is available or required
-                                '<simulation_id>': '11111111',
-                                '<simulation_type>': simType,
-                                '<file_type>': info.file_type,
+                                simulation_id: SIREPO.nonSimulationId,
+                                simulation_type: simType,
+                                file_type: info.file_type,
                             }),
                         function(data) {
                             parentScope.isUploading = false;
@@ -3010,7 +3010,7 @@ SIREPO.app.directive('deleteSimulationModal', function(appState, $location) {
     };
 });
 
-SIREPO.app.directive('resetSimulationModal', function(appDataService, appState, requestSender) {
+SIREPO.app.directive('resetSimulationModal', function(appDataService, appState) {
     return {
         restrict: 'A',
         scope: {
@@ -3035,7 +3035,7 @@ SIREPO.app.directive('resetSimulationModal', function(appDataService, appState, 
     };
 });
 
-SIREPO.app.directive('completeRegistration', function(requestSender, errorService) {
+SIREPO.app.directive('completeRegistration', function() {
     return {
         restrict: 'A',
         template: `
@@ -3140,7 +3140,7 @@ SIREPO.app.directive('emailLogin', function(requestSender, errorService) {
     };
 });
 
-SIREPO.app.directive('emailLoginConfirm', function(requestSender, $route) {
+SIREPO.app.directive('emailLoginConfirm', function() {
     return {
         restrict: 'A',
         template: `
@@ -3157,7 +3157,7 @@ SIREPO.app.directive('emailLoginConfirm', function(requestSender, $route) {
     };
 });
 
-SIREPO.app.directive('ldapLogin', function (requestSender, errorService) {
+SIREPO.app.directive('ldapLogin', function (requestSender) {
     return {
         restrict: 'A',
         scope: {

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -7,6 +7,8 @@ SIREPO.traceWS = false;
 SIREPO.http_timeout = 0;
 SIREPO.debounce_timeout = 350;
 SIREPO.nonDataFileFrame = -1;
+// Temporary until fix: https://github.com/radiasoft/sirepo/issues/6388
+SIREPO.nonSimulationId = 'NONSIMID';
 
 var srlog = SIREPO.srlog;
 var srdbg = SIREPO.srdbg;
@@ -647,23 +649,23 @@ SIREPO.app.factory('appState', function(errorService, fileManager, requestQueue,
         self.clearModels();
         var routeObj = {
             routeName: 'simulationData',
-            '<simulation_id>': simulationId,
-            '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
-            '<pretty>': false
+            simulation_id: simulationId,
+            simulation_type: SIREPO.APP_SCHEMA.simulationType,
+            pretty: false
         };
-        if(section) {
-            routeObj['<section>'] = section;
+        if (section) {
+            routeObj.section = section;
         }
         requestSender.sendRequest(
             routeObj,
             function(data) {
                 if (data.notFoundCopyRedirect) {
                     requestSender.localRedirect('notFoundCopy', {
-                        ':simulationIds': data.notFoundCopyRedirect.simulationId
+                        simulationIds: data.notFoundCopyRedirect.simulationId
                             + (data.notFoundCopyRedirect.userCopySimulationId
                                ? ('-' + data.notFoundCopyRedirect.userCopySimulationId)
                                : ''),
-                        ':section': data.notFoundCopyRedirect.section,
+                        section: data.notFoundCopyRedirect.section,
                     });
                     return;
                 }
@@ -1307,8 +1309,8 @@ SIREPO.app.factory('frameCache', function(appState, panelState, requestSender, $
             }, 1000);
             requestSender.sendRequest(
                 {
-                    'routeName': 'simulationFrame',
-                    '<frame_id>': self.frameId(modelName, index),
+                    routeName: 'simulationFrame',
+                    frame_id: self.frameId(modelName, index),
                 },
                 function(data) {
                     const c = appState.models.simulation.simulationId;
@@ -1437,7 +1439,7 @@ SIREPO.app.factory('authService', function(authState, requestSender, stringsServ
     self.loginUrl = requestSender.formatUrlLocal('login');
     self.logoutUrl = requestSender.formatUrl(
         'authLogout',
-        {'<simulation_type>': SIREPO.APP_SCHEMA.simulationType}
+        {simulation_type: SIREPO.APP_SCHEMA.simulationType}
     );
     return self;
 });
@@ -1479,20 +1481,6 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
         // this is the parent scope used for modal editors created from showModalEditor()
         self.ngViewScope = event.targetScope;
     });
-
-    const _downloadFile = (routeName, simulationId, modelName, reportTitle) => {
-        const args = {
-            '<simulation_id>': simulationId,
-            '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
-        };
-        if (modelName) {
-            args['<model>'] = modelName;
-        }
-        if (reportTitle) {
-            args['<title>'] = reportTitle;
-        }
-        return requestSender.newWindow(routeName, args);
-    };
 
     function applyToFields(method, modelName, fieldInfo) {
         var enableFun = function(f) {
@@ -1618,8 +1606,8 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
             return null;
         }
         const a = {
-            '<simulation_id>': simulationId,
-            '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
+            simulation_id: simulationId,
+            simulation_type: SIREPO.APP_SCHEMA.simulationType,
         };
         return requestSender.formatUrl(route, {...a, ...args});
     }
@@ -1659,7 +1647,7 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
 
     self.exportArchiveUrl = (simulationId, filename) => {
         return urlForExport(simulationId, 'exportArchive', {
-            '<filename>':  filename,
+            filename:  filename,
         });
     };
 
@@ -2099,6 +2087,25 @@ SIREPO.app.factory('msgRouter', ($http, $interval, $q, $window, errorService) =>
             _protocolError(header, content, wsreq);
             return;
         }
+        else if (wsreq.responseType === "json") {
+            if (angular.isString(content)) {
+                content = JSON.parse(content);
+            }
+            else {
+                if (content.error) {
+                    _replyError({data: content});
+                }
+                else {
+                    _replyError({
+                        data: {
+                            error: "unknown reply type, expecting json",
+                            content: content
+                        }
+                    });
+                }
+                return;
+            }
+        }
         if (SIREPO.traceWS) {
             srlog(`wsreq#${wsreq.header.reqSeq} reply:`, content);
         }
@@ -2444,6 +2451,18 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, utilit
         return SIREPO.APP_SCHEMA.appModes[appMode || 'default'].localRoute;
     };
 
+    self.downloadDataFileUrl = (appState, params) => {
+        return self.formatUrl(
+            'downloadDataFile',
+            {
+                simulation_id: appState.models.simulation.simulationId,
+                simulation_type: SIREPO.APP_SCHEMA.simulationType,
+                frame: SIREPO.nonDataFileFrame,
+                ...params
+            },
+        );
+    };
+
     self.formatUrlLocal = function(routeName, params, app, routeMap=localMap) {
         var u = '#' + formatUrl(routeMap, routeName, params);
         return app ? '/' + app + u : u;
@@ -2500,7 +2519,7 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, utilit
     self.globalRedirectRoot = function() {
         self.globalRedirect(
             'root',
-            {'<path_info>': SIREPO.APP_SCHEMA.simulationType}
+            {path_info: SIREPO.APP_SCHEMA.simulationType}
         );
     };
 
@@ -2608,7 +2627,21 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, utilit
         sendWithSimulationFields('analysisJob', appState, callback, data);
     };
 
-    self.sendRequest = function(urlOrParams, successCallback, data, errorCallback) {
+    self.sendDownloadDataFile = (appState, routeParams, successCb, errorCb) => {
+        // When other types are requested, we can add them, e.g. blob or txt.
+        if (routeParams.suffix !== "json") {
+            throw new Error("invalid downloadDataFile suffix=" + (routeParams.suffix || ""));
+        }
+        self.sendRequest(
+            self.downloadDataFileUrl(appState, routeParams),
+            successCb,
+            routeParams.suffix === "json" ? {responseType: "json"} : {},
+            errorCb || (reply => {throw new Error(reply.error);})
+        );
+    };
+
+
+    self.sendRequest = function(urlOrParams, successCallback, requestData, errorCallback) {
         const blobResponse = (response, successCallback, thisErrorCallback) => {
             // These two content-types are what the server might return with a 200.
             const r = new RegExp('^(application/json|text/html)$');
@@ -2637,10 +2670,11 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, utilit
         var timeout = $q.defer();
         var interval, t;
         var timed_out = false;
-        const httpConfig = {
-            timeout: timeout.promise,
-            responseType: (data || {}).responseType || '',
-        };
+        const httpConfig = {timeout: timeout.promise};
+        if (requestData && requestData.responseType) {
+            httpConfig.responseType = requestData.responseType;
+            delete requestData.responseType;
+        }
         if (SIREPO.http_timeout > 0) {
             interval = $interval(
                 function () {
@@ -2651,7 +2685,7 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, utilit
                 1
             );
         }
-        var req = msgRouter.send(url, data, httpConfig);
+        var req = msgRouter.send(url, requestData, httpConfig);
         var thisErrorCallback = function(response) {
             var data = response.data;
             var status = response.status;
@@ -2753,7 +2787,9 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, utilit
         (appState, callback, data) => {
             data.variables = appState.models.rpnVariables;
             self.sendStatefulCompute(appState, callback, data);
-        }, SIREPO.debounce_timeout);
+        },
+        SIREPO.debounce_timeout
+    );
 
     self.sendStatefulCompute = function(appState, callback, data, errorCb) {
         sendWithSimulationFields('statefulCompute', appState, callback, data, errorCb);
@@ -3714,7 +3750,7 @@ SIREPO.app.factory('fileManager', function(requestSender) {
         self.removeSimFromTree(sim.simulationId);
         self.addToTree(sim);
     };
-    
+
     return self;
 });
 
@@ -3778,9 +3814,9 @@ SIREPO.app.controller('NavController', function (activeSection, appState, fileMa
                 requestSender.globalRedirect(
                     'findByNameWithAuth',
                     {
-                        '<simulation_name>': name,
-                        '<simulation_type>': SIREPO.APP_SCHEMA.simulationType,
-                        '<application_mode>': applicationMode,
+                        simulation_name: name,
+                        simulation_type: SIREPO.APP_SCHEMA.simulationType,
+                        application_mode: applicationMode,
                     }
                 );
             }
@@ -3887,7 +3923,7 @@ SIREPO.app.controller('LoginWithController', function (authState, errorService, 
         requestSender.sendRequest(
             {
                 routeName: 'authGuestLogin',
-                '<simulation_type>': SIREPO.APP_SCHEMA.simulationType
+                simulation_type: SIREPO.APP_SCHEMA.simulationType
             },
             function (data) {
                 authState.handleLogin(data, self);


### PR DESCRIPTION
which only supports json replies.
- Wrapped downloadDataFileUrl, simplifying copy and paste
- Added json responseType, which is default for $http.get/post
- Partially fixed:
  - #6389 Eliminated responseType pass through to server
  - #6390 sirepo.js and cloudmc.js
  - #6388 document with SIREPO.nonSimulationId