### PR TITLE
Fix #6608 normalized job_driver's agent life cycle code

### DIFF
--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -65,7 +65,7 @@ def assign_instance_op(op):
         res.uid,
         m.get("computeJid"),
     )
-    res.ops[op.opId] = op
+    # Not linking to ops yet, because we aren't ready to send.
     return res
 
 
@@ -78,18 +78,18 @@ class DriverBase(PKDict):
         super().__init__(
             driver_details=PKDict({"type": self.__class__.__name__}),
             kind=op.kind,
-            ops=PKDict(),
             # TODO(robnagler) sbatch could override OP_RUN, but not OP_ANALYSIS
             # because OP_ANALYSIS touches the directory sometimes. Reasonably
             # there should only be one OP_ANALYSIS running on an agent at one time.
             op_slot_q=PKDict({k: job_supervisor.SlotQueue() for k in SLOT_OPS}),
             uid=op.msg.uid,
-            _agentId=job.unique_key(),
-            _agent_start_lock=tornado.locks.Lock(),
-            _agent_starting_timeout=None,
+            _agent_id=job.unique_key(),
+            _agent_life_change_lock=tornado.locks.Lock(),
             _idle_timer=None,
+            _prepared_sends=PKDict(),
             _websocket=None,
             _websocket_ready=sirepo.tornado.Event(),
+            _websocket_ready_timeout=None,
         )
         self._sim_db_file_token = sirepo.sim_db_file.FileReq.token_for_user(self.uid)
         self._global_resources_token = (
@@ -99,33 +99,35 @@ class DriverBase(PKDict):
             else None
         )
         # Drivers persist for the life of the program so they are never removed
-        self.__instances[self._agentId] = self
+        self.__instances[self._agent_id] = self
         pkdlog("{}", self)
 
     def destroy_op(self, op):
         """Clear our op and (possibly) free cpu slot"""
-        self.ops.pkdel(op.opId)
-        op.cpu_slot.free()
-        if op.op_slot:
-            op.op_slot.free()
+        self._prepared_sends.pkdel(op.op_id)
+        if x := op.pkdel("cpu_slot"):
+            x.free()
+        if x := op.pkdel("op_slot"):
+            x.free()
         if "lib_dir_symlink" in op:
             # lib_dir_symlink is unique_key so not dangerous to remove
             pykern.pkio.unchecked_remove(op.pkdel("lib_dir_symlink"))
 
-    def free_resources(self, internal_error=None):
+    async def free_resources(self, caller):
         """Remove holds on all resources and remove self from data structures"""
-        pkdlog("{} internal_error={}", self, internal_error)
         try:
-            self._agent_starting_done()
-            self._websocket_ready.clear()
-            w = self._websocket
-            self._websocket = None
-            if w:
-                # Will not call websocket_on_close()
-                w.sr_close()
-            for o in list(self.ops.values()):
-                o.destroy(internal_error=internal_error)
-            self._websocket_free()
+            async with self._agent_life_change_lock:
+                await self.kill()
+                self._websocket_ready_timeout_cancel()
+                self._websocket_ready.clear()
+                w = self._websocket
+                self._websocket = None
+                if w:
+                    # Will not call websocket_on_close()
+                    w.sr_close()
+                e = f"job_driver.free_resources caller={caller}"
+                for o in list(self._prepared_sends.values()):
+                    o.destroy(cancel_task=True, internal_error=e)
         except Exception as e:
             pkdlog("{} error={} stack={}", self, e, pkdexc())
 
@@ -156,16 +158,16 @@ class DriverBase(PKDict):
                 )
 
     def op_is_untimed(self, op):
-        return op.opName in _UNTIMED_OPS
+        return op.op_name in _UNTIMED_OPS
 
     def pkdebug_str(self):
         return pkdformat(
             "{}(a={:.4} k={} u={:.4} {})",
             self.__class__.__name__,
-            self._agentId,
+            self._agent_id,
             self.kind,
             self.uid,
-            list(self.ops.values()),
+            list(self._prepared_sends.values()),
         )
 
     async def prepare_send(self, op):
