### PR TITLE
Fix #6454 cloudmc filter types

### DIFF
--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -1752,7 +1752,7 @@ SIREPO.app.directive('multiLevelEditor', function(appState, panelState) {
                                 $scope.model[$scope.field],
                                 type(),
                             );
-                        }                            
+                        }
                     }
                 }
                 updateEditor();

--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -1719,7 +1719,8 @@ SIREPO.app.directive('multiLevelEditor', function(appState, panelState) {
             }
 
             function type(index) {
-                return index == null ? $scope.model[$scope.field]._type : $scope.model[`filter${index}`]._type;
+                const f = index == null ? $scope.field : `filter${index}`;
+                return $scope.model[f]._type;
             }
 
             function updateEditor() {
@@ -1727,6 +1728,7 @@ SIREPO.app.directive('multiLevelEditor', function(appState, panelState) {
                     return;
                 }
                 const inds = SIREPO.UTILS.SirepoUtils.indexArray(5, 1);
+                // can always select 'None'
                 const assignedTypes = inds.map(i => type(i)).filter(x => x !== NONE_TYPE);
                 // remove assigned types
                 ALL_TYPES.forEach(x => {

--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -1727,7 +1727,7 @@ SIREPO.app.directive('multiLevelEditor', function(appState, panelState) {
                 if ($scope.modelName !== 'filter') {
                     return;
                 }
-                const inds = SIREPO.UTILS.SirepoUtils.indexArray(5, 1);
+                const inds = [1, 2, 3, 4, 5];
                 // can always select 'None'
                 const assignedTypes = inds.map(i => type(i)).filter(x => x !== NONE_TYPE);
                 // remove assigned types

--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -2056,10 +2056,8 @@ SIREPO.viewLogic('tallyView', function(appState, panelState, $scope) {
     const inds = SIREPO.UTILS.indexArray(SIREPO.APP_SCHEMA.constants.maxFilters, 1);
     const TYPE_NONE = 'None';
 
-    $scope.modelData = appState.models[$scope.modelName];
-
     function type(index) {
-        return $scope.modelData[`filter${index}`]._type;
+        return appState.models[$scope.modelName][`filter${index}`]._type;
     }
 
     function updateEditor() {

--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -2053,7 +2053,7 @@ SIREPO.viewLogic('tallyView', function(appState, panelState, $scope) {
 
     const ALL_TYPES = SIREPO.APP_SCHEMA.enum.TallyFilter
         .map(x => x[SIREPO.ENUM_INDEX_VALUE]);
-    const inds = SIREPO.UTILS.indexArray(5, 1);
+    const inds = SIREPO.UTILS.indexArray(SIREPO.APP_SCHEMA.constants.maxFilters, 1);
     const TYPE_NONE = 'None';
 
     $scope.modelData = appState.models[$scope.modelName];

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1831,7 +1831,7 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
         setPanelValue(name, 'waiting', isWaiting);
     };
 
-    self.showEnum = function(model, field, value, isShown) {
+    self.showEnum = function(model, field, value, isShown, instance=null) {
         var eType = SIREPO.APP_SCHEMA.enum[appState.modelInfo(model)[field][SIREPO.INFO_INDEX_TYPE]];
         var optionIndex = -1;
         eType.forEach(function(row, index) {
@@ -1842,11 +1842,14 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
         if (optionIndex < 0) {
             throw new Error('no enum value found for ' + model + '.' + field + ' = ' + value);
         }
-        const sel = $(fieldClass(model, field));
+        let sel = $(fieldClass(model, field));
+        if (instance != null) {
+            sel = sel.eq(instance);
+        }
 
         // handles cases where we have multiple instances of the field
         const f = i => i % eType.length === optionIndex;
-        const opt = sel.find('option').filter(f);
+        let opt = sel.find('option').filter(f);
         if (! opt) {
             // handle case where enum is displayed as a button group rather than a select
             opt = sel.find('button').filter(f);

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1852,7 +1852,7 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
         const f = i => i % eType.length === optionIndex;
         let opt = sel.find('option').filter(f);
 
-        if (! opt) {
+        if (! opt || ! opt.length) {
             // handle case where enum is displayed as a button group rather than a select
             opt = sel.find('button').filter(f);
         }

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1842,14 +1842,15 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
         if (optionIndex < 0) {
             throw new Error('no enum value found for ' + model + '.' + field + ' = ' + value);
         }
+
+        // handles cases where we have multiple instances of the field
         let sel = $(fieldClass(model, field));
         if (instance != null) {
             sel = sel.eq(instance);
         }
-
-        // handles cases where we have multiple instances of the field
         const f = i => i % eType.length === optionIndex;
         let opt = sel.find('option').filter(f);
+        
         if (! opt) {
             // handle case where enum is displayed as a button group rather than a select
             opt = sel.find('button').filter(f);

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1843,14 +1843,15 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
             throw new Error('no enum value found for ' + model + '.' + field + ' = ' + value);
         }
 
-        // handles cases where we have multiple instances of the field
         let sel = $(fieldClass(model, field));
+        // apply to a specific instance
         if (instance != null) {
             sel = sel.eq(instance);
         }
+        // apply to all instances
         const f = i => i % eType.length === optionIndex;
         let opt = sel.find('option').filter(f);
-        
+
         if (! opt) {
             // handle case where enum is displayed as a button group rather than a select
             opt = sel.find('button').filter(f);

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1842,10 +1842,14 @@ SIREPO.app.factory('panelState', function(appState, requestSender, simulationQue
         if (optionIndex < 0) {
             throw new Error('no enum value found for ' + model + '.' + field + ' = ' + value);
         }
-        var opt = $(fieldClass(model, field)).find('option')[optionIndex];
+        const sel = $(fieldClass(model, field));
+
+        // handles cases where we have multiple instances of the field
+        const f = i => i % eType.length === optionIndex;
+        const opt = sel.find('option').filter(f);
         if (! opt) {
             // handle case where enum is displayed as a button group rather than a select
-            opt = $(fieldClass(model, field)).find('button')[optionIndex];
+            opt = sel.find('button').filter(f);
         }
         showValue($(opt), isShown);
         // this is required for MSIE 11 and Safari which can't hide select options


### PR DESCRIPTION
Notes:
- `multiLevelEditor` for filters contains five instances of the type dropdown; but without modification, `showEnum()` would apply only to the first instance of `optionIndex`
- Accordingly, this has `showEnum()` apply to all the corresponding options in each instance
- `showEnum()` also now takes a parameter to address an optional index for a specific instance
