### PR TITLE
Fix #6443 - skip non-dict models

### DIFF
--- a/sirepo/sim_data/radia.py
+++ b/sirepo/sim_data/radia.py
@@ -83,6 +83,8 @@ class SimData(sirepo.sim_data.SimDataBase):
                 "poleObjType",
                 "type",
             ):
+                if not hasattr(dm[m], "get"):
+                    continue
                 cls._fixup_box_to_cuboid(dm[m], f)
         for m in (
             "axisPath",


### PR DESCRIPTION
Quick way to get past this
