### PR TITLE
Fix #6698: remove api runMulti and related code

### DIFF
--- a/sirepo/job.py
+++ b/sirepo/job.py
@@ -41,9 +41,6 @@ SERVER_SRTIME_URI = "/job-api-srtime"
 #: path supervisor registers to receive requests from server
 SERVER_URI = "/job-api-request"
 
-#: path supervisor registers to receive runMulti requests from server
-SERVER_RUN_MULTI_URI = "/job-api-run-multi-request"
-
 #: path supervisor registers to receive pings from server
 SERVER_PING_URI = "/job-api-ping"
 

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -178,28 +178,6 @@ class API(sirepo.quest.API):
         # Always true from the client's perspective
         return self.reply_dict({"state": "canceled"})
 
-    @sirepo.quest.Spec("require_user", data="RunMultiSpec")
-    async def api_runMulti(self):
-        def _api(api):
-            # SECURITY: Make sure we have permission to call API
-            sirepo.uri_router.assert_api_name_and_auth(
-                self,
-                api,
-                ("runSimulation", "runStatus"),
-            )
-            # Necessary so dispatch to job supervisor works correctly
-            return "api_" + api
-
-        r = []
-        for m in self.parse_json():
-            c = self._request_content(PKDict(req_data=m))
-            c.data.pkupdate(api=_api(c.data.api), asyncReply=m.awaitReply)
-            r.append(c)
-        return await self._request_api(
-            _request_content=PKDict(data=r),
-            _request_uri=self._supervisor_uri(sirepo.job.SERVER_RUN_MULTI_URI),
-        )
-
     @sirepo.quest.Spec("require_user")
     async def api_runSimulation(self):
         r = self._request_content(PKDict(is_sim_data=True))

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -155,7 +155,6 @@
         "robotsTxt": "/robots.txt",
         "root": "/*<path_info>",
         "runCancel": "/run-cancel",
-        "runMulti": "/run-multi",
         "runSimulation": "/run-simulation",
         "runStatus": "/run-status",
         "saveModerationReason": "/save-moderation-reason",

--- a/sirepo/package_data/static/react-json/common-schema.json
+++ b/sirepo/package_data/static/react-json/common-schema.json
@@ -377,7 +377,6 @@
         "robotsTxt": "/robots.txt",
         "root": "/*:path_info",
         "runCancel": "/run-cancel",
-        "runMulti": "/run-multi",
         "runSimulation": "/run-simulation",
         "runStatus": "/run-status",
         "saveModerationReason": "/save-moderation-reason",

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -61,21 +61,6 @@ _api_modules = []
 _api_funcs = PKDict()
 
 
-def assert_api_name_and_auth(qcall, name, allowed):
-    """Check if `name` is executable and in allowed
-
-    Args:
-        qcall (sirepo.quest.API)
-        name (str): name of the api
-        allowed (tuple): names that are allowed to be called
-    Returns:
-        str: api name
-    """
-    _check_route(qcall, _api_to_route[name])
-    if name not in allowed:
-        raise AssertionError(f"api={name} not in allowed={allowed}")
-
-
 async def call_api(qcall, name, kwargs=None, data=None):
     """Should not be called outside of Base.call_api(). Use self.call_api() to call API.
 


### PR DESCRIPTION
Uses of runMulti were removed in
7f4f427f21cb71a60a9ba7dcce54ffd94e263b81. So, remove the API since it is unused.