### PR TITLE
fix #6366 show refresh modal when serverUpgraded detected

### DIFF
--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -3304,9 +3304,12 @@ SIREPO.app.directive('commonFooter', function() {
             <div data-modal-editor="" view-name="simulation" modal-title="simulationModalTitle"></div>
             <div data-sbatch-login-modal=""></div>
             <div data-jobs-list-modal="" data-title="Jobs" data-id="sr-jobsListModal-editor"></div>
+            <div data-confirmation-modal="" data-is-required="true" data-id="sr-newRelease" data-title="Server Upgraded" data-ok-text="Refresh" data-ok-clicked="refreshPage()">Sirepo has been upgraded. Select <b>Refresh</b> to update this simulation.</div>
+            <div data-confirmation-modal="" data-is-required="true" data-id="sr-invalidSimulationSerial" data-title="Simulation Conflict" data-ok-text="Refresh" data-ok-clicked="refreshPage()">This simulation has been updated outside of this browser. Select <b>Refresh</b> to update this simulation.</div>
         `,
         controller: function($scope, appState, stringsService) {
             $scope.simulationModalTitle = stringsService.formatKey('simulationDataType');
+            $scope.refreshPage = () => window.location.reload();
         }
     };
 });

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -2562,6 +2562,11 @@ SIREPO.app.factory('requestSender', function(cookieService, errorService, utilit
             self.globalRedirect(e.params.uri, undefined);
             return;
         }
+        if (e.routeName == "serverUpgraded" && e.params
+            && ['invalidSimulationSerial', 'newRelease'].includes(e.params.reason)) {
+            $(`#sr-${e.params.reason}`).modal('show');
+            return;
+        }
         const u = $location.url();
         if (e.routeName == LOGIN_ROUTE_NAME && u != LOGIN_URI) {
             saveCookieRedirect(u);


### PR DESCRIPTION
This change shows a modal dialog for two cases, invalidSimulationSerial and newRelease.

![x](https://github.com/radiasoft/sirepo/assets/6516910/ed97f293-888c-43e8-8e31-c437614a226b)
![x2](https://github.com/radiasoft/sirepo/assets/6516910/d22ef0b6-7731-43b0-8aba-1d03468f6087)
