### PR TITLE
Fix #6914 job_agent recover existing sbatch jobs

### DIFF
--- a/etc/run-server.sh
+++ b/etc/run-server.sh
@@ -6,7 +6,7 @@ export SIREPO_SMTP_PASSWORD='n/a'
 # POSIT: same as sirepo.smtp.DEV_SMTP_SERVER
 export SIREPO_SMTP_SERVER='dev'
 export SIREPO_SMTP_USER='n/a'
-export SIREPO_MPI_CORES=2
+export SIREPO_MPI_CORES=${SIREPO_MPI_CORES:-2}
 case ${1:-} in
     docker)
         # POSIT: run-supervisor.sh

--- a/etc/run-supervisor.sh
+++ b/etc/run-supervisor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 export PYKERN_PKDEBUG_WANT_PID_TIME=1
-export SIREPO_MPI_CORES=2
+export SIREPO_MPI_CORES=${SIREPO_MPI_CORES:-2}
 docker_image="radiasoft/sirepo:dev"
 case ${1:-} in
     docker)
@@ -43,8 +43,8 @@ radia_run redhat-docker
     sbatch)
         export SIREPO_JOB_DRIVER_MODULES=local:sbatch
         export SIREPO_JOB_DRIVER_SBATCH_HOST=${2:-localhost}
-        export SIREPO_JOB_DRIVER_SBATCH_CORES=2
-        export SIREPO_JOB_DRIVER_SBATCH_NODES=1
+        export SIREPO_JOB_DRIVER_SBATCH_CORES=${SIREPO_JOB_DRIVER_SBATCH_CORES:-2}
+        export SIREPO_JOB_DRIVER_SBATCH_NODES=${SIREPO_JOB_DRIVER_SBATCH_NODES:-1}
         if [[ $SIREPO_JOB_DRIVER_SBATCH_HOST =~ ^(localhost|$(hostname --fqdn)) ]]; then
             if [[ $(type -t sbatch) == '' ]]; then
                 echo 'slurm not installed. You need to run:
@@ -53,8 +53,6 @@ radia_run slurm-dev
 '
                 exit 1
             fi
-        else
-            export SIREPO_JOB_DRIVER_SBATCH_CORES=4
         fi
         export SIREPO_JOB_DRIVER_SBATCH_SIREPO_CMD=$(pyenv which sirepo)
         export SIREPO_JOB_DRIVER_SBATCH_SRDB_ROOT='/var/tmp/{sbatch_user}/sirepo'

--- a/sirepo/const.py
+++ b/sirepo/const.py
@@ -6,7 +6,6 @@
 
 import asyncio
 from pykern.pkcollections import PKDict
-import pykern.pkio
 
 ASYNC_CANCELED_ERROR = asyncio.CancelledError
 
@@ -55,5 +54,5 @@ SRUNIT_USER_AGENT = "srunit/1.0"
 
 TEST_PORT_RANGE = range(10000, 20000)
 
-#: hardwired root of development src tree
-DEV_SRC_RADIASOFT_DIR = pykern.pkio.py_path("~/src/radiasoft/")
+#: hardwired root of development src tree; Not a py.path, because must defer tilde evaluation
+DEV_SRC_RADIASOFT_DIR = "~/src/radiasoft/"

--- a/sirepo/const.py
+++ b/sirepo/const.py
@@ -53,7 +53,7 @@ SIM_DATA_BASENAME = "sirepo-data" + JSON_SUFFIX
 
 SRUNIT_USER_AGENT = "srunit/1.0"
 
-TEST_PORT_RANGE = range(10000, 11000)
+TEST_PORT_RANGE = range(10000, 20000)
 
 #: hardwired root of development src tree
 DEV_SRC_RADIASOFT_DIR = pykern.pkio.py_path("~/src/radiasoft/")

--- a/sirepo/const.py
+++ b/sirepo/const.py
@@ -50,6 +50,9 @@ SCHEMA_COMMON = PKDict(
 #: Simulation file name saved both in sim db and run directory
 SIM_DATA_BASENAME = "sirepo-data" + JSON_SUFFIX
 
+#: Simulation file name saved both in sim db and run directory
+SIM_RUN_INPUT_BASENAME = "in" + JSON_SUFFIX
+
 SRUNIT_USER_AGENT = "srunit/1.0"
 
 TEST_PORT_RANGE = range(10000, 20000)

--- a/sirepo/exporter.py
+++ b/sirepo/exporter.py
@@ -43,9 +43,10 @@ def _create_zip(sim, out_dir, qcall):
     """
     path = out_dir.join(sim.id + ".zip")
     data = simulation_db.open_json_file(sim.type, sid=sim.id, qcall=qcall)
-    simulation_db.update_rsmanifest(data)
+    s = sim_data.get_class(data)
+    data = s.sim_run_input_fixup(data)
     data.pkdel("report")
-    files = sim_data.get_class(data).lib_files_for_export(data, qcall=qcall)
+    files = s.lib_files_for_export(data, qcall=qcall)
     for f in _run_file(data, sim, qcall):
         files.append(f)
     with sirepo.util.write_zip(str(path)) as z:

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -222,7 +222,7 @@ def _init():
             "Trust Bash env to run Python and agents",
         ),
         ui_websocket=(
-            pkconfig.in_dev_mode(),
+            True,
             bool,
             "whether the UI should use a websocket",
         ),

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -390,7 +390,6 @@ class API(sirepo.quest.API):
                     continue
                 assert m[f] > 0, f"{f}={m[f]} must be greater than 0"
                 c[f] = m[f]
-            pkdp("cores={}", c.sbatchCores)
             return request_content
 
         d = kwargs.pkdel("req_data")

--- a/sirepo/job_api.py
+++ b/sirepo/job_api.py
@@ -390,6 +390,7 @@ class API(sirepo.quest.API):
                     continue
                 assert m[f] > 0, f"{f}={m[f]} must be greater than 0"
                 c[f] = m[f]
+            pkdp("cores={}", c.sbatchCores)
             return request_content
 
         d = kwargs.pkdel("req_data")

--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -170,7 +170,7 @@ class DriverBase(PKDict):
             return
         pkdlog("unknown agent, sending kill; msg={}", msg)
         try:
-            msg.handler.write_message(PKDict(opName=job.OP_KILL))
+            msg.handler.write_message(PKDict(opName=job.OP_KILL), binary=True)
         except tornado.websocket.WebSocketClosedError:
             pkdlog("websocket closed {} from unknown agent", self)
         except Exception as e:
@@ -179,7 +179,7 @@ class DriverBase(PKDict):
     def send(self, op):
         pkdlog("{} {} runDir={}", self, op, op.msg.get("runDir"))
         try:
-            self._websocket.write_message(pkjson.dump_bytes(op.msg))
+            self._websocket.write_message(pkjson.dump_bytes(op.msg), binary=True)
             return True
         except tornado.websocket.WebSocketClosedError:
             pkdlog("websocket closed op={}", op)

--- a/sirepo/job_driver/__init__.py
+++ b/sirepo/job_driver/__init__.py
@@ -324,7 +324,9 @@ class DriverBase(PKDict):
         if self._websocket:
             if self._websocket != msg.handler:
                 self._websocket = None
-                raise AssertionError(pkdformat("unexpected incoming msg.content={}", msg.content))
+                raise AssertionError(
+                    pkdformat("unexpected incoming msg.content={}", msg.content)
+                )
         else:
             self._websocket = msg.handler
         self._websocket_ready.set()

--- a/sirepo/job_driver/docker.py
+++ b/sirepo/job_driver/docker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """TODO(e-carlin): Doc
 
 :copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.

--- a/sirepo/job_driver/docker.py
+++ b/sirepo/job_driver/docker.py
@@ -3,6 +3,7 @@
 :copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+
 from __future__ import absolute_import, division, print_function
 from pykern import pkconfig, pkio
 from pykern.pkcollections import PKDict

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -142,7 +142,9 @@ class SbatchDriver(job_driver.DriverBase):
                     ["sbatchNodes", self.cfg.nodes],
                 ]:
                     if f in m and c:
+                        pkdp([m[f], c])
                         m[f] = min(m[f], c)
