### PR TITLE
Fix #7541: Enable jupyter explicilty (not through sim type)

### DIFF
--- a/etc/run.sh
+++ b/etc/run.sh
@@ -112,6 +112,7 @@ _op_jupyterhub() {
     if ! type configurable-http-proxy &> /dev/null; then
         npm install --global configurable-http-proxy
     fi
+    export SIREPO_FEATURE_CONFIG_ENABLE_JUPYTER=1
     _env_moderate jupyterhublogin
     sirepo service jupyterhub &
     _op_nginx_proxy

--- a/sirepo/const.py
+++ b/sirepo/const.py
@@ -55,6 +55,8 @@ SIM_DATA_BASENAME = "sirepo-data" + JSON_SUFFIX
 #: Simulation file name saved both in sim db and run directory
 SIM_RUN_INPUT_BASENAME = "in" + JSON_SUFFIX
 
+SIM_TYPE_JUPYTERHUBLOGIN = "jupyterhublogin"
+
 SRUNIT_USER_AGENT = "srunit/1.0"
 
 TEST_PORT_RANGE = range(10000, 20000)

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -100,6 +100,10 @@ def for_sim_type(sim_type):
     )
 
 
+def jupyter_is_enabled():
+    return cfg().enable_jupyter
+
+
 def have_payments():
     return "payments" in cfg().api_modules
 
@@ -130,6 +134,7 @@ def _init():
     from pykern import pkconfig
     from pykern import pkio
     from pykern.pkdebug import pkdp
+    from sirepo import jupyterhub
 
     global _cfg
 
@@ -160,6 +165,7 @@ def _init():
             bool,
             "enable the global resources allocation system",
         ),
