### PR TITLE
Provide the ability to use SSH-forwarded Unix Domain Sockets to connect to a job agent (e.g. on NERSC)

### DIFF
--- a/sirepo/__init__.py
+++ b/sirepo/__init__.py
@@ -4,10 +4,10 @@
 :license: https://www.apache.org/licenses/LICENSE-2.0.html
 """
 
-import pkg_resources
+import importlib.metadata
 
 try:
+    __version__ = importlib.metadata.version("sirepo")
+except importlib.metadata.PackageNotFoundError:
     # We only have a version once the package is installed.
-    __version__ = pkg_resources.get_distribution("sirepo").version
-except pkg_resources.DistributionNotFound:
     pass

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -1039,7 +1039,6 @@ class _SbatchRun(_SbatchCmd):
             f.write(content)
             return f"{cmd} {f}" if cmd else str(f)
 
-
         def _nodes_tasks():
             if n := self.msg.get("sbatchNodes"):
                 return f"#SBATCH --nodes={n}\n#SBATCH --cpus-per-task={self.msg.sbatchCores}"

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -1045,10 +1045,13 @@ class _SbatchRun(_SbatchCmd):
                 return f"#SBATCH --nodes={n}\n#SBATCH --cpus-per-task={self.msg.sbatchCores}"
             return f"#SBATCH --ntasks={self.msg.sbatchCores}"
 
-        def _python():
-            return (
-                "shifter --entrypoint " if self.msg.get("shifterImage") else ""
-            ) + "python"
+        def _python(include_image=False):
+            rv = "python"
+            if i := self.msg.get("shifterImage"):
+                if include_image:
+                    rv = f"--image={i} {rv}"
+                rv = "shifter --entrypoint " + rv
+            return rv
 
         def _shifter_header():
             # POSIT: job_api has validated values
@@ -1079,7 +1082,7 @@ exec {_srun()} {_python()} {template_common.PARAMETERS_PYTHON_FILE}
 
         def _sim_prepare_cmd():
             return _in_file(
-                _python(),
+                _python(True),
                 "prepare.py",
                 f"""#!/usr/bin/env python
 import sirepo.sim_data

--- a/sirepo/pkcli/job_agent.py
+++ b/sirepo/pkcli/job_agent.py
@@ -251,21 +251,12 @@ class _Dispatcher(PKDict):
 
     async def loop(self):
         async def _connect_and_loop():
+            tgt_url = _cfg.supervisor_uri
+            resolver = None
             if _cfg.supervisor_uri.startswith("unix:/"): # Handle unix domain sockets
                 socket_path, _, resource_path = _cfg.supervisor_uri.replace("unix:/", "", 1).partition(";")
-                if not resource_path.startswith("/"):
-                    resource_path = "/" + resource_path
-                tgt_url = "ws://localhost:0" + resource_path
+                tgt_url = f"ws://localhost:0/{resource_path.lstrip('/')}"
                 resolver = UnixResolver(socket_path)
