### PR TITLE
fix #7326 set multiElectronAnimation.watchpointId for examples

### DIFF
--- a/sirepo/package_data/template/srw/examples/bending-magnet-radiation.json
+++ b/sirepo/package_data/template/srw/examples/bending-magnet-radiation.json
@@ -294,6 +294,5 @@
             "verticalSymmetry": -1
         }
     },
-    "report": "powerDensityReport",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/boron_fiber_3lenses.json
+++ b/sirepo/package_data/template/srw/examples/boron_fiber_3lenses.json
@@ -243,7 +243,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 6
         },
         "multipole": {
             "distribution": "n",

--- a/sirepo/package_data/template/srw/examples/boron_fiber_4lenses.json
+++ b/sirepo/package_data/template/srw/examples/boron_fiber_4lenses.json
@@ -243,7 +243,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 6
         },
         "multipole": {
             "distribution": "n",

--- a/sirepo/package_data/template/srw/examples/circular-aperture.json
+++ b/sirepo/package_data/template/srw/examples/circular-aperture.json
@@ -215,7 +215,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 6
         },
         "multipole": {
             "distribution": "n",
@@ -543,6 +543,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport6",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/crl-example.json
+++ b/sirepo/package_data/template/srw/examples/crl-example.json
@@ -216,7 +216,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 3
         },
         "multipole": {
             "distribution": "n",
@@ -438,6 +438,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport3",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/double-crystal-monochromator-selecting.json
+++ b/sirepo/package_data/template/srw/examples/double-crystal-monochromator-selecting.json
@@ -255,7 +255,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 4
         },
         "multipole": {
             "distribution": "n",
@@ -526,6 +526,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport4",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/double-crystal-monochromator-truncating.json
+++ b/sirepo/package_data/template/srw/examples/double-crystal-monochromator-truncating.json
@@ -255,7 +255,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 4
         },
         "multipole": {
             "distribution": "n",
@@ -526,6 +526,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport4",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/focusing-bending-magnet.json
+++ b/sirepo/package_data/template/srw/examples/focusing-bending-magnet.json
@@ -208,7 +208,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": 30,
-            "watchpointId": 0
+            "watchpointId": 5
         },
         "multipole": {
             "distribution": "n",
@@ -481,6 +481,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "powerDensityReport",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/gaussian-x-ray-beam-through-imperfect-mirrors.json
+++ b/sirepo/package_data/template/srw/examples/gaussian-x-ray-beam-through-imperfect-mirrors.json
@@ -287,7 +287,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": 1.75601622,
-            "watchpointId": 0
+            "watchpointId": 9
         },
         "multipole": {
             "distribution": "n",
@@ -720,6 +720,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport10",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/gaussian-x-ray-beam-through-perfect-crl.json
+++ b/sirepo/package_data/template/srw/examples/gaussian-x-ray-beam-through-perfect-crl.json
@@ -239,7 +239,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": 1,
-            "watchpointId": 0
+            "watchpointId": 5
         },
         "multipole": {
             "distribution": "n",
@@ -604,6 +604,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "gaussianBeamIntensityReport",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/lcls-sxr-simplified.json
+++ b/sirepo/package_data/template/srw/examples/lcls-sxr-simplified.json
@@ -248,7 +248,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": 10,
-            "watchpointId": 0
+            "watchpointId": 5
         },
         "multipole": {
             "distribution": "n",
@@ -614,6 +614,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport11",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/lcls-sxr.json
+++ b/sirepo/package_data/template/srw/examples/lcls-sxr.json
@@ -298,7 +298,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": 10,
-            "watchpointId": 0
+            "watchpointId": 5
         },
         "multipole": {
             "distribution": "n",
@@ -737,6 +737,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport5",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/lens-slit-obstacle.json
+++ b/sirepo/package_data/template/srw/examples/lens-slit-obstacle.json
@@ -230,7 +230,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "1",
-            "watchpointId": 0
+            "watchpointId": 8
         },
         "multipole": {
             "distribution": "n",
@@ -584,6 +584,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport8",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/mask_example.json
+++ b/sirepo/package_data/template/srw/examples/mask_example.json
@@ -270,7 +270,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 11
         },
         "multipole": {
             "distribution": "n",

--- a/sirepo/package_data/template/srw/examples/nsls-ii-chx-beamline-tab.json
+++ b/sirepo/package_data/template/srw/examples/nsls-ii-chx-beamline-tab.json
@@ -316,7 +316,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 11
         },
         "multipole": {
             "distribution": "n",
@@ -864,6 +864,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport11",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/nsls-ii-chx-beamline.json
+++ b/sirepo/package_data/template/srw/examples/nsls-ii-chx-beamline.json
@@ -315,7 +315,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 11
         },
         "multipole": {
             "distribution": "n",
@@ -854,6 +854,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "powerDensityReport",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/nsls-ii-esm-beamline-tab.json
+++ b/sirepo/package_data/template/srw/examples/nsls-ii-esm-beamline-tab.json
@@ -344,7 +344,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 12
         },
         "multipole": {
             "distribution": "n",

--- a/sirepo/package_data/template/srw/examples/nsls-ii-esm-beamline.json
+++ b/sirepo/package_data/template/srw/examples/nsls-ii-esm-beamline.json
@@ -338,18 +338,13 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 12
         },
         "multipole": {
             "distribution": "n",
             "field": 0.4,
             "length": 3,
             "order": 1
-        },
-        "panelState": {
-            "hidden": [
-                "watchpointReport14"
-            ]
         },
         "postPropagation": [
             0,
@@ -887,6 +882,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport12",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/nsls-ii-fmx-beamline-tab.json
+++ b/sirepo/package_data/template/srw/examples/nsls-ii-fmx-beamline-tab.json
@@ -291,7 +291,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 7
         },
         "multipole": {
             "distribution": "n",
@@ -301,9 +301,7 @@
         },
         "panelState": {
             "hidden": [
-                "fluxReport",
-                "watchpointReport8",
-                "watchpointReport9"
+                "fluxReport"
             ]
         },
         "postPropagation": [
@@ -722,6 +720,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport7",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/nsls-ii-fmx-beamline.json
+++ b/sirepo/package_data/template/srw/examples/nsls-ii-fmx-beamline.json
@@ -291,7 +291,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 7
         },
         "multipole": {
             "distribution": "n",
@@ -301,9 +301,7 @@
         },
         "panelState": {
             "hidden": [
-                "fluxReport",
-                "watchpointReport8",
-                "watchpointReport9"
+                "fluxReport"
             ]
         },
         "postPropagation": [
@@ -721,6 +719,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport7",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/nsls-ii-hxn-beamline-ssa-closer.json
+++ b/sirepo/package_data/template/srw/examples/nsls-ii-hxn-beamline-ssa-closer.json
@@ -405,7 +405,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 14
         },
         "multipole": {
             "distribution": "n",
@@ -1167,6 +1167,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "initialIntensityReport",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/nsls-ii-hxn-beamline.json
+++ b/sirepo/package_data/template/srw/examples/nsls-ii-hxn-beamline.json
@@ -405,7 +405,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 14
         },
         "multipole": {
             "distribution": "n",
@@ -1155,6 +1155,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "initialIntensityReport",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/nsls-ii-smi-beamline.json
+++ b/sirepo/package_data/template/srw/examples/nsls-ii-smi-beamline.json
@@ -373,7 +373,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": 2,
-            "watchpointId": 0
+            "watchpointId": 19
         },
         "multipole": {
             "distribution": "n",
@@ -383,13 +383,10 @@
         },
         "panelState": {
             "hidden": [
-                "watchpointReport1",
                 "intensityReport",
                 "powerDensityReport",
                 "sourceIntensityReport",
-                "fluxReport",
-                "watchpointReport14",
-                "watchpointReport17"
+                "fluxReport"
             ]
         },
         "postPropagation": [

--- a/sirepo/package_data/template/srw/examples/nsls-ii-srx-beamline.json
+++ b/sirepo/package_data/template/srw/examples/nsls-ii-srx-beamline.json
@@ -377,7 +377,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 11
         },
         "multipole": {
             "distribution": "n",
@@ -1030,6 +1030,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "initialIntensityReport",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/polarization-of-bending-magnet.json
+++ b/sirepo/package_data/template/srw/examples/polarization-of-bending-magnet.json
@@ -210,7 +210,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": 8,
-            "watchpointId": 0
+            "watchpointId": 7
         },
         "multipole": {
             "distribution": "n",
@@ -549,6 +549,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "powerDensityReport",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/sample-from-image.json
+++ b/sirepo/package_data/template/srw/examples/sample-from-image.json
@@ -226,7 +226,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 3
         },
         "multipole": {
             "distribution": "n",
@@ -449,6 +449,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "initialIntensityReport",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/slit-obstacle.json
+++ b/sirepo/package_data/template/srw/examples/slit-obstacle.json
@@ -220,7 +220,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "1",
-            "watchpointId": 0
+            "watchpointId": 8
         },
         "multipole": {
             "distribution": "n",
@@ -534,6 +534,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "watchpointReport8",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/tabulated-undulator.json
+++ b/sirepo/package_data/template/srw/examples/tabulated-undulator.json
@@ -203,7 +203,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "0.6",
-            "watchpointId": 0
+            "watchpointId": 3
         },
         "multipole": {
             "distribution": "n",
@@ -424,6 +424,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "intensityReport",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/two-slit-interferometer.json
+++ b/sirepo/package_data/template/srw/examples/two-slit-interferometer.json
@@ -230,7 +230,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": "1",
-            "watchpointId": 0
+            "watchpointId": 7
         },
         "multipole": {
             "distribution": "n",
@@ -555,19 +555,6 @@
             "verticalInitialPhase": 0,
             "verticalSymmetry": -1
         },
