### PR TITLE
fix #6737 raydata ui changes

### DIFF
--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -32,6 +32,9 @@ SIREPO.app.config(() => {
         <div data-ng-switch-when="SearchTerms">
           <div data-search-terms="" data-model="model" data-field="field"></div>
         </div>
+        <div data-ng-switch-when="SearchTermText" data-ng-class="fieldClass">
+          <div data-search-term-text="" data-model="model" data-field="field"></div>
+        </div>
         <div data-ng-switch-when="ColumnList" data-ng-class="fieldClass">
           <div data-column-list="" data-model="model" data-field="field"></div>
         </div>
@@ -1205,6 +1208,24 @@ SIREPO.app.directive('searchTerms', function() {
                     return true;
                 }
                 return false;
+            };
+        },
+    };
+});
+
+SIREPO.app.directive('searchTermText', function() {
+    return {
+        restrict: 'A',
+        scope: {
+            model: '=',
+            field: '=',
+            },
+        template: `
+          <input data-ng-disabled="disabled()" data-ng-model="model[field]" class="form-control" data-lpignore="true" />
+        `,
+        controller: function($scope, columnsService) {
+            $scope.disabled = () => {
+                return $scope.model.column === columnsService.selectSearchFieldText;
             };
         },
     };

--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -374,6 +374,7 @@ SIREPO.app.directive('presetTimePicker', function() {
         template: `
           <button type="button" class="btn btn-info btn-xs" data-ng-click="setSearchTimeLastHour()">Last Hour</button>
           <button type="button" class="btn btn-info btn-xs" data-ng-click="setSearchTimeLastDay()">Last Day</button>
+          <button type="button" class="btn btn-info btn-xs" data-ng-click="setSearchTimeLastWeek()">Last Week</button>
           <button type="button" class="btn btn-info btn-xs" data-ng-click="setSearchTimeMaxRange()">All Time</button>
         `,
         controller: function(appState, timeService, $scope) {
@@ -391,6 +392,11 @@ SIREPO.app.directive('presetTimePicker', function() {
 
             $scope.setSearchTimeLastHour = () => {
                 $scope.model.searchStartTime = timeService.roundUnixTimeToMinutes(timeService.unixTimeOneHourAgo());
+                $scope.model.searchStopTime = timeService.roundUnixTimeToMinutes(timeService.unixTimeNow());
+            };
+
+            $scope.setSearchTimeLastWeek = () => {
+                $scope.model.searchStartTime = timeService.roundUnixTimeToMinutes(timeService.unixTimeOneWeekAgo());
                 $scope.model.searchStopTime = timeService.roundUnixTimeToMinutes(timeService.unixTimeNow());
             };
 

--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -509,7 +509,7 @@ SIREPO.app.directive('scansTable', function() {
                     </tr>
                   </tbody>
                 </table>
-                <div style="height: 20px; position: relative;">
+                <div style="height: 40px; position: relative;">
                   <span data-loading-spinner data-sentinel="!isLoadingNewScans">
                   <div ng-show="isRefreshingScans && ! isLoadingNewScans">Checking for new scans</div>
                   <div ng-show="noScansReturned">No scans found</div>

--- a/sirepo/package_data/static/js/raydata.js
+++ b/sirepo/package_data/static/js/raydata.js
@@ -509,8 +509,8 @@ SIREPO.app.directive('scansTable', function() {
                     </tr>
                   </tbody>
                 </table>
-                <div style="height: 20px;">
-                  <div ng-show="isLoadingNewScans">Loading scans ...</div>
+                <div style="height: 20px; position: relative;">
+                  <span data-loading-spinner data-sentinel="!isLoadingNewScans">
                   <div ng-show="isRefreshingScans && ! isLoadingNewScans">Checking for new scans</div>
                   <div ng-show="noScansReturned">No scans found</div>
                   <div ng-show="searchError"><span class="bg-warning">{{ searchError }}</span></div>

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1071,6 +1071,11 @@ SIREPO.app.factory('timeService', function() {
         return self.unixTimeNow() - (60 * 60);
     };
 
+    self.unixTimeOneWeekAgo = () => {
+        return self.unixTimeNow() - (60 * 60 * 24 * 7);
+    };
+
+
     self.unixTimeToDate = (unixTime) => {
         return new Date(unixTime * UNIX_TIMESTAMP_SCALE);
     };

--- a/sirepo/package_data/static/json/raydata-schema.json
+++ b/sirepo/package_data/static/json/raydata-schema.json
@@ -91,7 +91,7 @@
         },
         "searchTerm": {
             "column": ["Column", "ColumnList", ""],
-            "term": ["Search Term", "OptionalString", ""]
+            "term": ["Search Term", "SearchTermText", ""]
         },
         "simulation": {
             "catalogNamePicker": ["Catalog Name", "CatalogNamePicker", ""]

--- a/sirepo/raydata/analysis_driver/__init__.py
+++ b/sirepo/raydata/analysis_driver/__init__.py
@@ -74,7 +74,7 @@ class AnalysisDriverBase(PKDict):
             *self._get_papermill_args(),
         ]:
             res.extend(["-p", f"'{n}'", f"'{v}'"])
-            res.extend(("--report-mode", "--log-output", "--no-progress-bar"))
+        res.extend(("--report-mode", "--log-output", "--no-progress-bar"))
         return res
 
     def get_run_log(self):

--- a/sirepo/raydata/analysis_driver/__init__.py
+++ b/sirepo/raydata/analysis_driver/__init__.py
@@ -74,7 +74,7 @@ class AnalysisDriverBase(PKDict):
             *self._get_papermill_args(),
         ]:
             res.extend(["-p", f"'{n}'", f"'{v}'"])
-        res.extend(("--report-mode", "--log-output", "--no-progress-bar"))
+        res.extend(("--report-mode", "--log-output", "--progress-bar"))
         return res
 
     def get_run_log(self):

--- a/sirepo/template/raydata.py
+++ b/sirepo/template/raydata.py
@@ -32,7 +32,9 @@ def stateless_compute_analysis_output(data, **kwargs):
 
 def stateless_compute_analysis_run_log(data, **kwargs):
     def _filter_log(log):
-        return re.sub("Ending Cell.*\n", "", log)
+        for f in ("Ending Cell.*\n", "Executing Cell.*\n"):
+            log = re.sub(f, "", log)
+        return log
 
     def _log_to_html(log):
         return pygments.highlight(


### PR DESCRIPTION
- fix #6737
- fix radiasoft/raydata#148
   - this version of papermill doesn't have a lot of options, so the easiest way to achieve this was to add back the progress bars
- fix #6741 
- fix #6736
   - I was inspired by the Gmail example we looked at the other day, where the loading spinner is in the middle of the page and then "no results" is at the top. I wasn't sure if we had any official design language decisions regarding loading spinners like this one (feedback welcome @mkeilman)