### PR TITLE
fix #7666 use feature_config.package_path when looking up sim_apis

### DIFF
--- a/sirepo/package_data/static/json/cortex-schema.json
+++ b/sirepo/package_data/static/json/cortex-schema.json
@@ -1,4 +1,7 @@
 {
+    "apiRoute": {
+        "cortexDb": "/cortex-db"
+    },
     "appInfo": {
         "cortex": {
             "longName": "CORTEX Material Database",

--- a/sirepo/package_data/static/json/schema-common.json
+++ b/sirepo/package_data/static/json/schema-common.json
@@ -135,7 +135,6 @@
         "contentTooLarge": "/content-too-large",
         "copyNonSessionSimulation": "/copy-non-session-simulation",
         "copySimulation": "/copy-simulation",
-        "cortexDb": "/cortex-db",
         "deleteFile": "/delete-file",
         "deleteLibFile": "/delete-lib-file",
         "deleteSimulation": "/delete-simulation",

--- a/sirepo/simulation_db.py
+++ b/sirepo/simulation_db.py
@@ -913,6 +913,7 @@ def _init_schemas():
 
         # TODO(mvk): improve merging common and local schema
         _merge_dicts(s.common.dynamicFiles, s.dynamicFiles)
+        _merge_dicts(s.get("apiRoute", PKDict()), s.route)
         s.dynamicModules = _files_in_schema(s.dynamicFiles)
         for i in [
             "appDefaults",

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -561,15 +561,15 @@ def _path_to_route(path):
 
 
 def _register_sim_modules(package, sim_types):
-    for pp in sirepo.feature_config.cfg().package_path:
-        p = pkinspect.module_name_join((pp, package))
-        try:
-            for n in pkinspect.package_module_names(p):
-                if n in sim_types:
-                    register_api_module(pkinspect.module_name_join((p, n)))
-        except ModuleNotFoundError:
-            if pp == "sirepo":
-                raise
+    def _modules(package_path):
+        for n in sim_types:
+            try:
+                yield pkinspect.import_submodule(n, package, package_path)
+            except pkinspect.SubmoduleNotFound:
+                continue
+
+    for m in _modules(sirepo.feature_config.cfg().package_path):
+        register_api_module(m)
 
 
 def _split_uri(uri):

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -92,8 +92,10 @@ def init_module(want_apis, **imports):
     f = sirepo.feature_config.cfg()
     for n in _REQUIRED_MODULES + sorted(f.api_modules):
         register_api_module("sirepo." + n)
-    _register_sim_modules("sim_api", f.sim_types)
-    _register_sim_modules("sim_oauth", f.proprietary_oauth_sim_types)
+    _register_sim_modules(
+        sirepo.feature_config.cfg().package_path, "sim_api", f.sim_types
+    )
+    _register_sim_modules(("sirepo",), "sim_oauth", f.proprietary_oauth_sim_types)
     _init_uris(simulation_db, f.sim_types)
 
 
@@ -560,11 +562,12 @@ def _path_to_route(path):
     return (None, route, kwargs)
 
 
-def _register_sim_modules(package, sim_types):
-    p = pkinspect.module_name_join(("sirepo", package))
-    for n in pkinspect.package_module_names(p):
-        if n in sim_types:
-            register_api_module(pkinspect.module_name_join((p, n)))
+def _register_sim_modules(package_path, package, sim_types):
+    for pp in package_path:
+        p = pkinspect.module_name_join((pp, package))
+        for n in pkinspect.package_module_names(p):
+            if n in sim_types:
+                register_api_module(pkinspect.module_name_join((p, n)))
 
 
 def _split_uri(uri):

--- a/sirepo/uri_router.py
+++ b/sirepo/uri_router.py
@@ -92,10 +92,8 @@ def init_module(want_apis, **imports):
     f = sirepo.feature_config.cfg()
     for n in _REQUIRED_MODULES + sorted(f.api_modules):
         register_api_module("sirepo." + n)
-    _register_sim_modules(
-        sirepo.feature_config.cfg().package_path, "sim_api", f.sim_types
-    )
-    _register_sim_modules(("sirepo",), "sim_oauth", f.proprietary_oauth_sim_types)
+    _register_sim_modules("sim_api", f.sim_types)
+    _register_sim_modules("sim_oauth", f.proprietary_oauth_sim_types)
     _init_uris(simulation_db, f.sim_types)
 
 
@@ -562,12 +560,16 @@ def _path_to_route(path):
     return (None, route, kwargs)
 
 
-def _register_sim_modules(package_path, package, sim_types):
-    for pp in package_path:
+def _register_sim_modules(package, sim_types):
+    for pp in sirepo.feature_config.cfg().package_path:
         p = pkinspect.module_name_join((pp, package))
-        for n in pkinspect.package_module_names(p):
-            if n in sim_types:
-                register_api_module(pkinspect.module_name_join((p, n)))
+        try:
+            for n in pkinspect.package_module_names(p):
+                if n in sim_types:
+                    register_api_module(pkinspect.module_name_join((p, n)))
+        except ModuleNotFoundError:
+            if pp == "sirepo":
+                raise
 
 
 def _split_uri(uri):


### PR DESCRIPTION
- apps can now define extra routes to sim_apis in the app schema
- moved cortexDb route from schema-common to cortex-schema