@@ -176,13 +178,14 @@ class DriverBase(PKDict):
         """
         await self._agent_ready(op)
         await self._slots_ready(op)
+        self._prepared_sends[op.op_id] = op
 
     @classmethod
     def receive(cls, msg):
         """Receive message from agent"""
         a = cls.__instances.get(msg.content.agentId)
         if a:
-            a._receive(msg)
+            a._agent_receive(msg)
             return
         pkdlog("unknown agent, sending kill; msg={}", msg)
         try:
@@ -208,21 +211,32 @@ class DriverBase(PKDict):
 
     def websocket_on_close(self):
         pkdlog("{}", self)
-        self.free_resources()
+        self._start_free_resources(caller="websocket_on_close")
 
-    def _agent_cmd_stdin_env(self, **kwargs):
+    def _websocket_ready_timeout_cancel(self):
+        if self._websocket_ready_timeout:
+            tornado.ioloop.IOLoop.current().remove_timeout(
+                self._websocket_ready_timeout
+            )
+            self._websocket_ready_timeout = None
+
+    async def _websocket_ready_timeout_handler(self):
+        pkdlog("{} timeout={}", self, self.cfg.agent_starting_secs)
+        await self._start_free_resources(caller="_websocket_ready_timeout_handler")
+
+    def _agent_cmd_stdin_env(self, op, **kwargs):
         return job.agent_cmd_stdin_env(
             ("sirepo", "job_agent", "start"),
-            env=self._agent_env(),
+            env=self._agent_env(op),
             uid=self.uid,
             **kwargs,
         )
 
-    def _agent_env(self, env=None):
+    def _agent_env(self, op, env=None):
         return job.agent_env(
             env=(env or PKDict()).pksetdefault(
                 PYKERN_PKDEBUG_WANT_PID_TIME="1",
-                SIREPO_PKCLI_JOB_AGENT_AGENT_ID=self._agentId,
+                SIREPO_PKCLI_JOB_AGENT_AGENT_ID=self._agent_id,
                 # POSIT: same as pkcli.job_agent.start
                 SIREPO_PKCLI_JOB_AGENT_DEV_SOURCE_DIRS=os.environ.get(
                     "SIREPO_PKCLI_JOB_AGENT_DEV_SOURCE_DIRS",
@@ -230,7 +244,7 @@ class DriverBase(PKDict):
                 ),
                 SIREPO_PKCLI_JOB_AGENT_SUPERVISOR_GLOBAL_RESOURCES_TOKEN=self._global_resources_token,
                 SIREPO_PKCLI_JOB_AGENT_SUPERVISOR_GLOBAL_RESOURCES_URI=f"{self.cfg.supervisor_uri}{job.GLOBAL_RESOURCES_URI}",
-                SIREPO_PKCLI_JOB_AGENT_START_DELAY=self.get("_agent_start_delay", "0"),
+                SIREPO_PKCLI_JOB_AGENT_START_DELAY=str(op.get("_agent_start_delay", 0)),
                 SIREPO_PKCLI_JOB_AGENT_SUPERVISOR_SIM_DB_FILE_TOKEN=self._sim_db_file_token,
                 SIREPO_PKCLI_JOB_AGENT_SUPERVISOR_SIM_DB_FILE_URI=job.supervisor_file_uri(
                     self.cfg.supervisor_uri,
@@ -248,66 +262,19 @@ class DriverBase(PKDict):
             uid=self.uid,
         )
 
+    def _agent_is_idle(self):
+        return not self._prepared_sends and not self._websocket_ready_timeout
+
     async def _agent_ready(self, op):
         if self._websocket_ready.is_set():
             return
         await self._agent_start(op)
         pkdlog("{} {} await _websocket_ready", self, op)
         await self._websocket_ready.wait()
-        pkdc("{} websocket alive", op)
+        pkdlog("{} {} websocket alive", self, op)
         raise job_supervisor.Awaited()
 
-    async def _agent_start(self, op):
-        if self._agent_starting_timeout:
-            return
-        async with self._agent_start_lock:
-            # POSIT: we do not have to raise Awaited(), because
-            # this is the first thing an op waits on.
-            if self._agent_starting_timeout or self._websocket_ready.is_set():
-                return
-            try:
-                t = self.cfg.agent_starting_secs
-                if pkconfig.channel_in_internal_test():
-                    x = op.msg.pkunchecked_nested_get("data.models.dog.favoriteTreat")
-                    if x:
-                        x = re.search(r"agent_start_delay=(\d+)", x)
-                        if x:
-                            self._agent_start_delay = int(x.group(1))
-                            t += self._agent_start_delay
-                            pkdlog(
-                                "op={} agent_start_delay={}",
-                                op,
-                                self._agent_start_delay,
-                            )
-                pkdlog("{} {} await _do_agent_start", self, op)
-                # All awaits must be after this. If a call hangs the timeout
-                # handler will cancel this task
-                self._agent_starting_timeout = (
-                    tornado.ioloop.IOLoop.current().call_later(
-                        t,
-                        self._agent_starting_timeout_handler,
-                    )
-                )
-                # POSIT: Canceled errors aren't smothered by any of the below calls
-                await self.kill()
-                await self._do_agent_start(op)
-            except (Exception, sirepo.const.ASYNC_CANCELED_ERROR) as e:
-                pkdlog("{} error={} stack={}", self, e, pkdexc())
-                self.free_resources(internal_error="failure starting agent")
-                raise
-
-    def _agent_starting_done(self):
-        self._start_idle_timeout()
-        if self._agent_starting_timeout:
-            tornado.ioloop.IOLoop.current().remove_timeout(self._agent_starting_timeout)
-            self._agent_starting_timeout = None
-
-    async def _agent_starting_timeout_handler(self):
-        pkdlog("{} timeout={}", self, self.cfg.agent_starting_secs)
-        await self.kill()
-        self.free_resources(internal_error="timeout waiting for agent to start")
-
-    def _receive(self, msg):
+    def _agent_receive(self, msg):
         c = msg.content
         i = c.get("opId")
         if ("opName" not in c or c.opName == job.OP_ERROR) or (
@@ -323,64 +290,112 @@ class DriverBase(PKDict):
             if "reply" not in c:
                 pkdlog("{} no reply={}", self, c)
                 c.reply = PKDict(state="error", error="no reply")
-            if i in self.ops:
+            if i in self._prepared_sends:
                 # SECURITY: only ops known to this driver can be replied to
-                self.ops[i].reply_put(c.reply)
+                self._prepared_sends[i].reply_put(c.reply)
             else:
                 pkdlog(
-                    "{} not pending opName={} o={:.4}",
+                    "{} not in prepared_sends opName={} o={:.4} content={}",
                     self,
-                    i,
                     c.opName,
+                    i,
+                    c,
                 )
         else:
-            getattr(self, "_receive_" + c.opName)(msg)
+            getattr(self, "_agent_receive_" + c.opName)(msg)
 
-    def _receive_alive(self, msg):
+    def _agent_receive_alive(self, msg):
         """Receive an ALIVE message from our agent
 
         Save the websocket and register self with the websocket
         """
-        self._agent_starting_done()
+        self._websocket_ready_timeout_cancel()
         if self._websocket:
-            if self._websocket != msg.handler:
-                pkdlog("{} new websocket", self)
-                # New _websocket so bind
-                self.free_resources()
-        self._websocket = msg.handler
+            assert self._websocket == msg.handler, f"incoming msg.content={msg.content}"
+        else:
+            self._websocket = msg.handler
         self._websocket_ready.set()
         self._websocket.sr_driver_set(self)
+        self._start_idle_timeout()
 
-    def __str__(self):
-        return f"{type(self).__name__}({self._agentId:.4}, {self.uid:.4}, ops={list(self.ops.values())})"
-
-    def _receive_error(self, msg):
+    def _agent_receive_error(self, msg):
         # TODO(robnagler) what does this mean? Just a way of logging? Document this.
         pkdlog("{} msg={}", self, msg)
 
+    async def _agent_start(self, op):
+        if self._websocket_ready_timeout:
+            return
+        try:
+            async with self._agent_life_change_lock:
+                # POSIT: we do not have to raise Awaited(), because
+                # this is the first thing an op waits on.
+                if self._websocket_ready_timeout or self._websocket_ready.is_set():
+                    return
+                pkdlog("{} {} await=_do_agent_start", self, op)
+                # All awaits must be after this. If a call hangs the timeout
+                # handler will cancel this task
+                self._websocket_ready_timeout = (
+                    tornado.ioloop.IOLoop.current().call_later(
+                        self._agent_start_delay(op),
+                        self._websocket_ready_timeout_handler,
+                    )
+                )
+                # POSIT: Canceled errors aren't smothered by any of the below calls
+                await self._do_agent_start(op)
+        except (Exception, sirepo.const.ASYNC_CANCELED_ERROR) as e:
+            pkdlog("{} error={} stack={}", self, e, pkdexc())
+            self._start_free_resources(caller="_agent_start")
+            raise
+
+    def _agent_start_delay(self, op):
+        t = self.cfg.agent_starting_secs
+        if not pkconfig.channel_in_internal_test():
+            return t
+        x = op.pkunchecked_nested_get("msg.data.models.dog.favoriteTreat")
+        if not x:
+            return t
+        x = re.search(r"agent_start_delay=(\d+)", x)
+        if not x:
+            return t
+        op._agent_start_delay = int(x.group(1))
+        pkdlog("op={} agent_start_delay={}", op, self._agent_start_delay)
+        return t + op._agent_start_delay
+
+    def __str__(self):
+        return f"{type(self).__name__}({self._agent_id:.4}, {self.uid:.4}, ops={list(self._prepared_sends.values())})"
+
     async def _slots_ready(self, op):
         """Only one op of each type allowed"""
-        n = op.opName
+        n = op.op_name
         if n in (job.OP_CANCEL, job.OP_KILL, job.OP_BEGIN_SESSION):
             return
         if n == job.OP_SBATCH_LOGIN:
-            l = [o for o in self.ops.values() if o.opId != op.opId]
-            assert not l, "received {} but have other ops={}".format(op, l)
+            assert (
+                not self._prepared_sends
+            ), f"received op={op} but have _prepared_sends={self._prepared_sends}"
             return
-        await op.op_slot.alloc("Waiting for another simulation to complete")
-        await op.run_dir_slot.alloc("Waiting for access to simulation state")
+        await op.op_slot.alloc(
+            "Waiting for another simulation to complete await=op_slot"
+        )
+        await op.run_dir_slot.alloc(
+            "Waiting for access to simulation state await=run_dir_slot"
+        )
         if n not in _CPU_SLOT_OPS:
             return
         # once job-op relative resources are acquired, ask for global resources
         # so we only acquire on global resources, once we know we are ready to go.
-        await op.cpu_slot.alloc("Waiting for CPU resources")
+        await op.cpu_slot.alloc("Waiting for CPU resources await=cpu_slot")
+
+    def _start_free_resources(self, caller):
+        pkdlog("{} caller={}", self, caller)
+        tornado.ioloop.IOLoop.current().add_callback(self.free_resources, caller=caller)
 
     def _start_idle_timeout(self):
         async def _kill_if_idle():
             self._idle_timer = None
-            if not self.ops:
+            if self._agent_is_idle():
                 pkdlog("{}", self)
-                await self.kill()
+                self._start_free_resources(caller="_kill_if_idle")
             else:
                 self._start_idle_timeout()
 
@@ -389,9 +404,6 @@ class DriverBase(PKDict):
                 _cfg.idle_check_secs,
                 _kill_if_idle,
             )
-
-    def _websocket_free(self):
-        pass
 
 
 def init_module(**imports):

--- a/sirepo/job_driver/docker.py
+++ b/sirepo/job_driver/docker.py
@@ -117,9 +117,10 @@ class DockerDriver(job_driver.DriverBase):
         return cls
 
     async def kill(self):
-        c = self.pkdel("_cid")
-        pkdlog("{} cid={:.12}", self, c)
+        c = None
         try:
+            c = self.pkdel("_cid")
+            pkdlog("{} cid={:.12}", self, c)
             # TODO(e-carlin): This can possibly hang and needs to be handled
             # Ex. docker daemon is not responsive
             await self._cmd(
@@ -132,7 +133,7 @@ class DockerDriver(job_driver.DriverBase):
             pkdlog("{} error={} stack={}", self, e, pkdexc())
 
     async def prepare_send(self, op):
-        if op.opName == job.OP_RUN:
+        if op.op_name == job.OP_RUN:
             op.msg.mpiCores = self.cfg[self.kind].get("cores", 1)
         return await super().prepare_send(op)
 
@@ -169,7 +170,7 @@ class DockerDriver(job_driver.DriverBase):
         )
 
     async def _do_agent_start(self, op):
-        cmd, stdin, env = self._agent_cmd_stdin_env(cwd=self._agent_exec_dir)
+        cmd, stdin, env = self._agent_cmd_stdin_env(op, cwd=self._agent_exec_dir)
         pkdlog("{} agent_exec_dir={}", self, self._agent_exec_dir)
         pkio.mkdir_parent(self._agent_exec_dir)
         c = self.cfg[self.kind]

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -1137,7 +1137,6 @@ class _Op(PKDict):
             pkdlog("assigned driver={} to op={}", self.driver, self)
             self.cpu_slot = self.driver.cpu_slot_q.sr_slot_proxy(self)
             if q := self.driver.op_slot_q.get(self.op_name):
-                pkdp("assigned slot")
                 self.op_slot = q.sr_slot_proxy(self)
             self.max_run_secs = self._get_max_run_secs()
             if "dataFileKey" in self.msg:
@@ -1146,7 +1145,6 @@ class _Op(PKDict):
                     job.DATA_FILE_URI,
                     self.msg.pop("dataFileKey"),
                 )
-        pkdp("{} driver", self)
         await self.driver.prepare_send(self)
 
     async def reply_get(self):

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -1,4 +1,4 @@
-n  # -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """TODO(e-carlin): Doc
 
 :copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -253,22 +253,16 @@ class _Supervisor(PKDict):
     async def op_run_timeout(self, op):
         pass
 
