### PR TITLE
Fix radiasoft/raydata#176: remove ability to create new simulations

### DIFF
--- a/sirepo/package_data/static/html/simulations.html
+++ b/sirepo/package_data/static/html/simulations.html
@@ -57,7 +57,7 @@
               <div style="display: inline-block"><a href data-ng-click="simulations.openItem(item)"><span data-ng-class="{ 'sr-user-item': ! simulations.fileManager.isItemExample(item) }">{{ item.name | simulationName | limitTo: 60 }}</span></a> <span data-sr-tooltip="{{ item.notes }}"><span></div>
               <ul class="dropdown-menu">
                 <li><a href data-ng-click="simulations.openItem(item)"><span class="glyphicon sr-nav-icon" data-ng-class="{'glyphicon-folder-open': item.isFolder, 'glyphicon-open-file': ! item.isFolder}"></span> Open</a></li>
-                <li data-ng-if="! item.isFolder"><a href data-ng-click="simulations.copyItem(item)"><span class="glyphicon glyphicon-duplicate sr-nav-icon"></span> Open as a New Copy</a></li>
+                <li data-ng-if="! item.isFolder && simulations.canCreateNewSimulation()"><a href data-ng-click="simulations.copyItem(item)"><span class="glyphicon glyphicon-duplicate sr-nav-icon"></span> Open as a New Copy</a></li>
                 <li data-ng-if="! simulations.fileManager.isItemExample(item)"><a href data-ng-click="simulations.renameItem(item)"><span class="glyphicon glyphicon-edit sr-nav-icon"></span> Rename</a></li>
                 <li data-ng-if="! simulations.fileManager.isItemExample(item)"><a href data-ng-click="simulations.moveItem(item)"><span class="glyphicon glyphicon-arrow-right sr-nav-icon"></span> Move</a></li>
                 <li data-ng-if="item.canExport"><a data-ng-href="{{ simulations.exportArchiveUrl(item, 'zip') }}"><span class="glyphicon glyphicon-save-file sr-nav-icon"></span> Export as Zip</a></li>

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -237,15 +237,16 @@ SIREPO.app.directive('getStarted', function(browserStorage, stringsService) {
                 <span>
                     <div class="text-center"><strong>Welcome to Sirepo - ${SIREPO.APP_SCHEMA.appInfo[SIREPO.APP_SCHEMA.simulationType].longName}!</strong></div>
                     Below are some example ${SIREPO.APP_SCHEMA.strings.simulationDataTypePlural}
-                    and folders containing ${SIREPO.APP_SCHEMA.strings.simulationDataTypePlural}
+                    and folders containing ${SIREPO.APP_SCHEMA.strings.simulationDataTypePlural}.
                     Click on the ${SIREPO.APP_SCHEMA.strings.simulationDataType}
                     to open and view the ${SIREPO.APP_SCHEMA.strings.simulationDataType} results.
-                    You can create a new ${SIREPO.APP_SCHEMA.strings.simulationDataType}
-                    by selecting the "${stringsService.newSimulationLabel()}" link above.
+                    <span data-ng-if="SIREPO.APP_SCHEMA.constants.canCreateNewSimulation">You can create a new ${SIREPO.APP_SCHEMA.strings.simulationDataType}
+                    by selecting the "${stringsService.newSimulationLabel()}" link above.</span>
                 </span>
             </div>
         `,
         controller: function($scope) {
+	    $scope.SIREPO = SIREPO;
             const storageKey = 'getStarted';
             let isActive = true;
 
@@ -2569,7 +2570,7 @@ SIREPO.app.directive('appHeaderRight', function(appDataService, authState, appSt
                 </li>
               </ul>
               <ul class="nav navbar-nav" data-ng-show="nav.isActive('simulations')">
-                <li class="sr-new-simulation-item"><a href data-ng-click="showSimulationModal()"><span
+                <li data-ng-if="SIREPO.APP_SCHEMA.constants.canCreateNewSimulation" class="sr-new-simulation-item"><a href data-ng-click="showSimulationModal()"><span
                         class="glyphicon glyphicon-plus sr-small-icon"></span><span class="glyphicon glyphicon-file"></span>
                   {{ newSimulationLabel() }}</a></li>
                 <li><a href data-ng-click="showNewFolderModal()"><span class="glyphicon glyphicon-plus sr-small-icon"></span><span
@@ -2589,7 +2590,7 @@ SIREPO.app.directive('appHeaderRight', function(appDataService, authState, appSt
                             class="glyphicon glyphicon-exclamation-sign"></span> Report a Bug</a></li>
                     <li data-help-link="helpUserManualURL" data-title="User Manual" data-icon="list-alt"></li>
                     <li data-help-link="helpUserForumURL" data-title="User Forum" data-icon="globe"></li>
-                    <li data-ng-if="showLink" data-help-link="helpVideoURL" data-title="Instructional Video" data-icon="film"></li>
+                    <li data-ng-if="SIREPO.APP_SCHEMA.feature_config.show_video_links" data-help-link="helpVideoURL" data-title="Instructional Video" data-icon="film"></li>
                   </ul>
                 </li>
               </ul>
@@ -2612,7 +2613,7 @@ SIREPO.app.directive('appHeaderRight', function(appDataService, authState, appSt
         controller: function($scope, stringsService) {
             $scope.authState = authState;
             $scope.slackUri = $scope.authState.slackUri;
-            $scope.showLink = SIREPO.APP_SCHEMA.feature_config.show_video_links;
+	    $scope.SIREPO = SIREPO;
             $scope.modeIsDefault = function () {
                 return appDataService.isApplicationMode('default');
             };
@@ -3726,6 +3727,9 @@ SIREPO.app.directive('simConversionModal', function(appState, requestSender) {
             </div>
         `,
         controller: function($scope) {
+	    if (SIREPO.APP_SCHEMA.constants.canCreateNewSimulation) {
+		throw new Error(`SIREPO.APP_SCHEMA.constants.canCreateNewSimulation=${SIREPO.APP_SCHEMA.constants.canCreateNewSimulation} but adding simConversionModal`);
+	    }
             $scope.newSimURL = false;
             $scope.title = $scope.convMethod == 'create_shadow_simulation' ? 'Shadow' : 'SRW';
 

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -4801,7 +4801,7 @@ SIREPO.app.controller('SimulationsController', function (appState, browserStorag
 
     self.canCreateNewSimulation = () => {
 	return SIREPO.APP_SCHEMA.constants.canCreateNewSimulation;
-    }
+    };
 
     self.canDelete = function(item) {
         if (item.isFolder) {

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -924,7 +924,7 @@ SIREPO.app.factory('appDataService', function() {
         return self.applicationMode;
     };
     self.canCopy = function() {
-        return true;
+	return SIREPO.APP_SCHEMA.constants.canCreateNewSimulation;
     };
     return self;
 });
@@ -4797,6 +4797,10 @@ SIREPO.app.controller('SimulationsController', function (appState, browserStorag
                 });
                 self.selectedItem = null;
             });
+    }
+
+    self.canCreateNewSimulation = () => {
+	return SIREPO.APP_SCHEMA.constants.canCreateNewSimulation;
     }
 
     self.canDelete = function(item) {

--- a/sirepo/package_data/static/json/raydata-schema.json
+++ b/sirepo/package_data/static/json/raydata-schema.json
@@ -5,6 +5,7 @@
         }
     },
     "constants": {
+	"canCreateNewSimulation": false,
 	"canDownloadInputFile": false,
 	"canExportArchive": false,
         "canShowDocumentationUrl": false,
@@ -82,8 +83,8 @@
     },
     "strings": {
         "completionState": "",
-        "simulationDataType": "notebook",
-        "simulationDataTypePlural": "notebooks",
+        "simulationDataType": "analysis",
+        "simulationDataTypePlural": "analyses",
         "typeOfSimulation": "poll"
     },
     "view": {

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -200,6 +200,7 @@
             }
         },
         "constants": {
+	    "canCreateNewSimulation": true,
             "canDownloadInputFile": true,
             "canExportArchive": true,
             "canShowDocumentationUrl": true,


### PR DESCRIPTION
It doesn't make sense for the Raydata app to create new simulations.

Also, rename "notebook" to "analysis" which fits the app better.