### PR TITLE
Fix #6553: create the output dir in all cases.

### DIFF
--- a/sirepo/package_data/raydata-execute-analysis.sh.jinja
+++ b/sirepo/package_data/raydata-execute-analysis.sh.jinja
@@ -11,9 +11,5 @@ if ! conda info --envs | grep -q -E '{{ conda_env }}\s+\*\s+\/' ; then
     conda info --envs
     exit 1
 fi
-{% if dev_mode -%}
-# Papermill expects the output path to exist.
-# On prod we expect the dir exists.
 mkdir -p "$(dirname '{{ output_f }}')"
-{% endif -%}
 papermill '{{ input_f }}'  '{{ output_f }}'  {{ papermill_args }}


### PR DESCRIPTION
After some testing we determined that the dir needs to be created in prod as well as dev. So, just create it in all cases.