+        enable_jupyter=(False, bool, "enable sirepo jupyter"),
         jspec=dict(
             derbenevskrinsky_force_formula=_test(
                 "Include Derbenev-Skrinsky force formula"
@@ -254,6 +260,10 @@ def _init():
     for v in _DEPENDENT_CODES:
         if v[0] in s:
             s.add(v[1])
+    if jupyterhub.SIM_TYPE in s:
+        _cfg.enable_jupyter = True
+    if jupyter_is_enabled():
+        s.add(jupyterhub.SIM_TYPE)
     _cfg.sim_types = frozenset(s)
     _check_packages(_cfg.package_path)
     _cfg.is_fedora_36 = _is_fedora_36()

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -1,34 +1,40 @@
-# -*- coding: utf-8 -*-
 """List of features available
 
-:copyright: Copyright (c) 2016 RadiaSoft LLC.  All Rights Reserved.
+To add a code that is not in the default list:
+
+    export SIREPO_FEATURE_CONFIG_SIM_TYPES=ALL_CODES:raydata
+
+:copyright: Copyright (c) 2016-2025 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+
 # defer all imports so *_CODES is available to testing functions
 
 
-#: Codes that depend on other codes. [x][0] depends on [x][1]
+#: Codes that depend on other codes
+_DEPENDENT_CODES = dict(
+    jspec=frozenset(("elegant",)),
+    controls=frozenset(("madx",)),
+    omega=frozenset(("elegant", "omega", "genesis")),
+)
 
-_DEPENDENT_CODES = [
-    ["jspec", "elegant"],
-    ["controls", "madx"],
-    ["omega", "elegant"],
-    ["omega", "genesis"],
-    ["omega", "opal"],
-]
-
-#: Codes on prod
-PROD_FOSS_CODES = frozenset(
+FOSS_CODES = frozenset(
     (
         "activait",
-        "openmc",
+        "canvas",
         "controls",
         "elegant",
+        "epicsllrf",
         "genesis",
+        "hellweg",
+        "impactt",
+        "impactx",
         "jspec",
         "madx",
+        "myapp",
         "omega",
         "opal",
+        "openmc",
         "radia",
         "shadow",
         "silas",
@@ -39,20 +45,7 @@ PROD_FOSS_CODES = frozenset(
     )
 )
 
-#: Codes on dev, alpha, and beta
-_NON_PROD_FOSS_CODES = frozenset(
-    (
-        "canvas",
-        "epicsllrf",
-        "impactt",
-        "impactx",
-        "myapp",
-        "hellweg",
-    )
-)
-
-#: All possible open source codes
-FOSS_CODES = PROD_FOSS_CODES.union(_NON_PROD_FOSS_CODES)
+_ALL_CODES = "ALL_CODES"
 
 #: Configuration
 _cfg = None
@@ -100,10 +93,6 @@ def for_sim_type(sim_type):
     )
 
 
-def jupyter_is_enabled():
-    return cfg().enable_jupyter
-
-
 def have_payments():
     return "payments" in cfg().api_modules
 
@@ -121,15 +110,6 @@ def proprietary_sim_types():
     )
 
 
-def _is_fedora_36():
-    from pykern import pkio
-
-    p = pkio.py_path("/etc/os-release")
-    if not p.check():
-        return False
-    return "fedora:36" in p.read()
-
-
 def _init():
     from pykern import pkconfig
     from pykern import pkio
@@ -138,8 +118,28 @@ def _init():
 
     global _cfg
 
+    def _check_package_path(path):
+        import importlib
+
+        for p in path:
+            importlib.import_module(p)
+
+    def _default_sim_types(sim_types):
+        if not sim_types or _ALL_CODES in sim_types:
+            sim_types.update(FOSS_CODES)
+            sim_types.discard(_ALL_CODES)
+        return sim_types
+
     def _dev(msg):
         return (pkconfig.in_dev_mode(), bool, msg)
+
+    def _is_fedora_36():
+        from pykern import pkio
+
+        p = pkio.py_path("/etc/os-release")
+        if not p.check():
+            return False
+        return "fedora:36" in p.read()
 
     def _test(msg):
         return (pkconfig.channel_in_internal_test(), bool, msg)
@@ -165,7 +165,6 @@ def _init():
             bool,
             "enable the global resources allocation system",
         ),
-        enable_jupyter=(False, bool, "enable sirepo jupyter"),
         jspec=dict(
             derbenevskrinsky_force_formula=_test(
                 "Include Derbenev-Skrinsky force formula"
@@ -249,31 +248,17 @@ def _init():
             ),
         ),
     )
-    s = set(
-        _cfg.sim_types
-        or (PROD_FOSS_CODES if pkconfig.channel_in("prod") else FOSS_CODES)
-    )
+    s = _default_sim_types(set(_cfg.sim_types))
     s.update(
         _cfg.default_proprietary_sim_types,
         _cfg.moderated_sim_types,
         _cfg.proprietary_oauth_sim_types,
         _cfg.proprietary_sim_types,
     )
-    for v in _DEPENDENT_CODES:
-        if v[0] in s:
-            s.add(v[1])
-    if const.SIM_TYPE_JUPYTERHUBLOGIN in s:
-        _cfg.enable_jupyter = True
-    if jupyter_is_enabled():
-        s.add(const.SIM_TYPE_JUPYTERHUBLOGIN)
+    for k, v in _DEPENDENT_CODES.items():
+        if k in s:
+            s.update(v)
     _cfg.sim_types = frozenset(s)
-    _check_packages(_cfg.package_path)
+    _check_package_path(_cfg.package_path)
     _cfg.is_fedora_36 = _is_fedora_36()
     return _cfg
-
-
-def _check_packages(packages):
-    import importlib
-
-    for p in packages:
-        importlib.import_module(p)

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -134,7 +134,7 @@ def _init():
     from pykern import pkconfig
     from pykern import pkio
     from pykern.pkdebug import pkdp
-    from sirepo import jupyterhub
+    from sirepo import const
 
     global _cfg
 
@@ -260,10 +260,10 @@ def _init():
     for v in _DEPENDENT_CODES:
         if v[0] in s:
             s.add(v[1])
-    if jupyterhub.SIM_TYPE in s:
+    if const.SIM_TYPE_JUPYTERHUBLOGIN in s:
         _cfg.enable_jupyter = True
     if jupyter_is_enabled():
-        s.add(jupyterhub.SIM_TYPE)
+        s.add(const.SIM_TYPE_JUPYTERHUBLOGIN)
     _cfg.sim_types = frozenset(s)
     _check_packages(_cfg.package_path)
     _cfg.is_fedora_36 = _is_fedora_36()

--- a/sirepo/jupyterhub.py
+++ b/sirepo/jupyterhub.py
@@ -14,7 +14,7 @@ import requests
 import tornado.web
 import traitlets
 
-_SIM_TYPE = "jupyterhublogin"
+SIM_TYPE = "jupyterhublogin"
 
 
 def template_dirs():

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
-"""?
+"""Application administration
 
 :copyright: Copyright (c) 2017 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+
 from pykern import pkio, pkconfig
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdc, pkdexc, pkdlog, pkdp
@@ -20,6 +20,7 @@ import json
 import os.path
 import re
 import shutil
+import sirepo.const
 import sirepo.quest
 
 
@@ -85,7 +86,7 @@ def delete_user(uid):
         if qcall.auth.unchecked_get_user(uid) is None:
             return
         with qcall.auth.logged_in_user_set(uid):
-            if feature_config.jupyter_is_enabled():
+            if sirepo.util.is_jupyter_enabled():
                 from sirepo.sim_api import jupyterhublogin
 
                 jupyterhublogin.delete_user_dir(qcall=qcall)

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -85,7 +85,7 @@ def delete_user(uid):
         if qcall.auth.unchecked_get_user(uid) is None:
             return
         with qcall.auth.logged_in_user_set(uid):
-            if sirepo.template.is_sim_type("jupyterhublogin"):
+            if feature_config.jupyter_is_enabled():
                 from sirepo.sim_api import jupyterhublogin
 
                 jupyterhublogin.delete_user_dir(qcall=qcall)

--- a/sirepo/pkcli/jupyterhublogin.py
+++ b/sirepo/pkcli/jupyterhublogin.py
@@ -11,6 +11,7 @@ from pykern.pkdebug import pkdp, pkdlog
 import pyisemail
 import sirepo.auth
 import sirepo.auth_role
+import sirepo.feature_config
 import sirepo.quest
 import sirepo.sim_api.jupyterhublogin
 import sirepo.template
@@ -49,7 +50,8 @@ def create_user(email, display_name):
 
     if not pyisemail.is_email(email):
         pkcli.command_error("invalid email={}", email)
-    sirepo.template.assert_sim_type("jupyterhublogin")
+    if not sirepo.feature_config.jupyter_is_enabled():
+        pkcli.command_error("jupyter must be enabled")
     with sirepo.quest.start() as qcall:
         u = maybe_create_sirepo_user(
             qcall,

--- a/sirepo/pkcli/jupyterhublogin.py
+++ b/sirepo/pkcli/jupyterhublogin.py
@@ -15,6 +15,7 @@ import sirepo.feature_config
 import sirepo.quest
 import sirepo.sim_api.jupyterhublogin
 import sirepo.template
+import sirepo.util
 
 
 def create_user(email, display_name):
@@ -50,7 +51,7 @@ def create_user(email, display_name):
 
     if not pyisemail.is_email(email):
         pkcli.command_error("invalid email={}", email)
-    if not sirepo.feature_config.jupyter_is_enabled():
+    if not sirepo.util.is_jupyter_enabled():
         pkcli.command_error("jupyter must be enabled")
     with sirepo.quest.start() as qcall:
         u = maybe_create_sirepo_user(

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -147,7 +147,7 @@ def nginx_proxy():
     with pkio.save_chdir(run_dir) as d:
         f = run_dir.join("default.conf")
         c = PKDict(_cfg()).pkupdate(run_dir=str(d))
-        if sirepo.template.is_sim_type("jupyterhublogin"):
+        if sirepo.feature_config.jupyter_is_enabled():
             c.pkupdate(
                 jupyterhub_root=sirepo.sim_api.jupyterhublogin.cfg().uri_root,
             )

--- a/sirepo/pkcli/service.py
+++ b/sirepo/pkcli/service.py
@@ -147,7 +147,7 @@ def nginx_proxy():
     with pkio.save_chdir(run_dir) as d:
         f = run_dir.join("default.conf")
         c = PKDict(_cfg()).pkupdate(run_dir=str(d))
-        if sirepo.feature_config.jupyter_is_enabled():
+        if sirepo.util.is_jupyter_enabled():
             c.pkupdate(
                 jupyterhub_root=sirepo.sim_api.jupyterhublogin.cfg().uri_root,
             )

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -9,8 +9,8 @@ from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp, pkdlog, pkdexc
 import re
 import sirepo.api_perm
+import sirepo.const
 import sirepo.events
-import sirepo.jupyterhub
 import sirepo.oauth
 import sirepo.quest
 import sirepo.srdb
@@ -31,12 +31,13 @@ _JUPYTERHUB_LOGOUT_USER_NAME_ATTR = "jupyterhub_logout_user_name"
 
 class API(sirepo.quest.API):
     @sirepo.quest.Spec(
-        "require_plan", sim_type=f"SimType const={sirepo.jupyterhub.SIM_TYPE}"
+        "require_plan",
+        sim_type=f"SimType const={sirepo.const.SIM_TYPE_JUPYTERHUBLOGIN}",
     )
     async def api_checkAuthJupyterHub(self):
         # TODO(rorour) do this role check at a higher level
         # (see https://github.com/radiasoft/sirepo/issues/7026)
-        self.parse_params(type=sirepo.jupyterhub.SIM_TYPE)
+        self.parse_params(type=sirepo.const.SIM_TYPE_JUPYTERHUBLOGIN)
         u = _unchecked_jupyterhub_user_name(
             self,
             have_simulation_db=False,
@@ -46,12 +47,13 @@ class API(sirepo.quest.API):
         return self.reply_ok(PKDict(username=u))
 
     @sirepo.quest.Spec(
-        "require_plan", sim_type=f"SimType const={sirepo.jupyterhub.SIM_TYPE}"
+        "require_plan",
+        sim_type=f"SimType const={sirepo.const.SIM_TYPE_JUPYTERHUBLOGIN}",
     )
     async def api_redirectJupyterHub(self):
         # TODO(rorour) do this role check at a higher level
         # (see https://github.com/radiasoft/sirepo/issues/7026)
-        self.parse_params(type=sirepo.jupyterhub.SIM_TYPE)
+        self.parse_params(type=sirepo.const.SIM_TYPE_JUPYTERHUBLOGIN)
         if not _unchecked_jupyterhub_user_name(self):
             create_user(self)
         return self.reply_redirect("jupyterHub")

--- a/sirepo/sim_api/jupyterhublogin.py
+++ b/sirepo/sim_api/jupyterhublogin.py
@@ -10,6 +10,7 @@ from pykern.pkdebug import pkdp, pkdlog, pkdexc
 import re
 import sirepo.api_perm
 import sirepo.events
+import sirepo.jupyterhub
 import sirepo.oauth
 import sirepo.quest
 import sirepo.srdb
@@ -27,15 +28,15 @@ _INVALID_USER_NAME_CHARS = re.compile(r"[^a-z0-9]+")
 
 _JUPYTERHUB_LOGOUT_USER_NAME_ATTR = "jupyterhub_logout_user_name"
 
-_SIM_TYPE = "jupyterhublogin"
-
 
 class API(sirepo.quest.API):
-    @sirepo.quest.Spec("require_plan", sim_type=f"SimType const={_SIM_TYPE}")
+    @sirepo.quest.Spec(
+        "require_plan", sim_type=f"SimType const={sirepo.jupyterhub.SIM_TYPE}"
+    )
     async def api_checkAuthJupyterHub(self):
         # TODO(rorour) do this role check at a higher level
         # (see https://github.com/radiasoft/sirepo/issues/7026)
-        self.parse_params(type=_SIM_TYPE)
+        self.parse_params(type=sirepo.jupyterhub.SIM_TYPE)
         u = _unchecked_jupyterhub_user_name(
             self,
             have_simulation_db=False,
@@ -44,11 +45,13 @@ class API(sirepo.quest.API):
             u = create_user(self)
         return self.reply_ok(PKDict(username=u))
 
-    @sirepo.quest.Spec("require_plan", sim_type=f"SimType const={_SIM_TYPE}")
+    @sirepo.quest.Spec(
+        "require_plan", sim_type=f"SimType const={sirepo.jupyterhub.SIM_TYPE}"
+    )
     async def api_redirectJupyterHub(self):
         # TODO(rorour) do this role check at a higher level
         # (see https://github.com/radiasoft/sirepo/issues/7026)
-        self.parse_params(type=_SIM_TYPE)
+        self.parse_params(type=sirepo.jupyterhub.SIM_TYPE)
         if not _unchecked_jupyterhub_user_name(self):
             create_user(self)
         return self.reply_redirect("jupyterHub")

--- a/sirepo/util.py
+++ b/sirepo/util.py
@@ -13,6 +13,7 @@ import asyncio
 import base64
 import hashlib
 import importlib
+import io
 import inspect
 import numconv
 import pykern.pkinspect
@@ -20,7 +21,7 @@ import pykern.pkio
 import pykern.pkjson
 import re
 import random
-import six
+import sirepo.const
 import unicodedata
 import zipfile
 
@@ -350,6 +351,10 @@ def import_submodule(submodule, type_or_data):
     )
 
 
+def is_jupyter_enabled():
+    return is_sim_type(sirepo.const.SIM_TYPE_JUPYTERHUBLOGIN)
+
+
 def is_python_identifier(name):
     return _VALID_PYTHON_IDENTIFIER.search(name)
 
@@ -410,7 +415,7 @@ def read_zip(path_or_bytes):
     """
     p = path_or_bytes
     if isinstance(p, bytes):
-        p = six.BytesIO(p)
+        p = io.BytesIO(p)
     with zipfile.ZipFile(p, "r") as z:
         for i in z.infolist():
             if i.is_dir():


### PR DESCRIPTION
jupyter is independent of prod/non-prod codes. We either want it enabled or not and we don't really care that it works by using a sim type. So, move the configuration into an explicit variable.

On sirepo alpha this will allow us to keep the existing configuration (not specifying sim types) while moving jupyterhublogin from a moderated_sim_types to just a sim_type (sirepo is now moderated across the board).