### PR TITLE
Fix #6972: Fix cancel in sbatch

### DIFF
--- a/sirepo/job.py
+++ b/sirepo/job.py
@@ -30,6 +30,12 @@ OP_RUN = "run"
 OP_SBATCH_LOGIN = "sbatch_login"
 OP_BEGIN_SESSION = "begin_session"
 
+
+#: Types of slots required by op types
+CPU_SLOT_OPS = frozenset((OP_ANALYSIS, OP_RUN))
+SLOT_OPS = frozenset().union(*[CPU_SLOT_OPS, (OP_IO,)])
+
+
 _OK_REPLY = PKDict(state="ok")
 
 #: path supervisor registers to receive messages from agent
@@ -125,6 +131,7 @@ UNIQUE_KEY_CHARS_RE = r"\w+"
 
 #: A standalone unique key
 UNIQUE_KEY_RE = re.compile(r"^{}$".format(UNIQUE_KEY_CHARS_RE))
+
 
 _QUASI_SID_PREFIX = "_1_"
 

--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -37,10 +37,6 @@ _DEFAULT_MODULE = "local"
 
 _cfg = None
 
-_CPU_SLOT_OPS = frozenset((job.OP_ANALYSIS, job.OP_RUN))
-
-SLOT_OPS = frozenset().union(*[_CPU_SLOT_OPS, (job.OP_IO,)])
-
 _UNTIMED_OPS = frozenset(
     (job.OP_ALIVE, job.OP_CANCEL, job.OP_ERROR, job.OP_KILL, job.OP_OK)
 )
@@ -77,7 +73,7 @@ class DriverBase(PKDict):
             # TODO(robnagler) sbatch could override OP_RUN, but not OP_ANALYSIS
             # because OP_ANALYSIS touches the directory sometimes. Reasonably
             # there should only be one OP_ANALYSIS running on an agent at one time.
-            op_slot_q=PKDict({k: job_supervisor.SlotQueue() for k in SLOT_OPS}),
+            op_slot_q=PKDict({k: job_supervisor.SlotQueue() for k in job.SLOT_OPS}),
             uid=op.msg.uid,
             _agent_id=job.unique_key(),
             _agent_life_change_lock=tornado.locks.Lock(),
@@ -407,7 +403,7 @@ class DriverBase(PKDict):
             op.run_dir_slot.alloc,
             "Waiting for access to simulation state await=run_dir_slot",
         )
-        if n not in _CPU_SLOT_OPS:
+        if n not in job.CPU_SLOT_OPS:
             return res
         # once job-op relative resources are acquired, ask for global resources
         # so we only acquire on global resources, once we know we are ready to go.

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -206,7 +206,7 @@ class _Dispatcher(PKDict):
                     tornado.httpclient.HTTPRequest(
                         connect_timeout=_CONNECT_SECS,
                         url=_cfg.supervisor_uri,
-                        validate_cert=sirepo.job.cfg().verify_tls,
+                        validate_cert=job.cfg().verify_tls,
                     ),
                     max_message_size=job.cfg().max_message_bytes,
                     ping_interval=job.cfg().ping_interval_secs,
@@ -440,6 +440,10 @@ class _Dispatcher(PKDict):
 class _Cmd(PKDict):
     def __init__(self, *args, send_reply=True, **kwargs):
         super().__init__(*args, send_reply=send_reply, **kwargs)
+        if self.msg.opName not in job.SLOT_OPS:
+            raise AssertionError(
+                f"self.msg.opName={self.msg.opName} must be one of job.SLOT_OPS={job.SLOT_OPS} to create _Cmd"
+            )
         self.run_dir = pkio.py_path(self.msg.runDir)
         self._is_compute = self.msg.jobCmd == "compute"
         if self._is_compute:

--- a/sirepo/srunit.py
+++ b/sirepo/srunit.py
@@ -153,6 +153,27 @@ class _TestClient:
         if feature_config.cfg().ui_websocket:
             self._websocket = _WebSocket(self)
 
+    def iter_sleep(self, kind, op_desc):
+        import time
+
+        def _setup():
+            rv = PKDict(_ITER_SLEEP[kind])
+            rv.countdown = range(rv.count, -1, -1)
+            return rv
+
+        s = _setup()
+        for i in s.countdown:
+            yield
+            if i > 0:
+                time.sleep(s.sleep_secs)
+        else:
+            pkfail(
+                "timeout secs={} kind={} op_desc={}",
+                s.sleep_secs * s.count,
+                kind,
+                op_desc,
+            )
+
     @contextlib.contextmanager
     def sr_adjust_time(self, days):
         from sirepo import srtime
@@ -324,27 +345,6 @@ class _TestClient:
             raw_response=True,
             **kwargs,
         )
