### PR TITLE
Fix #6892 - watch planePos.numSteps

### DIFF
--- a/sirepo/package_data/static/js/cloudmc.js
+++ b/sirepo/package_data/static/js/cloudmc.js
@@ -2911,6 +2911,7 @@ SIREPO.viewLogic('tallySettingsView', function(appState, cloudmcService, panelSt
         ], autoUpdate,
         ['openmcAnimation.tally'], validateTally,
         [
+            'tallyReport.planePos.numSteps',
             'tallyReport.selectedGeometry',
             'openmcAnimation.score',
             'openmcAnimation.showSources',


### PR DESCRIPTION
Note we just watch numSteps since that is the only property used to show or hide the field