+                pkdp("cores={}", m.sbatchCores)
                 m.mpiCores = m.sbatchCores
             m.shifterImage = self.cfg.shifter_image
         return await super().prepare_send(op)
@@ -191,9 +193,10 @@ class SbatchDriver(job_driver.DriverBase):
             try:
                 if not before_start:
                     await tornado.gen.sleep(self.cfg.agent_log_read_sleep)
+                f = f"{agent_start_dir}/{log_file}"
                 async with connection.create_process(
                     # test is a shell-builtin so no abs path
-                    f"test -e {agent_start_dir}/{log_file} && /bin/cat {agent_start_dir}/{log_file}"
+                    f"test -e {f} && /bin/tail --lines=200 {f}"
                 ) as p:
                     o, e = await p.communicate()
                     _write_to_log(

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -193,8 +193,9 @@ class SbatchDriver(job_driver.DriverBase):
                     await tornado.gen.sleep(self.cfg.agent_log_read_sleep)
                 f = f"{agent_start_dir}/{log_file}"
                 async with connection.create_process(
-                    # test is a shell-builtin so no abs path
-                    f"test -e {f} && /bin/tail --lines=200 {f}"
+                    # test is a shell-builtin so no abs path. tail varies in
+                    # location. can trust that it will be in the path
+                    f"test -e {f} && tail --lines=200 {f}"
                 ) as p:
                     o, e = await p.communicate()
                     _write_to_log(

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -70,7 +70,6 @@ class SbatchDriver(job_driver.DriverBase):
         except Exception as e:
             pkdlog("{} error={} stack={}", self, e, pkdexc())
 
-
     @classmethod
     def get_instance(cls, op):
         u = op.msg.uid

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -22,6 +22,8 @@ import sirepo.util
 import tornado.gen
 import tornado.ioloop
 
+_RUN_DIR_OPS = job.SLOT_OPS.union((job.OP_RUN_STATUS,))
+
 
 class SbatchDriver(job_driver.DriverBase):
     cfg = None
@@ -107,6 +109,17 @@ class SbatchDriver(job_driver.DriverBase):
         return True
 
     async def prepare_send(self, op):
+        def _add_dirs(msg):
+            msg.userDir = "/".join(
+                (
+                    str(self._srdb_root),
+                    sirepo.simulation_db.USER_ROOT_DIR,
+                    self.uid,
+                )
+            )
+            msg.runDir = "/".join((msg.userDir, msg.simulationType, msg.computeJid))
+            return msg
+
         m = op.msg
         c = m.pkdel("sbatchCredentials")
         if self._srdb_root is None or c:
@@ -117,16 +130,9 @@ class SbatchDriver(job_driver.DriverBase):
             self._srdb_root = self.cfg.srdb_root.format(
                 sbatch_user=self._creds.username,
             )
-        if op.op_name in job.SLOT_OPS:
-            m.userDir = "/".join(
-                (
-                    str(self._srdb_root),
-                    sirepo.simulation_db.USER_ROOT_DIR,
-                    self.uid,
-                )
-            )
-            m.runDir = "/".join((m.userDir, m.simulationType, m.computeJid))
-            if op.op_name == job.OP_RUN:
+        if op.op_name in _RUN_DIR_OPS:
+            _add_dirs(m)
+            if op.op_name == job.OP_RUN and op.msg.jobCmd == job.CMD_COMPUTE:
                 assert m.sbatchHours
                 for f, c in [
                     ["sbatchCores", self.cfg.cores],
@@ -147,39 +153,27 @@ class SbatchDriver(job_driver.DriverBase):
         )
 
     async def _do_agent_start(self, op):
-        # must be saved, because op is only valid before first await
-        original_msg = op.msg
-        log_file = "job_agent.log"
-        agent_start_dir = self._srdb_root
-        script = f"""#!/bin/bash
-{self._agent_start_dev()}
-set -e
-mkdir -p '{agent_start_dir}'
-cd '{self._srdb_root}'
-{self._agent_env(op)}
-(/usr/bin/env; setsid {self.cfg.sirepo_cmd} job_agent start_sbatch) >& {log_file} &
-disown
-"""
 
-        def write_to_log(stdout, stderr, filename):
-            p = pkio.py_path(self._local_user_dir).join("agent-sbatch", self.cfg.host)
-            pkio.mkdir_parent(p)
-            f = p.join(
-                f'{datetime.datetime.now().strftime("%Y%m%d%H%M%S")}-{filename}.log'
+        def _creds():
+            return PKDict(
+                known_hosts=self._KNOWN_HOSTS,
+                password=(
+                    self._creds.password + self._creds.otp
+                    if "nersc" in self.cfg.host
+                    else self._creds.password
+                ),
+                username=self._creds.username,
             )
-            r = pkjson.dump_pretty(PKDict(stdout=stdout, stderr=stderr, filename=f), f)
-            if pkconfig.in_dev_mode():
-                pkdlog(r)
 
-        async def get_agent_log(connection, before_start=True):
+        async def _get_agent_log(connection, before_start=True):
             try:
                 if not before_start:
                     await tornado.gen.sleep(self.cfg.agent_log_read_sleep)
                 async with connection.create_process(
-                    f"/bin/cat {agent_start_dir}/{log_file}"
+                    f"/bin/test -e {agent_start_dir}/{log_file} && /bin/cat {agent_start_dir}/{log_file}"
                 ) as p:
                     o, e = await p.communicate()
-                    write_to_log(
+                    _write_to_log(
                         o, e, f"remote-{'before' if before_start else 'after'}-start"
                     )
             except Exception as e:
@@ -190,27 +184,43 @@ disown
                     pkdexc(),
                 )
 
+        def _write_to_log(stdout, stderr, filename):
+            p = pkio.py_path(self._local_user_dir).join("agent-sbatch", self.cfg.host)
+            pkio.mkdir_parent(p)
+            f = p.join(
+                f'{datetime.datetime.now().strftime("%Y%m%d%H%M%S")}-{filename}.log'
+            )
+            r = pkjson.dump_pretty(PKDict(stdout=stdout, stderr=stderr, filename=f), f)
+            if pkconfig.in_dev_mode():
+                pkdlog(r)
+
+        # must be saved, because op is only valid before first await
+        original_msg = op.msg
+        log_file = "job_agent.log"
+        agent_start_dir = self._srdb_root
+        if pkconfig.in_dev_mode():
+            pkdlog("agent_log={}/{}", agent_start_dir, log_file)
+        script = f"""#!/bin/bash
+{self._agent_start_dev()}
+set -e
+mkdir -p '{agent_start_dir}'
+cd '{self._srdb_root}'
+{self._agent_env(op)}
+(/usr/bin/env; setsid {self.cfg.sirepo_cmd} job_agent start_sbatch) &>> {log_file} &
+disown
+"""
         try:
-            async with asyncssh.connect(
-                self.cfg.host,
-                username=self._creds.username,
-                password=(
-                    self._creds.password + self._creds.otp
-                    if "nersc" in self.cfg.host
-                    else self._creds.password
-                ),
-                known_hosts=self._KNOWN_HOSTS,
-            ) as c:
+            async with asyncssh.connect(self.cfg.host, **_creds()) as c:
                 async with c.create_process("/bin/bash --noprofile --norc -l") as p:
-                    await get_agent_log(c, before_start=True)
+                    await _get_agent_log(c, before_start=True)
                     o, e = await p.communicate(input=script)
                     if o or e:
-                        write_to_log(o, e, "start")
+                        _write_to_log(o, e, "start")
                 self.driver_details.pkupdate(
                     host=self.cfg.host,
                     username=self._creds.username,
                 )
-                await get_agent_log(c, before_start=False)
+                await _get_agent_log(c, before_start=False)
         except Exception as e:
             pkdlog("error={} stack={}", e, pkdexc())
             self._srdb_root = None
@@ -228,9 +238,11 @@ disown
     def _agent_start_dev(self):
         if not pkconfig.in_dev_mode():
             return ""
-        res = """
-scancel -u $USER >& /dev/null || true
-"""
+        res = ""
+        # not valid with sbatch reattach_compute
+        #        res = """
+        # scancel -u $USER >& /dev/null || true
+        # """
         if self.cfg.shifter_image:
             res += (
                 "\n".join(

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -142,9 +142,7 @@ class SbatchDriver(job_driver.DriverBase):
                     ["sbatchNodes", self.cfg.nodes],
                 ]:
                     if f in m and c:
-                        pkdp([m[f], c])
                         m[f] = min(m[f], c)
-                pkdp("cores={}", m.sbatchCores)
                 m.mpiCores = m.sbatchCores
             m.shifterImage = self.cfg.shifter_image
         return await super().prepare_send(op)

--- a/sirepo/job_driver/sbatch.py
+++ b/sirepo/job_driver/sbatch.py
@@ -21,6 +21,7 @@ import sirepo.simulation_db
 import sirepo.util
 import tornado.gen
 import tornado.ioloop
+import tornado.websocket
 
 _RUN_DIR_OPS = job.SLOT_OPS.union((job.OP_RUN_STATUS,))
 
@@ -63,8 +64,12 @@ class SbatchDriver(job_driver.DriverBase):
         try:
             # hopefully the agent is nice and listens to the kill
             self._websocket.write_message(PKDict(opName=job.OP_KILL))
+        except tornado.websocket.WebSocketClosedError:
+            self._websocket = None
+            pkdlog("websocket closed {}", self)
         except Exception as e:
             pkdlog("{} error={} stack={}", self, e, pkdexc())
+
 
     @classmethod
     def get_instance(cls, op):

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -963,7 +963,7 @@ class _ComputeJob(_Supervisor):
 
         async def _valid_or_reply(force_run):
             if self._is_running_pending():
-                if self._req_is_valid(req):
+                if not self._req_is_valid(req):
                     return PKDict(
                         state=job.ERROR,
                         error="another browser is running the simulation",

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -85,6 +85,7 @@ _RUN_STATUS_FIELDS = (
     "isParallel",
     "jobRunMode",
     "simulationId",
+    "simulationType",
     "uid",
 )
 
@@ -1131,7 +1132,7 @@ class _ComputeJob(_Supervisor):
                     runDir=originating_req.content.runDir,
                     userDir=originating_req.content.userDir,
                 ),
-                runStatusPollSeconds=self.db.nextRequestSeconds,
+                nextRequestSeconds=self.db.nextRequestSeconds,
             )
 
         def _update_db(reply, op):

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -81,6 +81,7 @@ _NEXT_REQUEST_FIELDS = (
 _RUN_STATUS_FIELDS = (
     "computeJid",
     "computeJobSerial",
+    "computeModel",
     "isParallel",
     "jobRunMode",
     "uid",

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -84,6 +84,7 @@ _RUN_STATUS_FIELDS = (
     "computeModel",
     "isParallel",
     "jobRunMode",
+    "simulationId",
     "uid",
 )
 

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -1348,7 +1348,7 @@ class _Op(PKDict):
         self._reply_q.task_done()
         return r
 
-    def reply_put(self, reply_op_name, reply_content):
+    def reply_put(self, reply_content):
         self._reply_q.put_nowait(reply_content)
 
     def send(self):

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -1126,7 +1126,6 @@ class _ComputeJob(_Supervisor):
             r, k = await _send(o)
             if k:
                 if is_run_status_op and self._run_status_op == o:
-                    pkdp("free run_dir_slot {}", o)
                     o.run_dir_slot.free()
                 o = None
             return rv.pkupdate(reply=r)
@@ -1306,9 +1305,9 @@ class _Op(PKDict):
 
     def pkdebug_str(self):
         def _internal_error():
-            if not self.get("internal_error"):
-                return ""
-            return ", internal_error={self.internal_error}"
+            if e := self.get("internal_error"):
+                return f", internal_error={e}"
+            return ""
 
         return pkdformat(
             "_Op({}{}, {:.4}{})",

--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -971,7 +971,7 @@ class _ComputeJob(_Supervisor):
                 if force_run:
                     return PKDict(
                         state=job.ERROR,
-                        error="a simulation is already running, refresh the browser",
+                        error="simulation state unknown, refresh the browser",
                     )
                 # Not _receive_api_runStatus, because runStatus should have been
                 # called before this function is called.

--- a/sirepo/mpi.py
+++ b/sirepo/mpi.py
@@ -146,5 +146,4 @@ def _mpiexec_cmd():
 _cfg = pkconfig.init(
     cores=(1, int, "cores to use per run"),
     in_slurm=(False, bool, "True if being run by slurm"),
-    slaves=pkconfig.ReplacedBy("sirepo.mpi.cores"),
 )

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1195,7 +1195,7 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
 
     const _STATE_QUERIES = {
         ignoreSRException: (state) => {
-            return [_s_auth, _s_creds, _s_notNeeded, _s_status, _s_idle].includes(state);
+            return [_s_creds, _s_notNeeded, _s_status, _s_idle].includes(state);
         },
         isLoggedIn: (state) => {
             return state === _s_ok;
@@ -1287,7 +1287,7 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
         }
 
         transition() {
-            // debug (`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
+            srdbg(`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
             _state = this._newState;
             $rootScope.$broadcast('sbatchLoginEvent', this);
         }
@@ -1338,8 +1338,9 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
         // errors. Probably agent could be better coordinate with this. Could just be
         // a response to the auth request. Has to do with the internals of sbatch.py
         // which does not coordinate login.
-        if (self.query('ignoreSRException') && !(_state == _s_auth && r == _e_authMissing)) {
-            srlog('sbatchLoginService ignoring srException', srException, 'state', _state);
+        // TODO(robnagler) may need this !(_state == _s_auth && [_e_authMissing, _e_authError])
+        if (self.query('ignoreSRException')) {
+            srlog('sbatchLoginService ignoring srException', srException, 'state', _state, 'reason', r);
             return true;
         }
         //TODO(robnagler) an alternative is to broadcast an error.

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1,6 +1,11 @@
 'use strict';
-SIREPO.srlog = console.log.bind(console);
-SIREPO.srdbg = console.log.bind(console);
+SIREPO.srlog = (...args) => {
+    console.log(
+        (new Date().toISOString()).substring(11, 19),
+        ...args,
+    );
+};
+SIREPO.srdbg = SIREPO.srlog;
 SIREPO.traceWS = false;
 
 // No timeout for now (https://github.com/radiasoft/sirepo/issues/317)
@@ -1122,26 +1127,26 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
             [_e_authMissing]: _s_creds,
             [_e_authSuccess]: _s_ok,
             [_e_credsCancel]: _s_idle,
-            [_e_loginClicked]: _s_auth,
-            [_e_needNo]: _s_notNeeded,
-            [_e_needYes]: _s_auth,
+            //[_e_loginClicked]: _s_auth,
+            //[_e_needNo]: _s_notNeeded,
+            //[_e_needYes]: _s_auth,
             [_e_unloaded]: _s_initial,
         },
         [_s_creds]: {
-            [_e_authInvalid]: _s_creds,
-            [_e_authMissing]: _s_creds,
-            [_e_authSuccess]: _s_ok,
+            //[_e_authInvalid]: _s_creds,
+            //[_e_authMissing]: _s_creds,
+            //[_e_authSuccess]: _s_ok,
             [_e_credsCancel]: _s_idle,
             [_e_credsConfirm]: _s_auth,
-            [_e_loginClicked]: _s_creds,
-            [_e_needNo]: _s_notNeeded,
-            [_e_needYes]: _s_creds,
+            //[_e_loginClicked]: _s_creds,
+            //[_e_needNo]: _s_notNeeded,
+            //[_e_needYes]: _s_creds,
             [_e_unloaded]: _s_initial,
         },
         [_s_idle]: {
-            [_e_authInvalid]: _s_idle,
-            [_e_authMissing]: _s_idle,
-            [_e_authSuccess]: _s_ok,
+            //[_e_authInvalid]: _s_idle,
+            //[_e_authMissing]: _s_idle,
+            //[_e_authSuccess]: _s_ok,
             [_e_loginClicked]: _s_creds,
             [_e_needNo]: _s_notNeeded,
             [_e_needYes]: _s_status,
@@ -1154,29 +1159,29 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
             [_e_unloaded]: _s_initial,
         },
         [_s_notNeeded]: {
-            [_e_authInvalid]: _s_notNeeded,
-            [_e_authMissing]: _s_notNeeded,
-            [_e_authSuccess]: _s_notNeeded,
-            [_e_loginClicked]: _s_notNeeded,
+            //[_e_authInvalid]: _s_notNeeded,
+            //[_e_authMissing]: _s_notNeeded,
+            //[_e_authSuccess]: _s_notNeeded,
+            //[_e_loginClicked]: _s_notNeeded,
             [_e_needNo]: _s_notNeeded,
             [_e_needYes]: _s_status,
             [_e_unloaded]: _s_initial,
         },
         [_s_ok]: {
-            [_e_authInvalid]: _s_idle,
+            //[_e_authInvalid]: _s_idle,
             [_e_authMissing]: _s_idle,
-            [_e_authSuccess]: _s_ok,
-            [_e_loginClicked]: _s_ok,
+            //[_e_authSuccess]: _s_ok,
+            //[_e_loginClicked]: _s_ok,
             [_e_needNo]: _s_notNeeded,
             [_e_needYes]: _s_ok,
             [_e_unloaded]: _s_initial,
         },
         [_s_status]: {
-            [_e_authInvalid]: _s_idle,
-            [_e_authError]: _s_idle,
+            //[_e_authInvalid]: _s_idle,
+            //[_e_authError]: _s_idle,
             [_e_authMissing]: _s_idle,
             [_e_authSuccess]: _s_ok,
-            [_e_loginClicked]: _s_status,
+            //[_e_loginClicked]: _s_status,
             [_e_needNo]: _s_notNeeded,
             [_e_needYes]: _s_status,
             [_e_unloaded]: _s_initial,
@@ -1190,8 +1195,17 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
     let _state = _s_initial;
 
     const _STATE_QUERIES = {
+        ignoreSRException: (state) => {
+            return [_s_auth, _s_creds, _s_notNeeded, _s_status, _s_idle].includes(state);
+        },
         isLoggedIn: (state) => {
             return state === _s_ok;
+        },
+        sbatchLoginResponseOK: (state) => {
+            return state === _s_auth;
+        },
+        sbatchLoginStatusResponseOK: (state) => {
+            return state === _s_status;
         },
         showLogin: (state) => {
             return [_s_creds, _s_idle].includes(state);
@@ -1274,7 +1288,7 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
         }
 
         transition() {
-            //DEBUG: (`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
+            srdbg(`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
             _state = this._newState;
             $rootScope.$broadcast('sbatchLoginEvent', this);
         }
@@ -1316,6 +1330,19 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
         if (srException.routeName != 'sbatchLogin') {
             return false;
         }
+        const r = _REASON_TO_EVENTS[srException.params.reason] || _e_authError;
+        // Need to ignore exceptions that are coming in from separate requests.
+        // Decentralized requests is the problem. Frames are requested as soon as
+        // running comes back, but running isn't valid necessarily (see job_agent) until
+        // the agent is connected. ignoreSRException is broad to avoid conflicts.
+        // _s_auth is special, because it uses exceptions for invalid auth or other
+        // errors. Probably agent could be better coordinate with this. Could just be
+        // a response to the auth request. Has to do with the internals of sbatch.py
+        // which does not coordinate login.
+        if (self.query('ignoreSRException') && !(_state == _s_auth && r == _e_authMissing)) {
+            srlog('sbatchLoginService ignoring srException', srException, 'state', _state);
+            return true;
+        }
         //TODO(robnagler) an alternative is to broadcast an error.
         // there should be some type of global state management
         // here, since requests are all connected to this event.
@@ -1327,10 +1354,7 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
             error: `Please login to ${authState.sbatchHostDisplayName}`,
             sbatchLoginServiceSRException: true,
         });
-        self.event(
-            _REASON_TO_EVENTS[srException.params.reason] || _e_authError,
-            {srException: srException},
-        );
+        self.event(r, {srException: srException});
         return true;
     };
 
@@ -1352,10 +1376,12 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
             if (response.sbatchLoginServiceSRException) {
                 return;
             }
-            self.event(
-                response.ready || response.loginSuccess ? _e_authSuccess : _e_authMissing,
-                {authResponse: response},
-            );
+            if (self.query(route + 'ResponseOK')) {
+                self.event(
+                    response.ready || response.loginSuccess ? _e_authSuccess : _e_authMissing,
+                    {authResponse: response},
+                );
+            }
 	};
 	requestSender.sendRequest(
 	    route,

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1,10 +1,9 @@
 'use strict';
-SIREPO.srlog = (...args) => {
-    console.log(
-        (new Date().toISOString()).substring(11, 19),
-        ...args,
-    );
-};
+// needs to be here so test.sh doesn't see it
+SIREPO.srlog = (...args) => {console.log(
+    (new Date().toISOString()).substring(11, 19),
+    ...args,
+);};
 SIREPO.srdbg = SIREPO.srlog;
 SIREPO.traceWS = false;
 
@@ -1288,7 +1287,7 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
         }
 
         transition() {
-            srdbg(`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
+            // debug (`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
             _state = this._newState;
             $rootScope.$broadcast('sbatchLoginEvent', this);
         }

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -5,7 +5,7 @@ SIREPO.srlog = (...args) => {console.log(
     ...args,
 );};
 SIREPO.srdbg = SIREPO.srlog;
-SIREPO.traceWS = false;
+SIREPO.traceWS = true;
 
 // No timeout for now (https://github.com/radiasoft/sirepo/issues/317)
 SIREPO.http_timeout = 0;
@@ -1288,7 +1288,7 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
         }
 
         transition() {
-            // DEBUG (`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
+            srdbg(`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
             _state = this._newState;
             $rootScope.$broadcast('sbatchLoginEvent', this);
         }

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -1167,6 +1167,7 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
             [_e_unloaded]: _s_initial,
         },
         [_s_ok]: {
+            [_e_authError]: _s_idle,
             //[_e_authInvalid]: _s_idle,
             [_e_authMissing]: _s_idle,
             //[_e_authSuccess]: _s_ok,
@@ -1287,7 +1288,7 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
         }
 
         transition() {
-            srdbg(`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
+            // DEBUG (`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
             _state = this._newState;
             $rootScope.$broadcast('sbatchLoginEvent', this);
         }

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -5,7 +5,7 @@ SIREPO.srlog = (...args) => {console.log(
     ...args,
 );};
 SIREPO.srdbg = SIREPO.srlog;
-SIREPO.traceWS = true;
+SIREPO.traceWS = false;
 
 // No timeout for now (https://github.com/radiasoft/sirepo/issues/317)
 SIREPO.http_timeout = 0;
@@ -1288,7 +1288,7 @@ SIREPO.app.service('sbatchLoginService', function($rootScope, appState, authStat
         }
 
         transition() {
-            srdbg(`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
+            // DEBUG(`${this._oldState} ${this._event} => ${this._newState}`, this._arg);
             _state = this._newState;
             $rootScope.$broadcast('sbatchLoginEvent', this);
         }

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -2575,11 +2575,10 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
                 </div>
               </div>
               <div data-ng-show="simState.isStopped() && ! isFluxWithApproximateMethod()">
-                <div data-ng-if="normalCompletion()" data-simulation-stopped-status="simState"></div>
-                <div class="col-sm-12" data-ng-if="! normalCompletion()">Simulation Cancelled</div>
-                  <div class="col-sm-12" data-ng-show="showFrameCount()">
-                    Completed {{ runStepName }}: {{ particleNumber }} / {{ particleCount}}
-                  </div>
+                <div data-simulation-stopped-status="simState"></div>
+                <div class="col-sm-12" data-ng-show="showFrameCount()">
+                  Completed {{ runStepName }}: {{ particleNumber }} / {{ particleCount}}
+                </div>
                 <div class="col-sm-12" data-simulation-status-timer="simState"></div>
                 <div data-job-settings-sbatch-login-and-start-simulation data-sim-state="simState" data-start-simulation="startSimulation()"></div>
               </div>
@@ -2623,12 +2622,6 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
                 }
             }
 
-            $scope.normalCompletion = () => {
-                var d = Math.abs($scope.particleCount - $scope.particleNumber);
-                var a = appState.models.multiElectronAnimation;
-                return d < a.numberOfMacroElectronsAvg * a.savingPeriodicity;
-            };
-
             $scope.logFileURL = () => {
                 if (! appState.isLoaded()) {
                     return '';
@@ -2657,9 +2650,6 @@ SIREPO.app.directive('simulationStatusPanel', function(appState, beamlineService
                             ? 'mode' : 'macro-electrons';
                     }
                     $scope.particleCount = data.particleCount;
-                    if ($scope.simState.isStateCompleted() && $scope.normalCompletion()){
-                        $scope.particleNumber = $scope.particleCount;
-                    }
                 }
                 if (data.frameCount) {
                     if (data.frameCount != frameCache.getFrameCount($scope.model)) {

--- a/sirepo/package_data/template/omega/parameters.py.jinja
+++ b/sirepo/package_data/template/omega/parameters.py.jinja
@@ -60,9 +60,11 @@ def genesis_to_pmd(sim):
 
 
 def prep_run_dir(run_dir, data):
-    sirepo.simulation_db.prepare_simulation(data, run_dir)
+    sirepo.sim_data.get_class(data.simulationType).sim_run_dir_prepare(
+        run_dir=run_dir,
+        data=data,
+    )
     return pkio.save_chdir(run_dir)
-
 
 def read_sim(sim_type, sim_id):
     return sirepo.sim_data.get_class(sim_type).sim_db_read_sim(sim_id)

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -56,7 +56,8 @@ _MAX_SCONTROL_TRIES = 5
 _cfg = None
 
 _DEV_PYTHON_PATH = ":".join(
-    str(pkio.py_path(sirepo.const.DEV_SRC_RADIASOFT_DIR).join(p)) for p in ("sirepo", "pykern")
+    str(pkio.py_path(sirepo.const.DEV_SRC_RADIASOFT_DIR).join(p))
+    for p in ("sirepo", "pykern")
 )
 
 
@@ -520,7 +521,8 @@ class _Cmd(PKDict):
             self.job_state = job.PENDING
             if self.msg.opName == job.OP_RUN:
                 pkio.unchecked_remove(self.run_dir)
-                pkio.mkdir_parent(self.run_dir)
+            # Needs to exist for run_status so in_file can be created
+            pkio.mkdir_parent(self.run_dir)
 
         super().__init__(**kwargs)
         self.pksetdefault(

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -1002,7 +1002,7 @@ EOF"""
             # POSIT: job_api has validated values
             if not self.msg.get("shifterImage"):
                 return ""
-            return f"""#SBATCH --image={i}
+            return f"""#SBATCH --image={self.msg.shifterImage}
 #SBATCH --constraint=cpu
 #SBATCH --qos={self.msg.sbatchQueue}
 #SBATCH --tasks-per-node={self.msg.tasksPerNode}

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -1340,6 +1340,7 @@ class _SbatchRunStatus(_SbatchCmd):
             # parallelStatus only happens in the case we are at the end
             rv = PKDict()
             for f in "error", "parallelStatus", "computeJobStart":
+                # Will be overwritten if in "text"
                 if x := self._sbatch_status.get(f):
                     rv[f] = x
             return rv

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -956,6 +956,7 @@ class _SbatchRun(_SbatchCmd):
                 m = copy.deepcopy(self.msg)
                 m.opName = job.OP_RUN_STATUS
                 m.opId = None
+                m.jobCmd = "sbatch_parallel_status"
                 _SbatchRunStatus(
                     msg=m, dispatcher=self.dispatcher, sbatch_run=self
                 ).start()
@@ -1040,9 +1041,6 @@ exec srun {_shifter_cmd()} python {template_common.PARAMETERS_PYTHON_FILE}
 class _SbatchRunStatus(_SbatchCmd):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        # Always simulate OP_RUN, because default case is that way.
-        # opName is used as condition in job_cmd_reply
-        self.msg.jobCmd = "sbatch_parallel_status"
         self.pkdel("computeJobStart")
         self.pkupdate(
             _sbatch_status_cb=None,

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -286,7 +286,7 @@ class _Dispatcher(PKDict):
         try:
             if not isinstance(msg, _OpMsg):
                 raise AssertionError("expected _OpMsg type={} msg={}", type(msg), msg)
-            await self._websocket.write_message(pkjson.dump_bytes(msg))
+            await self._websocket.write_message(pkjson.dump_bytes(msg), binary=True)
             return True
         except Exception as e:
             pkdlog("exception={} msg={} stack={}", e, msg, pkdexc())

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -285,7 +285,7 @@ class _Dispatcher(PKDict):
             return False
         try:
             if not isinstance(msg, _OpMsg):
-                raise AssertionError("expected _OpMsg type={} msg={}", type(msg), msg)
+                raise AssertionError(f"expected _OpMsg not msg type={type(msg)}")
             await self._websocket.write_message(pkjson.dump_bytes(msg), binary=True)
             return True
         except Exception as e:
@@ -403,7 +403,7 @@ class _Dispatcher(PKDict):
                 return self.format_op(
                     msg,
                     job.ERROR,
-                    PKDict(state=job.ERROR, error="fastcgi process got an error"),
+                    reply=PKDict(state=job.ERROR, error="fastcgi process got an error"),
                 )
         if msg.jobCmd == "fastcgi":
             raise AssertionError("fastcgi called within fastcgi")
@@ -1300,7 +1300,7 @@ class _SbatchRunStatus(_SbatchCmd):
             if len(rv) == 1:
                 # Normal case
                 return next(iter(rv))
-            elif len(rv) > 1 and "CANCELLED" in rv:
+            if len(rv) > 1 and "CANCELLED" in rv:
                 return "CANCELLED"
             pkdlog("{} sacct parse failed words={} stdout={}", self, rv, p.stdout)
             return "FAILED"

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -56,7 +56,7 @@ _MAX_SCONTROL_TRIES = 5
 _cfg = None
 
 _DEV_PYTHON_PATH = ":".join(
-    str(sirepo.const.DEV_SRC_RADIASOFT_DIR.join(p)) for p in ("sirepo", "pykern")
+    str(pkio.py_path(sirepo.const.DEV_SRC_RADIASOFT_DIR).join(p)) for p in ("sirepo", "pykern")
 )
 
 

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -384,7 +384,7 @@ class _Dispatcher(PKDict):
     async def _fastcgi_op(self, msg):
         if msg.runDir:
             _assert_run_dir_exists(pkio.py_path(msg.runDir))
-        pkdp([msg, self.fastcgi_cmd, self._fastcgi_msg_q])
+        pkdp([msg, self.fastcgi_cmd])
         if not self.fastcgi_cmd:
             m = copy.deepcopy(msg)
             m.jobCmd = "fastcgi"
@@ -405,7 +405,7 @@ class _Dispatcher(PKDict):
             )
             # last thing, because of await: start fastcgi process
             await self._cmd(m, send_reply=False)
-            pkdp([msg, self.fastcgi_cmd])
+            pkdp([self.fastcgi_cmd])
             if not self._fastcgi_msg_q:
                 pkdp([msg, self.fastcgi_cmd])
                 return self.format_op(

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -505,7 +505,6 @@ class _Dispatcher(PKDict):
                 reply=PKDict(state=cmd.job_state),
             )
 
-
         if rv := _find():
             pass
         elif msg.jobRunMode == job.SBATCH:
@@ -1227,7 +1226,10 @@ class _SbatchRunStatus(_SbatchCmd):
             if p.returncode != 0:
                 # Invalid job id will happen on NERSC. No jobs in dev
                 if re.search("Invalid job id|No jobs", p.stderr):
-                    pkdlog("sbatch={} not in system, trying sacct", self._sbatch_status.sbatch_id)
+                    pkdlog(
+                        "sbatch={} not in system, trying sacct",
+                        self._sbatch_status.sbatch_id,
+                    )
                     return _sacct()
                 pkdlog(
                     "{} scontrol error exit={} sbatch={} stderr={} stdout={}",

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -953,12 +953,8 @@ class _SbatchRun(_SbatchCmd):
                 job_cmd_state=job.PENDING, sbatch_id=m.group(1)
             ):
                 # Start the status watcher
-                m = copy.deepcopy(self.msg)
-                m.opName = job.OP_RUN_STATUS
-                m.opId = None
-                m.jobCmd = "sbatch_parallel_status"
                 _SbatchRunStatus(
-                    msg=m, dispatcher=self.dispatcher, sbatch_run=self
+                    msg=copy.deepcopy(self.msg), dispatcher=self.dispatcher, sbatch_run=self
                 ).start()
                 rv = self.format_op_reply(state=job.STATE_OK)
             else:
@@ -1040,6 +1036,12 @@ exec srun {_shifter_cmd()} python {template_common.PARAMETERS_PYTHON_FILE}
 
 class _SbatchRunStatus(_SbatchCmd):
     def __init__(self, **kwargs):
+        kwargs["msg"].pkupdate(
+            jobCmd="sbatch_parallel_status",
+            opId=None,
+            opName=job.OP_RUN_STATUS,
+            sbatchStatusFile=str(kwargs["sbatch_run"]._sbatch_status_file),
+        )
         super().__init__(**kwargs)
         self.pkdel("computeJobStart")
         self.pkupdate(

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -703,6 +703,7 @@ class _Cmd(PKDict):
         _call_later_0(
             self.dispatcher.job_cmd_reply,
             msg=self.msg,
+            op_name=job.OP_RUN_STATUS_UPDATE,
             cmd=self,
         )
         return rv

--- a/sirepo/pkcli/job_cmd.py
+++ b/sirepo/pkcli/job_cmd.py
@@ -317,7 +317,7 @@ def _do_sbatch_parallel_status(msg, template):
     def _should_exit(status_file):
         try:
             s = pkjson.load_any(status_file)
-            if s.job_cmd_state in job.JOB_CMD_EXIT_SET:
+            if s.job_cmd_state in job.JOB_CMD_STATE_EXITS:
                 return s.job_cmd_state
             return None
         except Exception as e:
@@ -331,7 +331,7 @@ def _do_sbatch_parallel_status(msg, template):
     while not (s := _should_exit(f)):
         p = _write_parallel_status(p, msg, template, is_running=True)
         # Not asyncio.sleep: not in coroutine
-        time.sleep(msg.runStatusPollSeconds)
+        time.sleep(msg.nextRequestSeconds)
     if s == job.JOB_CMD_STATE_SBATCH_RUN_STATUS_STOP:
         # Only time can update the file when given request to stop
         # TODO(robnagler) completed_hack ensures we write COMPLETED to the file.

--- a/sirepo/pkcli/job_cmd.py
+++ b/sirepo/pkcli/job_cmd.py
@@ -35,6 +35,7 @@ _MAX_FASTCGI_MSG = int(1e8)
 
 _MAX_SBATCH_STATUS_RETRIES = 5
 
+
 def default_command(in_file):
     """Reads `in_file` passes to `msg.jobCmd`
 
@@ -317,7 +318,7 @@ def _do_sbatch_parallel_status(msg, template):
         )
 
     def _should_exit(status_file):
-        #TODO(robnagler) should be an class
+        # TODO(robnagler) should be an class
         nonlocal should_exit_tries
         try:
             s = pkjson.load_any(status_file)

--- a/sirepo/pkcli/job_cmd.py
+++ b/sirepo/pkcli/job_cmd.py
@@ -178,6 +178,11 @@ def _do_compute(msg, template):
             success_exit=success_exit,
         )
 
+    def _prepare():
+        return sirepo.sim_data.get_class(template.SIM_TYPE).sim_run_dir_prepare(
+            msg.runDir
+        )
+
     def _success_exit():
         return PKDict(
             state=job.COMPLETED,
@@ -188,11 +193,7 @@ def _do_compute(msg, template):
         rv = PKDict(run_log=msg.runDir.join(template_common.RUN_LOG))
         with rv.run_log.open("w") as f:
             return rv.pkupdate(
-                process=subprocess.Popen(
-                    _do_prepare_simulation(msg, template).cmd,
-                    stdout=f,
-                    stderr=f,
-                ),
+                process=subprocess.Popen(_prepare(), stdout=f, stderr=f),
             )
 
     # TODO(robnagler) ParallelStatus object to simplify the code here
@@ -302,15 +303,6 @@ def _do_get_simulation_frame(msg, template):
         )
     except Exception as e:
         return _maybe_parse_user_alert(e, error="report not generated")
-
-
-def _do_prepare_simulation(msg, template):
-    return PKDict(
-        cmd=simulation_db.prepare_simulation(
-            msg.data,
-            msg.runDir,
-        )[0],
-    )
 
 
 def _do_sbatch_parallel_status(msg, template):

--- a/sirepo/pkcli/job_cmd.py
+++ b/sirepo/pkcli/job_cmd.py
@@ -49,7 +49,6 @@ def default_command(in_file):
         str: json output of command, e.g. status msg
     """
     # must delete, because subprocesses will reopen it
-    del os.environ["PYKERN_PKDEBUG_OUTPUT"]
     msg = None
     try:
         f = pkio.py_path(in_file)

--- a/sirepo/pkcli/job_cmd.py
+++ b/sirepo/pkcli/job_cmd.py
@@ -35,6 +35,7 @@ _MAX_FASTCGI_MSG = int(1e8)
 
 _MAX_SBATCH_STATUS_RETRIES = 5
 
+
 def default_command(in_file):
     """Reads `in_file` passes to `msg.jobCmd`
 

--- a/sirepo/pkcli/job_cmd.py
+++ b/sirepo/pkcli/job_cmd.py
@@ -35,7 +35,6 @@ _MAX_FASTCGI_MSG = int(1e8)
 
 _MAX_SBATCH_STATUS_RETRIES = 5
 
-
 def default_command(in_file):
     """Reads `in_file` passes to `msg.jobCmd`
 

--- a/sirepo/pkcli/job_supervisor.py
+++ b/sirepo/pkcli/job_supervisor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Runs job supervisor tornado server
 
 :copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.

--- a/sirepo/pkcli/job_supervisor.py
+++ b/sirepo/pkcli/job_supervisor.py
@@ -144,7 +144,8 @@ class _ServerReq(_JsonPostRequestHandler):
         pass
 
     async def post(self):
-        self.write(await _incoming(self.request.body, self))
+        if (r := await _incoming(self.request.body, self)) is not None:
+            self.write(r)
 
     def sr_on_exception(self):
         self.send_error()
@@ -179,7 +180,8 @@ async def _incoming(content, handler):
             handler.sr_on_exception()
         except Exception as e:
             pkdlog("sr_on_exception: exception={}", e)
-        return PKDict(state=sirepo.job.ERROR, error="unexpected error")
+        # sr_on_exception writes error
+        return None
 
 
 def _sigterm(signum, frame):

--- a/sirepo/pkcli/job_supervisor.py
+++ b/sirepo/pkcli/job_supervisor.py
@@ -3,6 +3,7 @@
 :copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+
 from pykern import pkconfig
 from pykern import pkio
 from pykern import pkjson

--- a/sirepo/pkcli/nersc_test.py
+++ b/sirepo/pkcli/nersc_test.py
@@ -57,11 +57,12 @@ class _Sequential(PKDict):
         self.user = sirepo.const.MOCK_UID
         # job_cmd_file must be first, because used by _render_resource
         self.job_cmd_file = self._job_cmd_file()
-        d = pykern.pkjson.load_any(self.job_cmd_file).data
-        sirepo.sim_data.get_class(d.simulationType).sim_run_input_to_run_dir(
-            d,
-            self.run_dir,
-        )
+        if not self.pkunit_deviance:
+            d = pykern.pkjson.load_any(self.job_cmd_file).data
+            sirepo.sim_data.get_class(d.simulationType).sim_run_input_to_run_dir(
+                d,
+                self.run_dir,
+            )
         self.run_file = self._render_resource(self.RUN_FILE)
 
     def execute(self):

--- a/sirepo/pkcli/nersc_test.py
+++ b/sirepo/pkcli/nersc_test.py
@@ -57,6 +57,11 @@ class _Sequential(PKDict):
         self.user = sirepo.const.MOCK_UID
         # job_cmd_file must be first, because used by _render_resource
         self.job_cmd_file = self._job_cmd_file()
+        d = pykern.pkjson.load_any(self.job_cmd_file).data
+        sirepo.sim_data.get_class(d.simulationType).sim_run_input_to_run_dir(
+            d,
+            self.run_dir,
+        )
         self.run_file = self._render_resource(self.RUN_FILE)
 
     def execute(self):

--- a/sirepo/pkcli/setup_dev.py
+++ b/sirepo/pkcli/setup_dev.py
@@ -20,7 +20,7 @@ def default_command():
     )
     cfg = pkconfig.init(
         proprietary_code_uri=(
-            f"file://{sirepo.const.DEV_SRC_RADIASOFT_DIR.join('rsconf/proprietary')}",
+            f"file://{pkio.py_path(sirepo.const.DEV_SRC_RADIASOFT_DIR).join('rsconf/proprietary')}",
             str,
             "root uri of proprietary codes files location",
         ),

--- a/sirepo/template/opal.py
+++ b/sirepo/template/opal.py
@@ -19,6 +19,7 @@ from sirepo.template.madx_converter import MadxConverter
 import math
 import numpy as np
 import re
+import sirepo.const
 import sirepo.lib
 import sirepo.sim_data
 import os.path
@@ -432,11 +433,11 @@ def background_percent_complete(report, run_dir, is_running):
         frameCount=0,
     )
     if is_running:
-        data = simulation_db.read_json(run_dir.join(template_common.INPUT_BASE_NAME))
+        data = _SIM_DATA.sim_run_input(run_dir)
         # TODO(pjm): determine total frame count and set percentComplete
         res.frameCount = read_frame_count(run_dir) - 1
         return res
-    if run_dir.join("{}.json".format(template_common.INPUT_BASE_NAME)).exists():
+    if _SIM_DATA.sim_run_input(run_dir, checked=False):
         res.frameCount = read_frame_count(run_dir)
         if res.frameCount > 0:
             res.percentComplete = 100
@@ -1098,7 +1099,7 @@ def _iterate_hdf5_steps_from_handle(h5file, callback, state):
 
 def _output_info(run_dir):
     # TODO(pjm): cache to file with version, similar to template.elegant
-    data = simulation_db.read_json(run_dir.join(template_common.INPUT_BASE_NAME))
+    data = _SIM_DATA.sim_run_input(run_dir)
     files = LatticeUtil(data, SCHEMA).iterate_models(OpalOutputFileIterator()).result
     res = []
     for k in files.keys_in_order:

--- a/sirepo/template/template_common.py
+++ b/sirepo/template/template_common.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
 """Common execution template.
 
 :copyright: Copyright (c) 2015 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+
 from pykern import pkcompat
 from pykern import pkio
 from pykern import pkjinja
@@ -25,7 +25,7 @@ import types
 DEFAULT_INTENSITY_DISTANCE = 20
 
 #: Input json file
-INPUT_BASE_NAME = "in"
+INPUT_BASE_NAME = sirepo.const.SIM_RUN_INPUT_BASENAME
 
 #: Test if value is numeric text
 NUMERIC_RE = re.compile(r"^\s*(\-|\+)?(\d+|(\d*(\.\d*)))([eE][+-]?\d+)?\s*$")

--- a/sirepo/template/zgoubi.py
+++ b/sirepo/template/zgoubi.py
@@ -19,6 +19,7 @@ import math
 import numpy as np
 import py.path
 import re
+import sirepo.const
 import sirepo.sim_data
 import zipfile
 
@@ -324,11 +325,7 @@ def background_percent_complete(report, run_dir, is_running):
     if not is_running:
         show_tunes_report = False
         show_spin_3d = False
-        in_file = run_dir.join("{}.json".format(template_common.INPUT_BASE_NAME))
-        if in_file.exists():
-            data = simulation_db.read_json(
-                run_dir.join(template_common.INPUT_BASE_NAME)
-            )
+        if data := _SIM_DATA.sim_run_input(run_dir, checked=False):
             show_tunes_report = (
                 _particle_count(data) <= SCHEMA.constants.maxFilterPlotParticles
                 and data.models.simulationSettings.npass >= 10

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -235,7 +235,8 @@ def assert_sim_type(sim_type):
     Returns:
         str: validated sim_type
     """
-    assert is_sim_type(sim_type), f"invalid simulation type={sim_type}"
+    if not is_sim_type(sim_type):
+        raise AssertionError(f"invalid simulation type={sim_type}")
     return sim_type
 
 

--- a/test.sh
+++ b/test.sh
@@ -34,6 +34,7 @@ print(round(100 * timeit.timeit("str().join(str(i) for i in range(1000000))", nu
 EOF
     )
     echo 'SIREPO_FEATURE_CONFIG_UI_WEBSOCKET=1'
+    export PYKERN_PKCLI_TEST_MAX_PROCS=4
     SIREPO_FEATURE_CONFIG_UI_WEBSOCKET=1 pykern ci run
     echo 'SIREPO_FEATURE_CONFIG_UI_WEBSOCKET=0'
     SIREPO_FEATURE_CONFIG_UI_WEBSOCKET=0 pykern test

--- a/test.sh
+++ b/test.sh
@@ -34,6 +34,7 @@ print(round(100 * timeit.timeit("str().join(str(i) for i in range(1000000))", nu
 EOF
     )
     export PYKERN_PKCLI_TEST_MAX_PROCS=4
+    export SIREPO_MPI_CORES=2
     pykern ci run
 }
 

--- a/test.sh
+++ b/test.sh
@@ -33,11 +33,8 @@ import timeit;
 print(round(100 * timeit.timeit("str().join(str(i) for i in range(1000000))", number=2)))
 EOF
     )
-    echo 'SIREPO_FEATURE_CONFIG_UI_WEBSOCKET=1'
     export PYKERN_PKCLI_TEST_MAX_PROCS=4
-    SIREPO_FEATURE_CONFIG_UI_WEBSOCKET=1 pykern ci run
-    echo 'SIREPO_FEATURE_CONFIG_UI_WEBSOCKET=0'
-    SIREPO_FEATURE_CONFIG_UI_WEBSOCKET=0 pykern test
+    pykern ci run
 }
 
 _msg() {

--- a/tests/cancel_sim_test.py
+++ b/tests/cancel_sim_test.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
 """test cancel of sim
 
 :copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
-import pytest
 
 
 def test_srw(fc):

--- a/tests/job_cancel_test.py
+++ b/tests/job_cancel_test.py
@@ -9,6 +9,7 @@ _REPORT = "heightWeightReport"
 
 def test_myapp(fc):
     from pykern import pkunit
+
     from pykern.pkdebug import pkdc, pkdp, pkdlog
     from pykern.pkcollections import PKDict
 
@@ -48,6 +49,7 @@ def _t2(fc, sim_data):
     time.sleep(1)
     fc.sr_post("runCancel", sim_data)
     pkunit.pkeq("canceled", fc.sr_post("runStatus", sim_data).state)
+
 
 def _state_eq(fc, req, expect):
     import time

--- a/tests/job_cancel_test.py
+++ b/tests/job_cancel_test.py
@@ -43,13 +43,20 @@ def _t2(fc, sim_data):
     import time
     from pykern import pkunit
 
-    for _ in range(5):
-        time.sleep(1)
-        if fc.sr_post("runStatus", sim_data).state == "pending":
-            break
-    else:
-        pkunit.pkfail("job did not start running")
-    # Help ensure that t1 sees pending
+    _state_eq(fc, sim_data, "pending")
+    # Help ensure that t1 sees pending, too
     time.sleep(1)
     fc.sr_post("runCancel", sim_data)
     pkunit.pkeq("canceled", fc.sr_post("runStatus", sim_data).state)
+
+def _state_eq(fc, req, expect):
+    import time
+    from pykern import pkunit
+
+    for _ in range(5):
+        time.sleep(1)
+        r = fc.sr_post("runStatus", req)
+        if r.state == expect:
+            return r
+    else:
+        pkunit.pkfail("expect={} != actual={}", expect, r.state)

--- a/tests/job_cancel_test.py
+++ b/tests/job_cancel_test.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """test cancel of sim with agent_start_delay
 
 :copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-import pytest
 
 _REPORT = "heightWeightReport"
 
@@ -15,7 +13,9 @@ def test_myapp(fc):
     from pykern.pkcollections import PKDict
 
     d = fc.sr_sim_data()
-    d.models.dog.favoriteTreat = "agent_start_delay=5"
+    # TODO(robnagler) this does not work see:
+    # https://github.com/radiasoft/sirepo/issues/7400
+    # d.models.dog.favoriteTreat = "agent_start_delay=5"
     x = dict(
         forceRun=False,
         models=d.models,
@@ -43,6 +43,7 @@ def _t2(fc, sim_data):
     import time
     from pykern import pkunit
 
-    time.sleep(1)
+    # this is very sensitive
+    time.sleep(2)
     fc.sr_post("runCancel", sim_data)
     pkunit.pkeq("canceled", fc.sr_post("runStatus", sim_data).state)

--- a/tests/job_cancel_test.py
+++ b/tests/job_cancel_test.py
@@ -43,7 +43,13 @@ def _t2(fc, sim_data):
     import time
     from pykern import pkunit
 
-    # this is very sensitive
-    time.sleep(2)
+    for _ in range(5):
+        time.sleep(1)
+        if fc.sr_post("runStatus", sim_data).state == "pending":
+            break
+    else:
+        pkunit.pkfail("job did not start running")
+    # Help ensure that t1 sees pending
+    time.sleep(1)
     fc.sr_post("runCancel", sim_data)
     pkunit.pkeq("canceled", fc.sr_post("runStatus", sim_data).state)

--- a/tests/run_sim_test.py
+++ b/tests/run_sim_test.py
@@ -84,7 +84,7 @@ def test_myapp_sim(fc):
     )
     for _ in range(10):
         pkdlog(r)
-        pkunit.pkok(r.state != "error", "expected error state: {}")
+        pkunit.pkok(r.state != "error", "expected error state: {}", r.state)
         if r.state == "completed":
             break
         time.sleep(r.nextRequestSeconds)

--- a/tests/sim_db_file_test.py
+++ b/tests/sim_db_file_test.py
@@ -8,9 +8,11 @@
 def test_basic(sim_db_file_server):
     from pykern import pkdebug, pkunit
     from sirepo import sim_data, srunit
+    import time
 
     stype = srunit.SR_SIM_TYPE_DEFAULT
     c = sim_data.get_class(stype).sim_db_client()
+    time.sleep(1)
     pkunit.pkeq(b"xyzzy", c.get(c.LIB_DIR, "hello.txt"))
     c.put(c.LIB_DIR, "hello.txt", "abc")
     pkunit.pkeq(b"abc", c.get(c.LIB_DIR, "hello.txt"))

--- a/tests/supervisor_purge_free_sims_test.py
+++ b/tests/supervisor_purge_free_sims_test.py
@@ -97,7 +97,6 @@ def test_elegant_no_frame_after_purge(auth_fc):
     fc.sr_email_login(user_free)
     d = fc.sr_sim_data(sim_name="Compact Storage Ring", sim_type="elegant")
     r = fc.sr_run_sim(d, "animation")
-    pkdp(r.state)
     with fc.sr_adjust_time(_PURGE_FREE_AFTER_DAYS + 1):
         time.sleep(_CACHE_AND_SIM_PURGE_PERIOD + 3)
         s = _state_eq(

--- a/tests/supervisor_purge_free_sims_test.py
+++ b/tests/supervisor_purge_free_sims_test.py
@@ -100,7 +100,7 @@ def test_elegant_no_frame_after_purge(auth_fc):
     d = fc.sr_sim_data(sim_name="Compact Storage Ring", sim_type="elegant")
     r = fc.sr_run_sim(d, "animation")
     with fc.sr_adjust_time(_PURGE_FREE_AFTER_DAYS + 1):
-        time.sleep(_CACHE_AND_SIM_PURGE_PERIOD + 1)
+        time.sleep(_CACHE_AND_SIM_PURGE_PERIOD + 2)
         s = fc.sr_post(
             "runStatus",
             PKDict(

--- a/tests/supervisor_purge_free_sims_test.py
+++ b/tests/supervisor_purge_free_sims_test.py
@@ -41,7 +41,8 @@ def test_myapp_free_user_sim_purged(auth_fc):
     def _make_invalid_job():
         d = srdb.supervisor_dir()
         d.ensure(dir=True)
-        # This will be the first file found and cause purge_non_premium to raise
+        # This will be the first file found, but job_supervisor won't see a valid sim type
+        # so it will ignore.
         pkunit.data_dir().join("00000001-JzccRZNg-heightWeightReport.json").copy(d)
 
     def _make_user_premium(uid):
@@ -65,9 +66,6 @@ def test_myapp_free_user_sim_purged(auth_fc):
         r.update(data)
         return r
 
-    def _status_eq(next_req, status):
-        pkunit.pkeq(status, fc.sr_post("runStatus", next_req).state)
-
     fc = auth_fc
     user_free = "free@b.c"
     user_premium = "premium@x.y"
@@ -79,11 +77,11 @@ def test_myapp_free_user_sim_purged(auth_fc):
     fc.sr_email_login(user_free)
     next_req_free = _run_sim(fc.sr_sim_data())
     with fc.sr_adjust_time(_PURGE_FREE_AFTER_DAYS + 1):
-        time.sleep(_CACHE_AND_SIM_PURGE_PERIOD + 1)
-        _status_eq(next_req_free, "job_run_purged")
+        time.sleep(_CACHE_AND_SIM_PURGE_PERIOD + 3)
+        _state_eq(fc, next_req_free, "job_run_purged")
         _check_run_dir(should_exist=0)
         fc.sr_email_login(user_premium)
-        _status_eq(next_req_premium, "completed")
+        _state_eq(fc, next_req_premium, "completed")
         _check_run_dir(should_exist=6)
 
 
@@ -99,10 +97,11 @@ def test_elegant_no_frame_after_purge(auth_fc):
     fc.sr_email_login(user_free)
     d = fc.sr_sim_data(sim_name="Compact Storage Ring", sim_type="elegant")
     r = fc.sr_run_sim(d, "animation")
+    pkdp(r.state)
     with fc.sr_adjust_time(_PURGE_FREE_AFTER_DAYS + 1):
-        time.sleep(_CACHE_AND_SIM_PURGE_PERIOD + 2)
-        s = fc.sr_post(
-            "runStatus",
+        time.sleep(_CACHE_AND_SIM_PURGE_PERIOD + 3)
+        s = _state_eq(
+            auth_fc,
             PKDict(
                 computeJobHash=r.computeJobHash,
                 models=d.models,
@@ -110,9 +109,17 @@ def test_elegant_no_frame_after_purge(auth_fc):
                 simulationId=d.models.simulation.simulationId,
                 simulationType=d.simulationType,
             ),
+            "job_run_purged",
         )
-        pkunit.pkeq("job_run_purged", s.state)
-        pkunit.pkeq(
-            0,
-            s.frameCount,
-        )
+        pkunit.pkeq(0, s.frameCount)
+
+
+def _state_eq(fc, req, expect):
+    import time
+    from pykern import pkunit, pkdebug
+
+    # Cannot do a loop here, because runStatus puts the job back
+    # in instances, and the job_supervisor won't purge jobs in instances.
+    r = fc.sr_post("runStatus", req)
+    pkunit.pkeq(expect, r.state)
+    return r


### PR DESCRIPTION
- Fix #7308 ui_websocket default is True and removed False case from test.sh
- Fix #7385 job_supervisor run returns immediately and is not a task
- job_supervisor run_status_op pends until run or status watcher complete
- run_status_update is new op that is sent asynchronously from agent to supervisor
- job_agent separate out logic for run/state; reconnects to sbatch job
- job_cmd restructured and more error handling
- job_cmd centralized dispatch in _process_msg
- job_cmd._do_compute more robust and supports separate run/status
- job documents more ops and statuses
- Added max_procs=4 to test.sh to parallelize tests
- Fixed global state checks (mpiexec) to allow parallel test execution
- Increased timeouts to allow for delays during parallel test execution
- Improve arg validation in simulation_db.json_filename
- sbatchLoginService commented out invalid state transitions
- SIREPO.srlog includes time