### PR TITLE
Fix #6378: Get flash oauth working again

### DIFF
--- a/sirepo/oauth.py
+++ b/sirepo/oauth.py
@@ -4,10 +4,8 @@
 :copyright: Copyright (c) 2022 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from pykern import pkinspect
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdc, pkdexc, pkdlog, pkdp
-from sirepo import auth
 import authlib.integrations.base_client
 import authlib.integrations.requests_client
 import sirepo.events

--- a/sirepo/request.py
+++ b/sirepo/request.py
@@ -57,14 +57,13 @@ def init_quest(qcall, internal_req=None):
         )
     elif "tornado" in str(type(internal_req)):
         r = internal_req.request
-        u = f"{r.protocol}://{r.host}"
         sreq = _SRequest(
             body_as_bytes=lambda: internal_req.request.body,
             http_authorization=_parse_authorization(r.headers.get("Authorization")),
             http_headers=r.headers,
             http_method=r.method,
-            http_request_uri=u + r.path,
-            http_server_uri=u + "/",
+            http_request_uri=r.full_url(),
+            http_server_uri=f"{r.protocol}://{r.host}/",
             internal_req=internal_req,
             _kind="tornado_http",
             remote_addr=r.remote_ip,


### PR DESCRIPTION
This is a partial fix to get flash oauth working again. There are two aspects that were/are broken:
1. When setting up the tornado _SRequest http_request_uri only added the path to the protocol and host. In the case of flash this was /sim-oauth-flash-authorized. But, this missed all of the query params (?code=xxx). So, authlib would raise a
"MissingCodeException". Changing to full_url() fixes this.
2. Oauth wasn't working in dev because websockets and our oauth flow are incompatible. We do Set-Cookie when returning the oauth flow redirect but I believe the redirect response is in a websocket so Set-Cookie has no impact.

For now, point 2 isn't a problem on prod. We only use websockets in dev and alpha. So, I want to push this fix through while a figure out a fix for websockets.