### PR TITLE
fix #7117 zpre simulation now runs with material temperature

### DIFF
--- a/sirepo/package_data/static/json/openmc-schema.json
+++ b/sirepo/package_data/static/json/openmc-schema.json
@@ -78,6 +78,8 @@
         ],
         "MaterialLibrary": [
             ["ENDFB-7.1-NNDC", "ENDFB-7.1-NNDC"],
+            ["ENDFB-8.0-NNDC", "ENDFB-8.0-NNDC"],
+            ["FENDL-3.1d", "FENDL-3.1d"],
             ["TENDL-2019", "TENDL-2019"]
         ],
         "Particle": [

--- a/sirepo/package_data/template/openmc/examples/zpre.json
+++ b/sirepo/package_data/template/openmc/examples/zpre.json
@@ -76,7 +76,7 @@
         "settings": {
             "batches": 1,
             "inactive": 0,
-            "materialLibrary": "TENDL-2019",
+            "materialLibrary": "ENDFB-8.0-NNDC",
             "particles": 10000,
             "photon_transport": "0",
             "run_mode": "eigenvalue",

--- a/sirepo/package_data/template/openmc/parameters.py.jinja
+++ b/sirepo/package_data/template/openmc/parameters.py.jinja
@@ -48,6 +48,9 @@ def create_settings():
     settings.batches = {{ settings_batches }}
     settings.inactive = {{ settings_inactive }}
     settings.particles = {{ settings_particles }}
+    settings.temperature = dict(
+        method='interpolation',
+    )
 {% if settings_varianceReduction == "weight_windows_mesh" or settings_varianceReduction == "weight_windows_tally" %}
     settings.max_splits = {{ settings_max_splits }}
 {% endif %}


### PR DESCRIPTION
- Added additional material library choices: ENDFB-8.0-NNDC and FENDL-3.1d
- Use temperature.method "interpolation"
- Update zpre example to use the ENDFB-8.0-NNDC which has multiple temperatures