### PR TITLE
Fix #7536 add SIREPO_STATUS_REPLY_SENTINEL

### DIFF
--- a/sirepo/status.py
+++ b/sirepo/status.py
@@ -35,6 +35,7 @@ class API(sirepo.quest.API):
         return self.reply_ok(
             {
                 "datetime": datetime.datetime.utcnow().isoformat(),
+                "sentinel": _cfg.reply_sentinel,
             }
         )
 
@@ -136,13 +137,13 @@ class API(sirepo.quest.API):
 
 
 def init_apis(*args, **kwargs):
-    pass
+    global _cfg
 
-
-_cfg = pkconfig.init(
-    max_calls=(30, int, "1 second calls"),
-    # only used for srunit
-    sim_name=("Undulator Radiation", str, "which sim"),
-    sim_report=("initialIntensityReport", str, "which report"),
-    sim_type=("srw", str, "which app to test"),
-)
+    _cfg = pkconfig.init(
+        max_calls=(30, int, "1 second calls"),
+        reply_sentinel=("any-string", str, "unique string for reply"),
+        # only configured for srunit
+        sim_name=("Undulator Radiation", str, "which sim"),
+        sim_report=("initialIntensityReport", str, "which report"),
+        sim_type=("srw", str, "which app to test"),
+    )

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -10,6 +10,7 @@ import pytest
 pytestmark = pytest.mark.sirepo_args(
     fc_module=PKDict(
         cfg=PKDict(
+            SIREPO_STATUS_REPLY_SENTINEL="unique-value",
             SIREPO_STATUS_SIM_NAME="Scooby Doo",
             SIREPO_STATUS_SIM_REPORT="heightWeightReport",
             SIREPO_STATUS_SIM_TYPE="myapp",
@@ -25,7 +26,9 @@ def test_basic(auth_fc):
     import base64
 
     def _status(fc, headers):
-        pkeq("ok", fc.sr_get_json("serverStatus", headers=headers).state)
+        r = fc.sr_get_json("serverStatus", headers=headers)
+        pkeq("ok", r.state)
+        pkeq("unique-value", r.sentinel)
 
     # POSIT: sirepo.auth.basic.require_user returns logged_in_user in srunit
     u = auth_fc.sr_login_as_guest()


### PR DESCRIPTION
- Fixed conftest.py to parse fc_args always