### PR TITLE
Fix #6716 - use 90% instead of 90vh

### DIFF
--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -687,7 +687,7 @@ SIREPO.app.directive('tallyViewer', function(appState, cloudmcService, plotting,
             reportId: '<',
         },
         template: `
-            <div style="height: 90vh">
+            <div style="height: 90%">
                 <ul class="nav nav-tabs">
                     <li role="presentation" data-ng-class="{active: is2D()}">
                         <a href data-ng-click="setSelectedGeometry('2D')">2D</a>


### PR DESCRIPTION
This seems to work fine on my laptop screen but I'd like to know how it fares on bigger screens...