-    def _create_op(self, opName, req, kind, job_run_mode, **kwargs):
+    def _create_op(self, op_name, req, kind, job_run_mode, **kwargs):
         req.kind = kind
-        o = _Op(
+        return _Op(
             _supervisor=self,
             kind=req.kind,
-            msg=PKDict(req.copy_content()).pksetdefault(jobRunMode=job_run_mode),
-            opName=opName,
+            msg=PKDict(req.copy_content())
+            .pksetdefault(jobRunMode=job_run_mode)
+            .pkupdate(**kwargs),
+            op_name=op_name,
         )
-        if "dataFileKey" in o.msg:
-            kwargs["dataFileUri"] = job.supervisor_file_uri(
-                o.driver.cfg.supervisor_uri,
-                job.DATA_FILE_URI,
-                o.msg.pop("dataFileKey"),
-            )
-        o.msg.pkupdate(**kwargs)
-        return o
 
     def _get_running_pending_jobs(self, uid=None):
         def _filter_jobs(job):
@@ -387,7 +381,7 @@ class _Supervisor(PKDict):
             # so no need to try again after Awaited.
             pass
         finally:
-            c.destroy(cancel=False)
+            c.destroy(cancel_task=False)
         return PKDict()
 
     async def _receive_api_globalResources(self, req):
@@ -565,7 +559,7 @@ class _ComputeJob(_Supervisor):
             )
 
     def set_situation(self, op, situation, exception=None):