-
-    def sr_iter_sleep(self, kind, op_desc):
-        import time
-
-        def _setup():
-            rv = PKDict(_ITER_SLEEP[kind])
-            rv.countdown = range(rv.count, -1, -1)
-            return rv
-
-        s = _setup()
-        for i in s.countdown:
-            yield
-            if i > 0:
-                time.sleep(s.sleep_secs)
-        else:
-            pkfail(
-                "timeout secs={} kind={} op_desc={}",
-                s.sleep_secs * s.count,
-                kind,
-                op_desc,
-            )
 
     def sr_login_as_guest(self, sim_type=None):
         """Sets up a guest login

--- a/tests/sbatch_test.py
+++ b/tests/sbatch_test.py
@@ -44,7 +44,7 @@ def test_srw_cancel(fc):
         ),
         expect_completed=False,
     )
-    for _ in fc.sr_iter_sleep("slurm", "runStatus"):
+    for _ in fc.iter_sleep("slurm", "runStatus"):
         pkok(
             r.state in ("running", "pending"),
             "runSimulation did not start: reply={}",
@@ -54,7 +54,7 @@ def test_srw_cancel(fc):
             break
         r = fc.sr_post("runStatus", r.nextRequest)
     r = fc.sr_post("runCancel", r.nextRequest)
-    for _ in fc.sr_iter_sleep("slurm", "runCancel"):
+    for _ in fc.iter_sleep("slurm", "runCancel"):
         if _squeue_num_jobs() == 0:
             break
 

--- a/tests/sbatch_test.py
+++ b/tests/sbatch_test.py
@@ -13,13 +13,66 @@
 # EOF
 
 
-def test_srw_data_file(new_user_fc):
+def test_srw_cancel(fc):
+    from pykern.pkcollections import PKDict
+    from pykern.pkdebug import pkdp
+    from pykern.pkunit import pkeq, pkfail, pkok
+    import subprocess
+    import time
+
+    def _squeue_num_jobs():
+        # slurm is a shared resource (not unique to each test) so this
+        # has the potential to conflict with jobs users have started
+        # outside of tests.
+        # Will be fixed by https://github.com/radiasoft/sirepo/issues/7012
+        # -1 to remove header line
+        return int(subprocess.check_output("squeue | wc -l", shell=True)) - 1
+
+    pkeq(0, _squeue_num_jobs())
+    sim_name = "Young's Double Slit Experiment"
+    compute_model = "multiElectronAnimation"
+    fc.sr_sbatch_login(compute_model, sim_name)
+    d = fc.sr_sim_data(sim_name=sim_name)
+    d.models[compute_model].jobRunMode = fc.sr_job_run_mode
+    r = fc.sr_post(
+        "runSimulation",
+        PKDict(
+            models=d.models,
+            report=compute_model,
+            simulationId=d.models.simulation.simulationId,
+            simulationType=d.simulationType,
+        ),
+        expect_completed=False,
+    )
+
+    for _ in range(5):
+        pkok(
+            r.state in ("running", "pending"),
+            "runSimulation did not start: reply={}",
+            r,
+        )
+        if r.state == "running" and _squeue_num_jobs() == 1:
+            break
+        time.sleep(5)
+        r = fc.sr_post("runStatus", r.nextRequest)
+    else:
+        pkfail("failed to start running in sirepo and slurm reply={}", r)
+    r = fc.sr_post("runCancel", r.nextRequest)
+    for _ in range(5):
+        if _squeue_num_jobs() == 0:
+            break
+        time.sleep(5)
+    else:
+        pkfail("runCancel: failed to cancel in slurm")
+
+
+def test_srw_data_file(fc):
     from pykern.pkcollections import PKDict
     from pykern.pkunit import pkeq
 
     a = "Young's Double Slit Experiment"
     c = "multiElectronAnimation"
-    new_user_fc.sr_sbatch_animation_run(
+    fc.sr_sbatch_animation_run(
         a,
         c,
         PKDict(
@@ -31,8 +84,8 @@ def test_srw_data_file(new_user_fc):
         ),
         expect_completed=False,
     )
-    d = new_user_fc.sr_sim_data(a)
-    r = new_user_fc.sr_get(
+    d = fc.sr_sim_data(a)
+    r = fc.sr_get(
         "downloadRunFile",
         PKDict(
             simulation_type=d.simulationType,

--- a/tests/sbatch_test.py
+++ b/tests/sbatch_test.py
@@ -44,8 +44,7 @@ def test_srw_cancel(fc):
         ),
         expect_completed=False,
     )
-
-    for _ in range(5):
+    for _ in fc.sr_iter_sleep("slurm", "runStatus"):
         pkok(
             r.state in ("running", "pending"),
             "runSimulation did not start: reply={}",
@@ -53,17 +52,11 @@ def test_srw_cancel(fc):
         )
         if r.state == "running" and _squeue_num_jobs() == 1:
             break
-        time.sleep(5)
         r = fc.sr_post("runStatus", r.nextRequest)
-    else:
-        pkfail("failed to start running in sirepo and slurm reply={}", r)
     r = fc.sr_post("runCancel", r.nextRequest)
-    for _ in range(5):
+    for _ in fc.sr_iter_sleep("slurm", "runCancel"):
         if _squeue_num_jobs() == 0:
             break
-        time.sleep(5)
-    else:
-        pkfail("runCancel: failed to cancel in slurm")
 
 
 def test_srw_data_file(fc):


### PR DESCRIPTION
 - In the cancel case we don't have fields like simulationType. We just have opId's to cancel. So, we can't construct userDir. But, we don't need userDir (or runDir, sbatchCores, etc) in the cancel case (or for any non SLOT_OPS). So, only add those fields when not SLOT_OP.
- Add a check inside of the job_agent for op_name to keep job_driver.sbatch and job_agent in sync. job_agent._Cmd's require fields like runDir.
- Add a test for sbatch cancel which wasn't covered previously.