-        "watchpointReport4": {
-            "aspectRatio": "1",
-            "characteristic": 0,
-            "colorMap": "grayscale",
-            "fieldUnits": "1",
-            "intensityPlotsWidth": "0",
-            "notes": "",
-            "plotScale": "linear",
-            "polarization": 6,
-            "precision": 0.01,
-            "rotateAngle": 0,
-            "rotateReshape": "1"
-        },
         "watchpointReport6": {
             "aspectRatio": "1",
             "characteristic": 0,
@@ -593,21 +580,7 @@
             "precision": 0.01,
             "rotateAngle": 0,
             "rotateReshape": "1"
-        },
-        "watchpointReport8": {
-            "aspectRatio": "1",
-            "characteristic": 0,
-            "colorMap": "grayscale",
-            "fieldUnits": "1",
-            "intensityPlotsWidth": "0",
-            "notes": "",
-            "plotScale": "linear",
-            "polarization": 6,
-            "precision": 0.01,
-            "rotateAngle": 0,
-            "rotateReshape": "1"
         }
     },
-    "report": "intensityReport",
     "simulationType": "srw"
 }

--- a/sirepo/package_data/template/srw/examples/vls-grating.json
+++ b/sirepo/package_data/template/srw/examples/vls-grating.json
@@ -302,7 +302,7 @@
             "stokesParameter": "0",
             "verticalPosition": 0,
             "verticalRange": 20,
-            "watchpointId": 0
+            "watchpointId": 10
         },
         "multipole": {
             "distribution": "n",
@@ -801,6 +801,5 @@
             "rotateReshape": "1"
         }
     },
-    "report": "intensityReport",
     "simulationType": "srw"
 }

--- a/tests/animation_test.py
+++ b/tests/animation_test.py
@@ -115,7 +115,6 @@ def test_srw(fc):
     data = fc.sr_sim_data("Young's Double Slit Experiment")
     data.models.multiElectronAnimation.pkupdate(
         numberOfMacroElectrons=4,
-        watchpointId=7,
     )
     data.models.simulation.sampleFactor = 0.0001
     fc.sr_animation_run(


### PR DESCRIPTION
This backs out the change to animation_test.test_srw() and makes sure all examples have a valid multiElectronAnimation.watchpointId set.