-        if op.opName != job.OP_RUN:
+        if op.op_name != job.OP_RUN:
             return
         s = self.db.jobStatusMessage
         p = "Exception: "
@@ -737,7 +731,9 @@ class _ComputeJob(_Supervisor):
                 # compute job. Both can have relevant data in the event of a canceled compute job.
                 # In the case of OP_IO we excpect that the only reason for cancelation is due to
                 # a timeout (max_run_secs reached) in which case we send back "content-too-large".
-                if not (self.db.isParallel and o.opName in (job.OP_ANALYSIS, job.OP_IO))
+                if not (
+                    self.db.isParallel and o.op_name in (job.OP_ANALYSIS, job.OP_IO)
+                )
             )
             if timed_out_op in self.ops:
                 r.add(timed_out_op)
@@ -759,6 +755,7 @@ class _ComputeJob(_Supervisor):
         ):
             # job is not relevant, but let the user know it isn't running
             return r
+        internal_error = None
         candidates = _ops_to_cancel()
         c = None
         o = set()
@@ -775,15 +772,16 @@ class _ComputeJob(_Supervisor):
                             c = self._create_op(job.OP_CANCEL, req)
                         await c.prepare_send()
                     elif c:
-                        c.destroy()
+                        # nothing left to cancel
+                        c.destroy(cancel_task=False)
                         c = None
