### PR TITLE
Fix #6837 cloudmc path nan

### DIFF
--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -830,19 +830,9 @@ SIREPO.app.directive('geometry2d', function(appState, cloudmcService, frameCache
                     tallyService.getSourceParticles().map(p => particleColor(p))
                 );
 
-                function isPosOutsideMesh(pos, dim) {
-                    const [j, k] = SIREPO.GEOMETRY.GeometryUtils.nextAxisIndices(dim);
-                    const s = cloudmcService.GEOMETRY_SCALE;
+                function isPosOutsideMesh(pos, j, k) {
                     const r = tallyService.getMeshRanges();
-                    const [rj, rk] = [
-                        r[j].slice(0, 2).map(x => x / s),
-                        r[k].slice(0, 2).map(x => x / s)
-                    ];
-                    return pos[j] < rj[0] || pos[j] > rj[1] || pos[k] < rk[0] || pos[k]  > rk[1];
-                    return [
-                        Math.min(rj[1], Math.max(rj[0], pos[j])),
-                        Math.min(rk[1], Math.max(rk[0], pos[k])),
-                    ];
+                    return pos[j] < r[j][0] || pos[j] > r[j][1] || pos[k] < r[k][0] || pos[k]  > r[k][1];
                 }
 
                 function particleColor(p) {
@@ -920,10 +910,10 @@ SIREPO.app.directive('geometry2d', function(appState, cloudmcService, frameCache
                 const [j, k] = SIREPO.GEOMETRY.GeometryUtils.nextAxisIndices(dim);
                 tallyService.getSourceParticles().forEach((p, n) => {
                     // ignore sources outside the plotting range
-                    if (isPosOutsideMesh(p.position, dim)) {
+                    const p1 = [p.position[j], p.position[k]].map(x => x * cloudmcService.GEOMETRY_SCALE);
+                    if (isPosOutsideMesh(p1, j, k)) {
                         return;
                     }
-                    const p1 = [p.position[j], p.position[k]].map(x => x * cloudmcService.GEOMETRY_SCALE);
                     // normalize in the plane and check if perpendicular
                     const d = Math.hypot(p.direction[j], p.direction[k]);
                     const p2 = d ? [p1[0] + r * p.direction[j] / d, p1[1] + r * p.direction[k] / d] : p1;

--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -909,8 +909,8 @@ SIREPO.app.directive('geometry2d', function(appState, cloudmcService, frameCache
                 const r = vectorScaleFactor();
                 const [j, k] = SIREPO.GEOMETRY.GeometryUtils.nextAxisIndices(dim);
                 tallyService.getSourceParticles().forEach((p, n) => {
-                    // ignore sources outside the plotting range
                     const p1 = [p.position[j], p.position[k]].map(x => x * cloudmcService.GEOMETRY_SCALE);
+                    // ignore sources outside the plotting range
                     if (isPosOutsideMesh(p1, j, k)) {
                         return;
                     }

--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -1025,7 +1025,7 @@ SIREPO.app.directive('geometry2d', function(appState, cloudmcService, frameCache
                     v[dim] = true;
                     SIREPO.GEOMETRY.GeometryUtils.BASIS_VECTORS()[dim].forEach((bv, bi) => {
                         if (! bv && tallyService.mesh.dimension[bi] < SIREPO.APP_SCHEMA.constants.minTallyResolution) {
-                            //delete v[dim];
+                            delete v[dim];
                         }
                     });
                 });


### PR DESCRIPTION
Notes:
- The NaN errors were caused by a source particle vector being aligned with the slice axis (hence no size in the plane and a divide by 0)
- This sets the endpoints of the vector to be the same in that case
- Any source particles outside the 2d plot range are now omitted