-                pkdlog(
-                    "connecting to unix socket={} resource_path={} tgt_url={}",
-                    socket_path,
-                    resource_path,
-                    tgt_url,
-                )
-            else:
-                tgt_url = _cfg.supervisor_uri
-                resolver = None
 
             self._websocket = await tornado.websocket.websocket_connect(
                 tornado.httpclient.HTTPRequest(

--- a/sirepo/srunit.py
+++ b/sirepo/srunit.py
@@ -177,7 +177,7 @@ class _TestClient:
         """
         from pykern.pkunit import pkexcept
 
-        return pkexcept("(SRException|Error)\(")
+        return pkexcept(r"(SRException|Error)\(")
 
     def iter_sleep(self, kind, op_desc):
         import time
@@ -529,17 +529,6 @@ class _TestClient:
                 pkdlog("runCancel")
                 self.sr_post("runCancel", cancel)
             _assert_no_mpiexec()
-
-    def sr_sbatch_animation_run(self, sim_name, compute_model, reports, **kwargs):
-        self.sr_sbatch_login(compute_model, sim_name)
-        self.sr_animation_run(
-            self.sr_sim_data(sim_name, compute_model=compute_model),
-            compute_model,
-            reports,
-            # Things take longer with Slurm.
-            timeout=90,
-            **kwargs,
-        )
 
     def sr_sbatch_creds(self):
         return PKDict(sbatchCredentials=_cfg().sbatch.copy())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,6 @@ import pytest
 import re
 import subprocess
 
-#: Maximum time an individual test case (function) can run
-MAX_CASE_RUN_SECS = int(os.getenv("SIREPO_CONFTEST_MAX_CASE_RUN_SECS", 120))
-
 
 @pytest.fixture(scope="function")
 def auth_fc(auth_fc_module):
@@ -101,30 +98,6 @@ def pytest_collection_modifyitems(session, config, items):
     import sirepo.srunit
 
     sirepo.srunit.CONFTEST_DEFAULT_CODES = ":".join(codes)
-
-
-@pytest.hookimpl(tryfirst=True)
-def pytest_runtest_protocol(item, *args, **kwargs):
-    import signal
-
-    def _timeout(*args, **kwargs):
-        from pykern import pkunit
-
-        signal.signal(signal.SIGALRM, _timeout_failed)
-        signal.alarm(1)
-        pkunit.pkfail("MAX_CASE_RUN_SECS={} exceeded", MAX_CASE_RUN_SECS)
-
-    def _timeout_failed(*args, **kwargs):
-        import os
-        import sys
-        from pykern.pkdebug import pkdlog
-
-        pkdlog("failed to die after timeout (pkfail)")
-        os.killpg(os.getpgrp(), signal.SIGKILL)
-
-    # Seems to be the only way to get the module under test
-    signal.signal(signal.SIGALRM, _timeout)
-    signal.alarm(MAX_CASE_RUN_SECS)
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/tests/sbatch_test.py
+++ b/tests/sbatch_test.py
@@ -4,7 +4,7 @@
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 
-# If you see: _timeout MAX_CASE_RUN_SECS=120 exceeded
+# If you see: TIMEOUT=<time> exceeded, the default
 # Run sinfo to see if slurmd is down for this node.
 # https://github.com/radiasoft/sirepo/issues/2136
 # sudo scontrol <<EOF
@@ -72,10 +72,13 @@ def test_srw_data_file(fc):
     from pykern.pkcollections import PKDict
     from pykern.pkunit import pkeq
 
-    a = "Young's Double Slit Experiment"
+    d = fc.sr_sim_data("Young's Double Slit Experiment")
+    d.models.multiElectronAnimation.numberOfMacroElectrons = 50
+    d.models.simulation.sampleFactor = 0.0001
     c = "multiElectronAnimation"
-    fc.sr_sbatch_animation_run(
-        a,
+    fc.sr_sbatch_login(c, d.models.simulation.name)
+    fc.sr_animation_run(
+        d,
         c,
         PKDict(
             multiElectronAnimation=PKDict(
@@ -84,11 +87,12 @@ def test_srw_data_file(fc):
                 expect_title="E=4.24 keV",
             ),
         ),
+        # Things take longer with Slurm.
+        timeout=90,
         expect_completed=False,
     )
     # TODO(robnagler) jobRunMode needs to be set?
     # https://github.com/radiasoft/sirepo/issues/7093
-    d = fc.sr_sim_data(a, compute_model=c)
     r = fc.sr_get(
         "downloadRunFile",
         PKDict(


### PR DESCRIPTION
In some setups, it may not be possible to open a port to the internet for the job agent to communicate to the Sirepo server. Using SSH to forward a port can be a nice fallback for this situation. This can also eventually allow users to connect to clusters while running Sirepo locally.

We use Unix Domain Sockets (UDS) for this instead of port-to-port forwarding. This eliminates the possibility of port conflicts on the cluster, and provides better security, as the UDS can only be accessed by the user that owns it.

Instead of adding another configuration option, if the supervisor URI points to localost, while the SLURM host is not localhost, the supervisor URI is likely inaccessible and we should try to setup an SSH port forwarding over SSH.