### PR TITLE
Fix #7111: Make api_notFound capable of handling any args

### DIFF
--- a/sirepo/server.py
+++ b/sirepo/server.py
@@ -364,7 +364,7 @@ class API(sirepo.quest.API):
         return self._save_new_and_reply(req, d)
 
     @sirepo.quest.Spec("allow_visitor")
-    async def api_notFound(self):
+    async def api_notFound(self, *args, **kwargs):
         raise sirepo.util.NotFound("app forced not found (uri parsing error)")
 
     @sirepo.quest.Spec(

--- a/tests/uri_router_test.py
+++ b/tests/uri_router_test.py
@@ -56,7 +56,7 @@ def test_not_found(fc):
     from pykern.pkdebug import pkdp
     from pykern.pkunit import pkeq
 
-    for uri in ("/some random uri", "/srw/wrong-param", "/export-archive"):
+    for uri in ("/some random uri", "/srw/wrong-param", "/export-archive/"):
         fc.sr_get(uri).assert_http_status(404)
 
 


### PR DESCRIPTION
    In the case where we can't correctly parse a uri (ex unknown uri
    or required params missing) then we default to api_notFound but
    still pass through the args from the original route. So, make
    api_notFound capable of handling any args and just ignoring them.