### PR TITLE
Fix #6580 - add geomGroup type and fixup

### DIFF
--- a/sirepo/package_data/template/radia/examples/undulator.json
+++ b/sirepo/package_data/template/radia/examples/undulator.json
@@ -125,7 +125,8 @@
                                 }
                             ]
                         }
-                    ]
+                    ],
+                    "type": "geomGroup"
                 },
                 {
                     "name": "Termination Magnet",
@@ -157,6 +158,7 @@
                         "b40f7233-89ba-49d5-90bc-f4efb4e0e421"
                     ],
                     "transforms": [],
+                    "type": "geomGroup",
                     "groupId": "630ea5d1-4948-498e-8ef3-1f2d86d51e57",
                     "id": "a2e13feb-19d9-4a8a-931f-0d231f4c8c7c"
                 },
@@ -207,7 +209,8 @@
                             "symmetryPoint": [0, 0, 0],
                             "symmetryType": "perpendicular"
                         }
-                    ]
+                    ],
+                    "type": "geomGroup"
                 }
             ]
         },

--- a/sirepo/sim_data/radia.py
+++ b/sirepo/sim_data/radia.py
@@ -98,6 +98,8 @@ class SimData(sirepo.sim_data.SimDataBase):
             if dm.get(m):
                 dm[m].type = m
         for o in dm.geometryReport.objects:
+            if o.get("model") and not o.get("type"):
+                o.type = o.get("model")
             for f in (
                 "model",
                 "type",


### PR DESCRIPTION
Adds the geomGroup type to the undulator example and has a fixup for missing type fields