-                    pkdlog("{} cancel={}", self, o)
+                    pkdlog("{} to_cancel={}", self, o)
                     for x in o:
-                        x.destroy(cancel=True)
+                        x.destroy(cancel_task=True)
                     if timed_out_op:
                         self.db.canceledAfterSecs = timed_out_op.max_run_secs
                     if c:
-                        c.msg.opIdsToCancel = [x.opId for x in o]
+                        c.msg.opIdsToCancel = [x.op_id for x in o]
                         c.send()
                         await c.reply_get()
                     return r
@@ -791,9 +789,11 @@ class _ComputeJob(_Supervisor):
                     pass
             else:
                 raise AssertionError("too many retries {}".format(req))
+        except Exception as e:
+            internal_error = f"_run exception={e}"
         finally:
             if c:
-                c.destroy(cancel=False)
+                c.destroy(cancel_task=False, internal_error=internal_error)
 
     async def _receive_api_runSimulation(self, req, recursion_depth=0):
         f = req.content.data.get("forceRun")
@@ -834,7 +834,6 @@ class _ComputeJob(_Supervisor):
             computeJobQueued=t,
             computeJobSerial=t,
             computeModel=req.content.computeModel,
-            driverDetails=o.driver.driver_details,
             # run mode can change between runs so we must update the db
             jobRunMode=req.content.jobRunMode,
             simName=req.content.data.models.simulation.name,
