### PR TITLE
fix #7545 no moderation required for non-email authentication methods

### DIFF
--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -672,7 +672,6 @@ class _Auth(sirepo.quest.Attr):
             roles=[],
             userName=None,
             uiWebSocket=sirepo.feature_config.cfg().ui_websocket,
-            userModeration=sirepo.feature_config.cfg().user_moderation,
             visibleMethods=visible_methods,
         )
         if "sbatch" in v.jobRunModeMap:
@@ -708,11 +707,10 @@ class _Auth(sirepo.quest.Attr):
         u = simulation_db.user_create()
         if want_login:
             self._login_user(module, u)
-        if r := sirepo.auth_role.for_new_user(
-            is_guest=module.AUTH_METHOD == METHOD_GUEST
-        ):
-            with self.logged_in_user_set(u, method=module.AUTH_METHOD):
-                self.qcall.auth_db.model("UserRole").add_roles(roles=r)
+        with self.logged_in_user_set(u, method=module.AUTH_METHOD):
+            self.qcall.auth_db.model("UserRole").add_roles(
+                roles=sirepo.auth_role.for_new_user()
+            )
         return u
 
     def _handle_user_dir_not_found(self, user_dir, uid):

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -709,9 +709,7 @@ class _Auth(sirepo.quest.Attr):
             self._login_user(module, u)
         with self.logged_in_user_set(u, method=module.AUTH_METHOD):
             self.qcall.auth_db.model("UserRole").add_roles(
-                roles=sirepo.auth_role.for_new_user(
-                    is_guest=module.AUTH_METHOD == METHOD_GUEST
-                )
+                roles=sirepo.auth_role.for_new_user(module.AUTH_METHOD)
             )
         return u
 

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -709,7 +709,9 @@ class _Auth(sirepo.quest.Attr):
             self._login_user(module, u)
         with self.logged_in_user_set(u, method=module.AUTH_METHOD):
             self.qcall.auth_db.model("UserRole").add_roles(
-                roles=sirepo.auth_role.for_new_user()
+                roles=sirepo.auth_role.for_new_user(
+                    is_guest=module.AUTH_METHOD == METHOD_GUEST
+                )
             )
         return u
 

--- a/sirepo/auth/__init__.py
+++ b/sirepo/auth/__init__.py
@@ -672,6 +672,7 @@ class _Auth(sirepo.quest.Attr):
             roles=[],
             userName=None,
             uiWebSocket=sirepo.feature_config.cfg().ui_websocket,
+            userModeration=sirepo.feature_config.cfg().user_moderation,
             visibleMethods=visible_methods,
         )
         if "sbatch" in v.jobRunModeMap:

--- a/sirepo/auth_role.py
+++ b/sirepo/auth_role.py
@@ -40,9 +40,9 @@ def for_moderated_sim_types():
     return [for_sim_type(s) for s in sirepo.feature_config.cfg().moderated_sim_types]
 
 
-def for_new_user():
+def for_new_user(is_guest):
     if pkconfig.in_dev_mode():
-        return list(filter(lambda r: r != ROLE_ADM, get_all()))
+        return list(filter(lambda r: is_guest or r != ROLE_ADM, get_all()))
     return [ROLE_USER]
 
 

--- a/sirepo/auth_role.py
+++ b/sirepo/auth_role.py
@@ -40,9 +40,15 @@ def for_moderated_sim_types():
     return [for_sim_type(s) for s in sirepo.feature_config.cfg().moderated_sim_types]
 
 
-def for_new_user(is_guest):
-    if pkconfig.in_dev_mode():
-        return list(filter(lambda r: is_guest or r != ROLE_ADM, get_all()))
+def for_new_user(auth_method):
+    import sirepo.auth
+
+    if pkconfig.in_dev_mode:
+        if auth_method == sirepo.auth.METHOD_GUEST:
+            return get_all()
+        # the email auth method on dev has limited roles for unit tests
+        if auth_method != sirepo.auth.METHOD_EMAIL:
+            return list(filter(lambda r: r != ROLE_ADM, get_all()))
     return [ROLE_USER]
 
 

