### PR TITLE
fix #7898 none typo in job_supervisor

### DIFF
--- a/sirepo/job_supervisor.py
+++ b/sirepo/job_supervisor.py
@@ -553,7 +553,7 @@ class _ComputeJob(_Supervisor):
             except sirepo.util.UserDirNotFound:
                 pkdlog(
                     "not found user_path={} not recreating jid={}",
-                    sirepo.simulation_db.user_path(check=none, qcall=qcall),
+                    sirepo.simulation_db.user_path(check=None, qcall=qcall),
                     jid,
                 )
                 return


### PR DESCRIPTION
- fix `check=none` to `check=None` in job_supervisor.py:556