### PR TITLE
Fix #6516 code var array expressions

### DIFF
--- a/sirepo/template/code_variable.py
+++ b/sirepo/template/code_variable.py
@@ -345,6 +345,7 @@ class PurePythonEval:
     def eval_var(self, expr, depends, variables):
         variables = variables.copy()
         for d in depends:
+            # recurse eval_var, but with empty dependencies
             v, err = self.eval_var(
                 self.__eval_indexed_variable(variables[d], variables), {}, variables
             )

--- a/sirepo/template/code_variable.py
+++ b/sirepo/template/code_variable.py
@@ -346,8 +346,8 @@ class PurePythonEval:
         variables = variables.copy()
         for d in depends:
             # recurse eval_var, but with empty dependencies
-            v, err = self.eval_var(
-                self.__eval_indexed_variable(variables[d], variables), {}, variables
+            v, err = PurePythonEval.eval_var(
+                self, self.__eval_indexed_variable(variables[d], variables), {}, variables
             )
             if err:
                 return None, err

--- a/sirepo/template/code_variable.py
+++ b/sirepo/template/code_variable.py
@@ -347,7 +347,10 @@ class PurePythonEval:
         for d in depends:
             # recurse eval_var, but with empty dependencies
             v, err = PurePythonEval.eval_var(
-                self, self.__eval_indexed_variable(variables[d], variables), {}, variables
+                self,
+                self.__eval_indexed_variable(variables[d], variables),
+                {},
+                variables,
             )
             if err:
                 return None, err

--- a/tests/template/code_variable_test.py
+++ b/tests/template/code_variable_test.py
@@ -47,7 +47,7 @@ def test_arrays():
     pkeq([124, 125, 126], code_var.eval_var("expressionArray")[0])
     pkeq([[1, 2, 3], [4, 5], [129]], code_var.eval_var("nestedArray")[0])
     # expressions containing arrays are not currently handled
-    pkeq("unknown token: numberArray[0]", code_var.eval_var("arrayExpression")[1])
+    pkeq(2, code_var.eval_var("arrayExpression")[0])
     pkeq("unknown token: y", code_var.eval_var("invalidExpressionArray")[1])
 
 


### PR DESCRIPTION
The main feature here is `__eval_indexed_variable ()`. It looks for substrings of the form <variable>[<index>] and replaces them with the variable's value at that index. e.g. for a variable:
```python
a = PKDict(name=a, value=[1, 2, 3])
```
an expression
```python
'1 + a[0]'
```
will become
```python
'1 + 1'
```
For expedience, this is strictly a regex substitution, not a modification of the parse tree. Anything more complicated (like say <variable 1>[<variable 2>] should probably involve the latter.

The test which used to expect a failure of these expressions now expects them to pass.