@@ -880,7 +879,7 @@ class _ComputeJob(_Supervisor):
     async def _receive_api_statelessCompute(self, req):
         return await self._send_op_analysis(req, "stateless_compute")
 
-    def _create_op(self, opName, req, **kwargs):
+    def _create_op(self, op_name, req, **kwargs):
         req.simulationType = self.db.simulationType
         # run mode can change between runs so use req.content.jobRunMode
         # not self.db.jobRunMode
@@ -890,12 +889,12 @@ class _ComputeJob(_Supervisor):
             raise sirepo.util.NotFound("invalid jobRunMode={} req={}", r, req)
         k = (
             job.PARALLEL
-            if self.db.isParallel and opName != job.OP_ANALYSIS
+            if self.db.isParallel and op_name != job.OP_ANALYSIS
             else job.SEQUENTIAL
         )
         o = (
             super()
-            ._create_op(opName, req, k, r, **kwargs)
+            ._create_op(op_name, req, k, r, **kwargs)
             .pkupdate(task=asyncio.current_task())
         )
         self.ops.append(o)
@@ -940,7 +939,7 @@ class _ComputeJob(_Supervisor):
                     pass
                 raise
             except Exception as e:
-                op.destroy(cancel=False)
+                op.destroy(cancel_task=False, internal_error=f"_send_op exception={e}")
                 if isinstance(e, sirepo.util.SRException) and e.sr_args.params.get(
                     "isGeneral"
                 ):
