### PR TITLE
fix #7433 ensure computed intensity limit return a valid number

### DIFF
--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -5529,6 +5529,13 @@ SIREPO.app.service('utilities', function($window, $interval, $interpolate, $root
 
     this.roundToPlaces = (val, p) => SIREPO.UTILS.roundToPlaces(val, p);
 
+    // Returns 0 for empty or NaN values
+    this.safeNumber = (value) => {
+        return ! value || isNaN(value)
+             ? 0
+             : value;
+    };
+
     this.trimText = function(text, maxLines, maxLength) {
         const m = text.match(new RegExp(`^(.*\n+){${maxLines}}`));
         if (m) {

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -453,6 +453,15 @@ SIREPO.app.factory('appState', function(errorService, fileManager, msgRouter, re
                             callback(resp);
                         }
                     },
+                    errorCallback: function(resp) {
+                        // give the user some feedback that the save failed
+                        if (! resp || resp.error === 'Server Error') {
+                            errorService.alertText('Save failed due to a server error');
+                        }
+                        else {
+                            errorService.alertText(resp.error);
+                        }
+                    },
                     data: lastAutoSaveData
                 };
             }

--- a/sirepo/package_data/static/js/srw.js
+++ b/sirepo/package_data/static/js/srw.js
@@ -68,7 +68,7 @@ SIREPO.app.config(function() {
     SIREPO.BEAMLINE_WATCHPOINT_MODEL_PREFIX = 'beamlineAnimation';
 });
 
-SIREPO.app.factory('srwService', function(activeSection, appDataService, appState, beamlineService, panelState, requestSender, $location, $rootScope) {
+SIREPO.app.factory('srwService', function(appDataService, appState, beamlineService, panelState, requestSender, utilities, $location, $rootScope) {
     var self = {};
     self.showCalcCoherence = false;
 
@@ -146,7 +146,6 @@ SIREPO.app.factory('srwService', function(activeSection, appDataService, appStat
             // update plot size info from summaryData
             if (appState.isLoaded()) {
                 var range = info.fieldRange;
-                // var intensityRange = info.fieldIntensityRange;
                 var m = appState.models[modelKey];
                 // only set the default plot range if no override is currently used
                 if (m && 'usePlotRange' in m && m.usePlotRange == '0') {
@@ -157,8 +156,8 @@ SIREPO.app.factory('srwService', function(activeSection, appDataService, appStat
                     appState.saveQuietly(modelKey);
                 }
                 if (m && 'useIntensityLimits' in m && m.useIntensityLimits == '0') {
-                    m.minIntensityLimit = info.fieldIntensityRange[0]; // intensityRange[0];
-                    m.maxIntensityLimit = info.fieldIntensityRange[1]; // intensityRange[1];
+                    m.minIntensityLimit = utilities.safeNumber(info.fieldIntensityRange[0]);
+                    m.maxIntensityLimit = utilities.safeNumber(info.fieldIntensityRange[1]);
                     appState.saveQuietly(modelKey);
                 }
             }

--- a/sirepo/template/srw.py
+++ b/sirepo/template/srw.py
@@ -415,7 +415,7 @@ def extract_report_data(sim_in):
             .get("summaryData", {})
             .get(
                 "fieldIntensityRange",
-                [np.min(points), np.max(points)],
+                [0, 0] if np.isnan(points).all() else [np.min(points), np.max(points)],
             ),
         ),
     )


### PR DESCRIPTION
 - updated autoSave to display an alert if an error occurs during save
 - protect against NaN intensity ranges on the client (for cached plot data) and on the server