--- a/sirepo/auth_role.py
+++ b/sirepo/auth_role.py
@@ -40,9 +40,9 @@ def for_moderated_sim_types():
     return [for_sim_type(s) for s in sirepo.feature_config.cfg().moderated_sim_types]
 
 
-def for_new_user(is_guest):
-    if is_guest and pkconfig.in_dev_mode():
-        return get_all()
+def for_new_user():
+    if pkconfig.in_dev_mode():
+        return list(filter(lambda r: r != ROLE_ADM, get_all()))
     return [ROLE_USER]
 
 

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -234,6 +234,11 @@ def _init():
             bool,
             "whether the UI should use a websocket",
         ),
+        user_moderation=(
+            True,
+            bool,
+            "whether user moderation is required for authenticated users",
+        ),
         warpvnd=dict(
             allow_3d_mode=(True, bool, "Include 3D features in the Warp VND UI"),
             display_test_boxes=_dev(

--- a/sirepo/feature_config.py
+++ b/sirepo/feature_config.py
@@ -234,11 +234,6 @@ def _init():
             bool,
             "whether the UI should use a websocket",
         ),
-        user_moderation=(
-            True,
-            bool,
-            "whether user moderation is required for authenticated users",
-        ),
         warpvnd=dict(
             allow_3d_mode=(True, bool, "Include 3D features in the Warp VND UI"),
             display_test_boxes=_dev(

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -3542,7 +3542,7 @@ SIREPO.app.directive('completeRegistration', function() {
         template: `
             <div class="col-sm-12 col-md-offset-2 col-md-8 col-lg-offset-3 col-lg-6">
               <form class="form-horizontal" autocomplete="off" novalidate>
-                <h2>Moderation Request</h2>
+                <h2 data-ng-if="userModeration">Moderation Request</h2>
                 <p>Please enter your full name to complete your Sirepo registration.</p>
                 <div class="form-group">
                   <label class="col-sm-3 control-label">Your full name</label>
@@ -3552,19 +3552,21 @@ SIREPO.app.directive('completeRegistration', function() {
                     <div class="sr-input-warning" data-ng-show="showWarning">{{ loginConfirm.warningText }}</div>
                   </div>
                 </div>
-                <p>To prevent abuse of our systems all new users must supply a reason for
-                  requesting access to {{ shortName }}. In a few sentences please describe
-                  how you plan to use {{ shortName }}</p>
-                <div class="form-group">
-                  <div class="col-sm-12">
-                    <textarea data-ng-model="loginConfirm.data.reason" id="requestAccessExplanation"
-                      class="form-control" rows="4" cols="50" required></textarea>
-                  </div>
+                <div data-ng-if="userModeration">
+                    <p>To prevent abuse of our systems all new users must supply a reason for
+                      requesting access to {{ shortName }}. In a few sentences please describe
+                      how you plan to use {{ shortName }}</p>
+                    <div class="form-group">
+                      <div class="col-sm-12">
+                        <textarea data-ng-model="loginConfirm.data.reason" id="requestAccessExplanation"
+                          class="form-control" rows="4" cols="50" required></textarea>
+                      </div>
+                    </div>
                 </div>
                 <div class="form-group">
-                  <div class="col-sm-12">
+                  <div class="col-sm-9 col-sm-offset-3">
                    <button data-ng-click="loginConfirm.submit()" class="btn btn-primary"
-                     data-ng-disabled="! (loginConfirm.data.displayName && loginConfirm.data.reason)">Submit</button>
+                     data-ng-disabled="! canSubmit()">Submit</button>
                   </div>
                 </div>
               </form>
@@ -3576,8 +3578,19 @@ SIREPO.app.directive('completeRegistration', function() {
                 after your request has been reviewed.</p>
             </div>
         `,
-        controller: function($scope) {
+        controller: function(authState, $scope) {
             $scope.shortName = SIREPO.APP_SCHEMA.productInfo.shortName;
+            $scope.userModeration = authState.userModeration;
+
+            $scope.canSubmit = () => {
+                if (! $scope.loginConfirm.data.displayName) {
+                    return false;
+                }
+                if (authState.userModeration) {
+                    return !!$scope.loginConfirm.data.reason;
+                }
+                return true;
+            };
         },
     };
 });
@@ -3708,6 +3721,8 @@ SIREPO.app.directive('ldapLogin', function (requestSender) {
                 <div class="col-sm-10">
                   <input type="text" value='' maxlength="256" class="form-control" data-ng-model="user"/>
                 </div>
+              </div>
+              <div class="form-group">
                 <label class="col-sm-2 control-label">Password</label>
                 <div class="col-sm-10">
                   <input type="password" value='' maxlength="256" class="form-control" data-ng-model="password"/>

--- a/sirepo/package_data/static/js/sirepo-components.js
+++ b/sirepo/package_data/static/js/sirepo-components.js
@@ -3542,7 +3542,7 @@ SIREPO.app.directive('completeRegistration', function() {
         template: `
             <div class="col-sm-12 col-md-offset-2 col-md-8 col-lg-offset-3 col-lg-6">
               <form class="form-horizontal" autocomplete="off" novalidate>
-                <h2 data-ng-if="userModeration">Moderation Request</h2>
+                <h2 data-ng-if="isModerated">Moderation Request</h2>
                 <p>Please enter your full name to complete your Sirepo registration.</p>
                 <div class="form-group">
                   <label class="col-sm-3 control-label">Your full name</label>
@@ -3552,7 +3552,7 @@ SIREPO.app.directive('completeRegistration', function() {
                     <div class="sr-input-warning" data-ng-show="showWarning">{{ loginConfirm.warningText }}</div>
                   </div>
                 </div>
-                <div data-ng-if="userModeration">
+                <div data-ng-if="isModerated">
                     <p>To prevent abuse of our systems all new users must supply a reason for
                       requesting access to {{ shortName }}. In a few sentences please describe
                       how you plan to use {{ shortName }}</p>
@@ -3580,13 +3580,13 @@ SIREPO.app.directive('completeRegistration', function() {
         `,
         controller: function(authState, $scope) {
             $scope.shortName = SIREPO.APP_SCHEMA.productInfo.shortName;
-            $scope.userModeration = authState.userModeration;
+            $scope.isModerated = authState.isModerated();
 
             $scope.canSubmit = () => {
                 if (! $scope.loginConfirm.data.displayName) {
                     return false;
                 }
-                if (authState.userModeration) {
+                if ($scope.isModerated) {
                     return !!$scope.loginConfirm.data.reason;
                 }
                 return true;

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -327,6 +327,8 @@ SIREPO.app.factory('authState', (errorService, uri, $rootScope) => {
         return self.roles.hasOwnProperty(role);
     };
 
+    self.isModerated = () => self.method === 'email';
+
     self.paymentPlanName = () => {
         const rv = SIREPO.APP_SCHEMA.constants.paymentPlans[self.paymentPlan];
         if (! rv) {
@@ -4705,7 +4707,7 @@ SIREPO.app.controller('LoginConfirmController', function (authState, requestSend
                 '<token>': p.token,
             },
             function (data) {
-                if (data.state === 'ok' && self.needCompleteRegistration && authState.userModeration) {
+                if (data.state === 'ok' && self.needCompleteRegistration && authState.isModerated()) {
                     $('#sr-complete-registration-done').modal('show');
                     return;
                 }

--- a/sirepo/package_data/static/js/sirepo.js
+++ b/sirepo/package_data/static/js/sirepo.js
@@ -4705,7 +4705,7 @@ SIREPO.app.controller('LoginConfirmController', function (authState, requestSend
                 '<token>': p.token,
             },
             function (data) {
-                if (data.state === 'ok' && self.needCompleteRegistration) {
+                if (data.state === 'ok' && self.needCompleteRegistration && authState.userModeration) {
                     $('#sr-complete-registration-done').modal('show');
                     return;
                 }


### PR DESCRIPTION
Turning off SIREPO_FEATURE_CONFIG_USER_MODERATION will stop moderation requests.