### PR TITLE
6599 radia param dipole 64 bit

### DIFF
--- a/sirepo/template/radia_util.py
+++ b/sirepo/template/radia_util.py
@@ -16,7 +16,7 @@ from pykern.pkdebug import pkdp
 AXES = ["x", "y", "z"]
 
 AXIS_VECTORS = PKDict(
-    x=numpy.array([1.0, 0, 0],),
+    x=numpy.array([1.0, 0, 0]),
     y=numpy.array([0, 1.0, 0]),
     z=numpy.array([0, 0, 1.0]),
 )

--- a/sirepo/template/radia_util.py
+++ b/sirepo/template/radia_util.py
@@ -16,9 +16,9 @@ from pykern.pkdebug import pkdp
 AXES = ["x", "y", "z"]
 
 AXIS_VECTORS = PKDict(
-    x=numpy.array([1, 0, 0]),
-    y=numpy.array([0, 1, 0]),
-    z=numpy.array([0, 0, 1]),
+    x=numpy.array([1.0, 0, 0],),
+    y=numpy.array([0, 1.0, 0]),
+    z=numpy.array([0, 0, 1.0]),
 )
 
 


### PR DESCRIPTION
The issue was in `_update_extruded()`, which refers to `radia_util.AXIS_VECTORS`, where `numpy.array([1, 0, 0])` etc. creates an array of `numpy.int64`. The simple expedient of using `numpy.array([1.0, 0, 0])` gets past this.
