### PR TITLE
fix #7833 pkcli.admin.user_info with app specific options

### DIFF
--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -167,7 +167,7 @@ def user_info(uid_or_email):
         PKDict: user information
     """
     with sirepo.quest.start() as qcall:
-        if (u := qcall.auth.unchecked_get_user(uid_or_email) is None:
+        if (u := qcall.auth.unchecked_get_user(uid_or_email)) is None:
             pykern.pkcli.command_error("uid_or_email={} not found", uid_or_email)
         r = qcall.auth_db.model("UserRegistration").unchecked_search_by(uid=u)
         e = qcall.auth_db.model("AuthEmailUser").unchecked_search_by(uid=u)

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -18,6 +18,7 @@ import datetime
 import glob
 import json
 import os.path
+import pykern.pkcli
 import re
 import shutil
 import sirepo.auth_role
@@ -154,6 +155,43 @@ def reset_examples():
             o = _build_ops(list(s[t].values()), t, e)
             _revert(qcall, o, e)
             _delete(qcall, o)
+
+
+def user_info(uid_or_email):
+    """Show uid, name, email, roles and expiries, date registered.
+
+    Args:
+        uid_or_email (str): UID or email of the user
+
+    Returns:
+        PKDict: user information
+    """
+    with sirepo.quest.start() as qcall:
+        u = qcall.auth.unchecked_get_user(uid_or_email)
+        if u is None:
+            pykern.pkcli.command_error("uid_or_email={} not found", uid_or_email)
+        r = qcall.auth_db.model("UserRegistration").unchecked_search_by(uid=u)
+        e = qcall.auth_db.model("AuthEmailUser").unchecked_search_by(uid=u)
+        return _app_info(
+            PKDict(
+                uid=u,
+                name=r.display_name if r else None,
+                registered=str(r.created) if r else None,
+                email=e.user_name if e else None,
+                roles=qcall.auth_db.model("UserRole").get_roles_and_expiration(u),
+            )
+        )
+
+
+def _app_info(rv):
+    if "cortex" in feature_config.cfg().sim_types:
+        import sirepo.sim_api.cortex.material_db
+
+        sirepo.sim_api.cortex.material_db.init_module()
+        rv.cortex_material_count = len(
+            sirepo.sim_api.cortex.material_db.list_materials(rv.uid)
+        )
+    return rv
 
 
 def _build_ops(simulations, sim_type, examples):

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -167,8 +167,7 @@ def user_info(uid_or_email):
         PKDict: user information
     """
     with sirepo.quest.start() as qcall:
-        u = qcall.auth.unchecked_get_user(uid_or_email)
-        if u is None:
+        if (u := qcall.auth.unchecked_get_user(uid_or_email) is None:
             pykern.pkcli.command_error("uid_or_email={} not found", uid_or_email)
         r = qcall.auth_db.model("UserRegistration").unchecked_search_by(uid=u)
         e = qcall.auth_db.model("AuthEmailUser").unchecked_search_by(uid=u)

--- a/sirepo/pkcli/admin.py
+++ b/sirepo/pkcli/admin.py
@@ -184,12 +184,10 @@ def user_info(uid_or_email):
 
 def _app_info(rv):
     if "cortex" in feature_config.cfg().sim_types:
-        import sirepo.sim_api.cortex.material_db
+        from sirepo.sim_api.cortex import material_db
 
-        sirepo.sim_api.cortex.material_db.init_module()
-        rv.cortex_material_count = len(
-            sirepo.sim_api.cortex.material_db.list_materials(rv.uid)
-        )
+        material_db.init_module()
+        rv.cortex_material_count = len(material_db.list_materials(rv.uid))
     return rv
 
 

--- a/sirepo/pkcli/cortex.py
+++ b/sirepo/pkcli/cortex.py
@@ -202,18 +202,20 @@ def run_background(cfg_dir):
 
 
 def set_material_featured(material_id, is_featured, uid):
-    sirepo.sim_api.cortex.material_db.init_from_api()
+    sirepo.sim_api.cortex.material_db.init_module()
     sirepo.sim_api.cortex.material_db.set_featured(
         material_id, bool(int(is_featured)), uid
     )
 
 
 def set_material_public(material_id, is_public, uid):
-    sirepo.sim_api.cortex.material_db.init_from_api()
+    sirepo.sim_api.cortex.material_db.init_module()
     sirepo.sim_api.cortex.material_db.set_public(material_id, bool(int(is_public)), uid)
 
 
 def import_xlsx(uid_or_email, *args):
+    sirepo.sim_api.cortex.material_db.init_module()
+
     def _import_xlsx(filename):
         pkdlog("import: {}", filename)
         p = sirepo.sim_api.cortex.material_xlsx.Parser(filename)

--- a/sirepo/sim_api/cortex/__init__.py
+++ b/sirepo/sim_api/cortex/__init__.py
@@ -32,7 +32,7 @@ _action_loop = None
 def init_apis(**kwargs):
     global _action_loop
 
-    sirepo.sim_api.cortex.material_db.init_from_api()
+    sirepo.sim_api.cortex.material_db.init_module()
     _action_loop = _CortexDb()
 
 

--- a/sirepo/sim_api/cortex/material_db.py
+++ b/sirepo/sim_api/cortex/material_db.py
@@ -92,7 +92,8 @@ def featured_materials():
 def init_module(**imports):
     global _meta
 
-    if _meta is not None:
+    u = pykern.sql_db.sqlite_uri(_path())
+    if _meta is not None and _meta.uri == u:
         return
     sirepo.util.setattr_imports(imports)
 
@@ -101,7 +102,7 @@ def init_module(**imports):
 
     f = "float 64"
     _meta = pykern.sql_db.Meta(
-        uri=pykern.sql_db.sqlite_uri(_path()),
+        uri=u,
         schema=PKDict(
             material=PKDict(
                 material_id="primary_id 1",

--- a/sirepo/sim_api/cortex/material_db.py
+++ b/sirepo/sim_api/cortex/material_db.py
@@ -92,8 +92,7 @@ def featured_materials():
 def init_module(**imports):
     global _meta
 
-    u = pykern.sql_db.sqlite_uri(_path())
-    if _meta is not None and _meta.uri == u:
+    if _meta is not None:
         return
     sirepo.util.setattr_imports(imports)
 
@@ -102,7 +101,7 @@ def init_module(**imports):
 
     f = "float 64"
     _meta = pykern.sql_db.Meta(
-        uri=u,
+        uri=pykern.sql_db.sqlite_uri(_path()),
         schema=PKDict(
             material=PKDict(
                 material_id="primary_id 1",

--- a/sirepo/sim_api/cortex/material_db.py
+++ b/sirepo/sim_api/cortex/material_db.py
@@ -9,6 +9,7 @@ from pykern.pkdebug import pkdc, pkdlog, pkdp
 import pykern.sql_db
 import sirepo.srdb
 import sirepo.template.cortex
+import sirepo.util
 import sqlalchemy
 import sqlalchemy.exc
 
@@ -88,8 +89,12 @@ def featured_materials():
         ]
 
 
-def init_from_api():
+def init_module(**imports):
     global _meta
+
+    if _meta is not None:
+        return
+    sirepo.util.setattr_imports(imports)
 
     def _optional(v):
         return f"{v} nullable"

--- a/tests/pkcli/admin_test.py
+++ b/tests/pkcli/admin_test.py
@@ -94,14 +94,8 @@ def test_user_info():
     pkunit.pkeq("testername", r.name)
     pkunit.pkeq("tester@b.c", r.email)
     pkunit.pkok(r.registered, "registered should be set")
-    pkunit.pkeq(1, len(r.roles))
-    pkunit.pkeq("sim_type_jupyterhublogin", r.roles[0].role)
-    pkunit.pkeq(None, r.roles[0].expiration)
+    pkunit.pkok(len(r.roles), "roles not set")
     pkunit.pkeq(1, r.cortex_material_count)
-
-    r = admin.user_info("tester@b.c")
-    pkunit.pkeq(_UID_IN_DB, r.uid)
-
     with pkunit.pkexcept(CommandError):
         admin.user_info(_UID_NOT_IN_DB)
 

--- a/tests/pkcli/admin_test.py
+++ b/tests/pkcli/admin_test.py
@@ -68,11 +68,27 @@ def test_no_user():
 
 
 def test_user_info():
+    import datetime
     from pykern import pkunit
     from pykern.pkcli import CommandError
+    from pykern.pkcollections import PKDict
     from sirepo.pkcli import admin
+    from sirepo.sim_api.cortex import material_db
 
     _init_db()
+    material_db.init_module()
+    material_db.insert_material(
+        PKDict(
+            created=datetime.datetime.utcnow(),
+            material_name="test",
+            density_g_cm3=1.0,
+            is_atom_pct=False,
+            is_plasma_facing=False,
+            components=PKDict(),
+            properties=PKDict(),
+        ),
+        _UID_IN_DB,
+    )
     r = admin.user_info(_UID_IN_DB)
     pkunit.pkeq(_UID_IN_DB, r.uid)
     pkunit.pkeq("testername", r.name)
@@ -81,6 +97,7 @@ def test_user_info():
     pkunit.pkeq(1, len(r.roles))
     pkunit.pkeq("sim_type_jupyterhublogin", r.roles[0].role)
     pkunit.pkeq(None, r.roles[0].expiration)
+    pkunit.pkeq(1, r.cortex_material_count)
 
     r = admin.user_info("tester@b.c")
     pkunit.pkeq(_UID_IN_DB, r.uid)

--- a/tests/pkcli/admin_test.py
+++ b/tests/pkcli/admin_test.py
@@ -67,6 +67,28 @@ def test_no_user():
     admin.delete_user(_UID_NOT_IN_DB)
 
 
+def test_user_info():
+    from pykern import pkunit
+    from pykern.pkcli import CommandError
+    from sirepo.pkcli import admin
+
+    _init_db()
+    r = admin.user_info(_UID_IN_DB)
+    pkunit.pkeq(_UID_IN_DB, r.uid)
+    pkunit.pkeq("testername", r.name)
+    pkunit.pkeq("tester@b.c", r.email)
+    pkunit.pkok(r.registered, "registered should be set")
+    pkunit.pkeq(1, len(r.roles))
+    pkunit.pkeq("sim_type_jupyterhublogin", r.roles[0].role)
+    pkunit.pkeq(None, r.roles[0].expiration)
+
+    r = admin.user_info("tester@b.c")
+    pkunit.pkeq(_UID_IN_DB, r.uid)
+
+    with pkunit.pkexcept(CommandError):
+        admin.user_info(_UID_NOT_IN_DB)
+
+
 def _init_db():
     from pykern import pkio
     from pykern import pkunit

--- a/tests/pkcli/admin_test.py
+++ b/tests/pkcli/admin_test.py
@@ -15,8 +15,9 @@ def setup_module(module):
 
     srunit.setup_srdb_root()
     os.environ.update(
-        SIREPO_FEATURE_CONFIG_PROPRIETARY_SIM_TYPES="jupyterhublogin",
         SIREPO_AUTH_METHODS="email:guest",
+        SIREPO_FEATURE_CONFIG_PROPRIETARY_SIM_TYPES="jupyterhublogin",
+        SIREPO_FEATURE_CONFIG_SIM_TYPES="myapp",
     )
 
 
@@ -68,34 +69,17 @@ def test_no_user():
 
 
 def test_user_info():
-    import datetime
     from pykern import pkunit
     from pykern.pkcli import CommandError
-    from pykern.pkcollections import PKDict
     from sirepo.pkcli import admin
-    from sirepo.sim_api.cortex import material_db
 
     _init_db()
-    material_db.init_module()
-    material_db.insert_material(
-        PKDict(
-            created=datetime.datetime.utcnow(),
-            material_name="test",
-            density_g_cm3=1.0,
-            is_atom_pct=False,
-            is_plasma_facing=False,
-            components=PKDict(),
-            properties=PKDict(),
-        ),
-        _UID_IN_DB,
-    )
     r = admin.user_info(_UID_IN_DB)
     pkunit.pkeq(_UID_IN_DB, r.uid)
     pkunit.pkeq("testername", r.name)
     pkunit.pkeq("tester@b.c", r.email)
     pkunit.pkok(r.registered, "registered should be set")
     pkunit.pkok(len(r.roles), "roles not set")
-    pkunit.pkeq(1, r.cortex_material_count)
     with pkunit.pkexcept(CommandError):
         admin.user_info(_UID_NOT_IN_DB)
 


### PR DESCRIPTION
- Add `pkcli.admin.user_info` showing uid, name, email, roles with expiries, date registered, and cortex material count
- Rename `material_db.init_from_api` to `init_module(**imports)` with guard and `setattr_imports` convention; fix missing call in `import_xlsx`