### PR TITLE
Fix #6597 radia button shapes

### DIFF
--- a/sirepo/package_data/static/js/sirepo-dom.js
+++ b/sirepo/package_data/static/js/sirepo-dom.js
@@ -471,21 +471,7 @@ class SVGPath extends UIElement {
     }
 
     update() {
-        let c = this.pathPoint(0);
-        this.corners = [c];
-        this.lines = [];
-        let p = `M${c[0]},${c[1]} `;
-        for (let i = 1; i < this.points.length; ++i) {
-            c = this.pathPoint(i);
-            this.lines.push([c, this.corners[this.corners.length - 1]]);
-            this.corners.push(c);
-            p += `L${c[0]},${c[1]} `;
-        }
-        if (this.doClose) {
-            this.lines.push([this.corners[this.corners.length - 1], this.corners[0]]);
-            p += 'z';
-        }
-        this.getAttr('d').setValue(p);
+        this.getAttr('d').setValue(this.pathString());
     }
 
 }


### PR DESCRIPTION
`SVGPath.update()` was calling `pathPoint()` instead of `pathPointAt()` - in fact `pathString()` is already dong the right thing and the bulk of the update code was redundant.
