### PR TITLE
Fix #6542: lock db_upgrade

### DIFF
--- a/sirepo/db_upgrade.py
+++ b/sirepo/db_upgrade.py
@@ -8,9 +8,9 @@ from pykern import pkinspect, pkio
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp, pkdlog, pkdexc
 import contextlib
-import os
 import shutil
 import sirepo.auth_db
+import sirepo.file_lock
 import sirepo.job
 import sirepo.quest
 import sirepo.sim_data
@@ -30,19 +30,20 @@ def do_all(qcall):
         y = pkinspect.module_functions("_2")
         return ((n, y[n]) for n in sorted(set(y.keys()) - set(x)))
 
-    assert (
-        not _prevent_db_upgrade_file().exists()
-    ), f"prevent_db_upgrade_file={_prevent_db_upgrade_file()} found"
+    with sirepo.file_lock.FileLock(_db_upgrade_file_lock_path()):
+        assert (
+            not _prevent_db_upgrade_file().exists()
+        ), f"prevent_db_upgrade_file={_prevent_db_upgrade_file()} found"
 
-    for n, f in _new_functions():
-        with _backup_db_and_prevent_upgrade_on_error():
-            pkdlog("running upgrade {}", n)
-            f(qcall=qcall)
-            qcall.auth_db.model(
-                "DbUpgrade",
-                name=n,
-                created=sirepo.srtime.utc_now(),
-            ).save()
+        for n, f in _new_functions():
+            with _backup_db_and_prevent_upgrade_on_error():
+                pkdlog("running upgrade {}", n)
+                f(qcall=qcall)
+                qcall.auth_db.model(
+                    "DbUpgrade",
+                    name=n,
+                    created=sirepo.srtime.utc_now(),
+                ).save()
 
 
 def _20230203_drop_spa_session(qcall):
@@ -82,6 +83,10 @@ def _backup_db_and_prevent_upgrade_on_error():
         pkdlog("original db={}", b)
         _prevent_db_upgrade_file().ensure()
         raise
+
+
+def _db_upgrade_file_lock_path():
+    return sirepo.srdb.root().join("db_upgrade_in_progress")
 
 
 def _migrate_sim_type(old_sim_type, new_sim_type, qcall):


### PR DESCRIPTION
In instances where multiple server process are started we need to lock db_upgrade so only one is running at a time. Otherwise, they can cause collisions. For example, in the case of flash files were being created by one process, deleted by another, and then when the original process went to use the file it was gone.