@@ -949,6 +948,7 @@ class _ComputeJob(_Supervisor):
                     return False
                 _set_error(compute_job_serial, op.internal_error)
                 raise
+            self.__db_update(driverDetails=op.driver.driver_details)
             op.make_lib_dir_symlink()
             op.send()
             return True
@@ -964,6 +964,9 @@ class _ComputeJob(_Supervisor):
                         self.db.queueState = None
                         # TODO(robnagler) is this ever true?
                         if op != self.run_op:
+                            pkdlog(
+                                "ignore op={} because not run_op={}", op, self.run_op
+                            )
                             return
                         # run_dir is in a stable state so don't need to lock
                         op.run_dir_slot.free()
@@ -991,10 +994,14 @@ class _ComputeJob(_Supervisor):
             if op == self.run_op:
                 self.__db_update(
                     status=job.ERROR,
+                    internal_error=f"_run exception={e}",
                     error="server error",
                 )
+            else:
+                pkdlog("no db_update op={} because not run_op={}", op, self.run_op)
+
         finally:
-            op.destroy(cancel=False)
+            op.destroy(cancel_task=False)
 
     async def _send_op_analysis(self, req, jobCmd):
         pkdlog(
@@ -1006,8 +1013,9 @@ class _ComputeJob(_Supervisor):
 
         return await self._send_with_single_reply(job.OP_ANALYSIS, req, jobCmd=jobCmd)
 
-    async def _send_with_single_reply(self, opName, req, **kwargs):
-        o = self._create_op(opName, req, **kwargs)
+    async def _send_with_single_reply(self, op_name, req, **kwargs):
+        o = self._create_op(op_name, req, **kwargs)
+        internal_error = None
         try:
             for i in range(_MAX_RETRIES):
                 try:
@@ -1024,8 +1032,11 @@ class _ComputeJob(_Supervisor):
                     pass
             else:
                 raise AssertionError("too many retries {}".format(req))
+        except Exception as e:
+            internal_error = f"_send_with_single_reply exception={e}"
+            raise
         finally:
-            o.destroy(cancel=False)
+            o.destroy(cancel_task=False, internal_error=internal_error)
 
     def _status_reply(self, req):
         def res(**kwargs):
@@ -1080,31 +1091,26 @@ class _Op(PKDict):
         self.update(
             do_not_send=False,
             internal_error=None,
-            opId=job.unique_key(),
+            op_id=job.unique_key(),
             _reply_q=sirepo.tornado.Queue(),
         )
         if "run_dir_slot_q" in self._supervisor:
             self.run_dir_slot = self._supervisor.run_dir_slot_q.sr_slot_proxy(self)
-        self.msg.update(opId=self.opId, opName=self.opName)
-        self.driver = job_driver.assign_instance_op(self)
-        self.cpu_slot = self.driver.cpu_slot_q.sr_slot_proxy(self)
-        q = self.driver.op_slot_q.get(self.opName)
-        self.op_slot = q and q.sr_slot_proxy(self)
-        self.max_run_secs = self._get_max_run_secs()
+        self.msg.update(opId=self.op_id, opName=self.op_name)
         pkdlog("{} runDir={}", self, self.msg.get("runDir"))
 
-    def destroy(self, cancel=True, internal_error=None):
-        "run_dir_slot" in self and self.run_dir_slot.free()
-        if cancel and self.get("task"):
-            self.task.cancel()
-            self.task = None
+    def destroy(self, cancel_task=True, internal_error=None):
+        if x := self.pkdel("run_dir_slot"):
+            x.free()
+        if (x := self.pkdel("task")) and cancel_task:
+            x.cancel()
+        for x in "run_callback", "timer":
+            if y := self.pkdel(x):
+                tornado.ioloop.IOLoop.current().remove_timeout(y)
         # Ops can be destroyed multiple times
         # The first error is "closest to the source" so don't overwrite it
-        if not self.internal_error:
+        if internal_error and not self.internal_error:
             self.internal_error = internal_error
-        for x in "run_callback", "timer":
-            if x in self:
-                tornado.ioloop.IOLoop.current().remove_timeout(self.pkdel(x))
         self._supervisor.destroy_op(self)
         self.driver.destroy_op(self)
 
@@ -1112,13 +1118,35 @@ class _Op(PKDict):
         self.driver.make_lib_dir_symlink(self)
 
     def pkdebug_str(self):
-        return pkdformat("_Op({}, {:.4})", self.opName, self.opId)
+        def _internal_error():
+            if not self.internal_error:
+                return ""
+            return ", internal_error={self.internal_error}"
+
+        return pkdformat(
+            "_Op({}, {:.4}{})", self.op_name, self.op_id, _internal_error()
+        )
 
     async def prepare_send(self):
         """Ensures resources are available for sending to agent
         To maintain consistency, do not modify global state before
         calling this method.
         """
+        if "driver" not in self:
+            self.driver = job_driver.assign_instance_op(self)
+            pkdlog("assigned driver={} to op={}", self.driver, self)
+            self.cpu_slot = self.driver.cpu_slot_q.sr_slot_proxy(self)
+            if q := self.driver.op_slot_q.get(self.op_name):
+                pkdp("assigned slot")
+                self.op_slot = q.sr_slot_proxy(self)
+            self.max_run_secs = self._get_max_run_secs()
+            if "dataFileKey" in self.msg:
+                self.msg.dataFileUri = job.supervisor_file_uri(
+                    self.driver.cfg.supervisor_uri,
+                    job.DATA_FILE_URI,
+                    self.msg.pop("dataFileKey"),
+                )
+        pkdp("{} driver", self)
         await self.driver.prepare_send(self)
 
     async def reply_get(self):
@@ -1162,14 +1190,14 @@ class _Op(PKDict):
     def _get_max_run_secs(self):
         if self.driver.op_is_untimed(self):
             return 0
-        if self.opName in (
+        if self.op_name in (
             sirepo.job.OP_ANALYSIS,
             sirepo.job.OP_IO,
         ):
-            return _cfg.max_secs[self.opName]
+            return _cfg.max_secs[self.op_name]
         if self.kind == job.PARALLEL and self.msg.get("isPremiumUser"):
             return _cfg.max_secs["parallel_premium"]
         return _cfg.max_secs[self.kind]
 
     def __hash__(self):
-        return hash((self.opId,))
+        return hash((self.op_id,))

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -170,11 +170,11 @@ class _Dispatcher(PKDict):
         self._fastcgi_file = None
         self.fastcgi_cmd = None
 
-    def format_op(self, msg, opName, **kwargs):
+    def format_op(self, msg, op_name, **kwargs):
         if msg:
             kwargs["opId"] = msg.get("opId")
         return pkjson.dump_bytes(
-            PKDict(agentId=_cfg.agent_id, opName=opName).pksetdefault(**kwargs),
+            PKDict(agentId=_cfg.agent_id, opName=op_name).pksetdefault(**kwargs),
         )
 
     async def job_cmd_reply(self, msg, op_name, text):

--- a/tests/job_timeout_test.py
+++ b/tests/job_timeout_test.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """test for canceling a long running simulation due to a timeout
 
 :copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
 import os
 import pytest


### PR DESCRIPTION
- Changed some conditionals to assertions to simplify code
- Locking around start and end of the agent life (_agent_life_change_lock)
- Ops are bound to driver in prepare_send, was too early in agent_start
- Fix #6613 _agent_start_delay is local to op
- Fix #6572 added more logging, fixed some messages, and normalized others
- Cleaned up some naming (opId > op_id when not in msg)
- Cascade exceptions into op.internal_error for better logging
- Improved error handling/logging in sirepo.status