### PR TITLE
Reinstate creation of output dir on prod

### DIFF
--- a/sirepo/package_data/raydata-execute-analysis.sh.jinja
+++ b/sirepo/package_data/raydata-execute-analysis.sh.jinja
@@ -11,9 +11,6 @@ if ! conda info --envs | grep -q -E '{{ conda_env }}\s+\*\s+\/' ; then
     conda info --envs
     exit 1
 fi
-{% if dev_mode -%}
-# Papermill expects the output path to exist.
-# On prod we expect the dir exists.
+# on prod, output path may not exist if it is user- or uid- specific
 mkdir -p "$(dirname '{{ output_f }}')"
-{% endif -%}
 papermill '{{ input_f }}'  '{{ output_f }}'  {{ papermill_args }}


### PR DESCRIPTION
We removed the `mkdir` from prod in a previous [commit](https://github.com/radiasoft/sirepo/blob/a157442375d0f194c3b965a5a5787e87bdbbdf28/sirepo/package_data/raydata-execute-analysis.sh.jinja#L14), however while testing on CHX I ran into an issue where the output dir didn't exist because it is specific to the user and cycle. This is a proposal to reinstate the mkdir in prod to fix this issue.